### PR TITLE
fixes #11

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -41,11 +41,16 @@ impl<'a> Display<'a> {
             });
         }
 
-        println!(
-            "{}",
-            grid.fit_into_width(term_width)
-                .expect("failed to print the grid")
-        );
+        if let Some(gridded_output) = grid.fit_into_width(term_width) {
+            println!("{}", gridded_output);
+        } else {
+            //does not fit into grid, usually because (some) filename(s)
+            //are longer or almost as long as term_width
+            //print line by line instead!
+            let lined_output = grid.fit_into_columns(1);
+            println!("{}", lined_output); 
+        }
+
     }
 
     pub fn print_tree_row(&self, output: String, depth: usize, last: bool) {


### PR DESCRIPTION
turns the longest file name was 138 chars, while my term_width is 148. `term_grid::Grid::fit_into_width` would return `None` as there was no suitable solution to actually draw a grid. The only way these files can be displayed is by simply printing them line by line. This code could probably not optimal as it calls into term_grid twice (first `fit_into_width`, then `fit_into_columns` if that strategy fails).