### PR TITLE
Color output based on LSCOLORS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,14 @@ version = "0.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "lscolors"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lsd"
 version = "0.12.1-pre"
 dependencies = [
@@ -90,6 +98,7 @@ dependencies = [
  "chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lscolors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -276,6 +285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)" = "10923947f84a519a45c8fefb7dd1b3e8c08747993381adee176d7a82b4195311"
+"checksum lscolors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9938fd8c379393454f73ec4c9c5b40f3d8332d80b25a29da05e41ee0ecbb559"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ time = "0.1.40"
 users = "0.8.0"
 chrono-humanize = "0.0.11"
 unicode-width = "0.1.5"
+lscolors = "0.5.0"
 
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]

--- a/src/color.rs
+++ b/src/color.rs
@@ -55,10 +55,13 @@ impl Elem {
 
 pub type ColoredString<'a> = ANSIString<'a>;
 
+
+#[allow(dead_code)]
 #[derive(Debug, Copy, Clone)]
 pub enum Theme {
     NoColor,
     Default,
+    NoLscolors,
 }
 
 pub struct Colors {
@@ -71,8 +74,13 @@ impl Colors {
         let colors = match theme {
             Theme::NoColor => None,
             Theme::Default => Some(Self::get_light_theme_colour_map()),
+            Theme::NoLscolors => Some(Self::get_light_theme_colour_map()),
         };
-        let lscolors = LsColors::from_env();
+        let lscolors = match theme {
+            Theme::NoColor => None,
+            Theme::Default => LsColors::from_env(),
+            Theme::NoLscolors => None,
+        };
 
         Self { colors, lscolors }
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -443,7 +443,7 @@ mod tests {
             );
             let output = name
                 .render(
-                    &Colors::new(color::Theme::Default),
+                    &Colors::new(color::Theme::NoLscolors),
                     &Icons::new(icon::Theme::NoIcon),
                 )
                 .to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate clap;
 extern crate ansi_term;
 extern crate chrono_humanize;
 extern crate libc;
+extern crate lscolors;
 #[cfg(test)]
 extern crate tempdir;
 extern crate term_grid;

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -84,7 +84,7 @@ mod test {
         File::create(&file_path).expect("failed to create file");
         let meta = file_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(Theme::Default);
+        let colors = Colors::new(Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
 
         assert_eq!(Colour::Fixed(184).paint("."), file_type.render(&colors));
@@ -95,7 +95,7 @@ mod test {
         let tmp_dir = TempDir::new("test_dir_type").expect("failed to create temp dir");
         let meta = tmp_dir.path().metadata().expect("failed to get metas");
 
-        let colors = Colors::new(Theme::Default);
+        let colors = Colors::new(Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
 
         assert_eq!(Colour::Fixed(33).paint("d"), file_type.render(&colors));
@@ -116,7 +116,7 @@ mod test {
             .symlink_metadata()
             .expect("failed to get metas");
 
-        let colors = Colors::new(Theme::Default);
+        let colors = Colors::new(Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
 
         assert_eq!(Colour::Fixed(44).paint("l"), file_type.render(&colors));
@@ -136,7 +136,7 @@ mod test {
         assert_eq!(true, success, "failed to exec mkfifo");
         let meta = pipe_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(Theme::Default);
+        let colors = Colors::new(Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
 
         assert_eq!(Colour::Fixed(44).paint("|"), file_type.render(&colors));
@@ -161,7 +161,7 @@ mod test {
         assert_eq!(true, success, "failed to exec mknod");
         let meta = char_device_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(Theme::Default);
+        let colors = Colors::new(Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
 
         assert_eq!(Colour::Fixed(44).paint("c"), file_type.render(&colors));
@@ -176,7 +176,7 @@ mod test {
         UnixListener::bind(&socket_path).expect("failed to create the socket");
         let meta = socket_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(Theme::Default);
+        let colors = Colors::new(Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
 
         assert_eq!(Colour::Fixed(44).paint("s"), file_type.render(&colors));

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 #[derive(Debug, Eq)]
 pub struct Name {
     name: String,
+    path: String,
     extension: Option<String>,
     file_type: FileType,
 }
@@ -27,8 +28,11 @@ impl Name {
             );
         }
 
+        let path_string = path.to_string_lossy().to_string();
+
         Self {
             name,
+            path: path_string,
             extension,
             file_type,
         }
@@ -39,6 +43,7 @@ impl Name {
         let mut content = String::with_capacity(icon.len() + self.name.len() + 3 /* spaces */);
 
         content += icon.as_str();
+        content += &self.name;
 
         let elem = match self.file_type {
             FileType::CharDevice => Elem::CharDevice,
@@ -51,9 +56,7 @@ impl Name {
             },
         };
 
-        content += &self.name;
-
-        colors.colorize(content, &elem)
+        colors.colorize_using_path(content, &self.path, &elem)
     }
 
     pub fn name(&self) -> String {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -115,7 +115,7 @@ mod test {
         File::create(&file_path).expect("failed to create file");
         let meta = file_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(color::Theme::Default);
+        let colors = Colors::new(color::Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&file_path, file_type);
 
@@ -135,7 +135,7 @@ mod test {
         fs::create_dir(&dir_path).expect("failed to create the dir");
         let meta = dir_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(color::Theme::Default);
+        let colors = Colors::new(color::Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&dir_path, file_type);
 
@@ -161,7 +161,7 @@ mod test {
             .symlink_metadata()
             .expect("failed to get metas");
 
-        let colors = Colors::new(color::Theme::Default);
+        let colors = Colors::new(color::Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&symlink_path, file_type);
 
@@ -186,7 +186,7 @@ mod test {
         assert_eq!(true, success, "failed to exec mkfifo");
         let meta = pipe_path.metadata().expect("failed to get metas");
 
-        let colors = Colors::new(color::Theme::Default);
+        let colors = Colors::new(color::Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&pipe_path, file_type);
 


### PR DESCRIPTION
Uses https://github.com/sharkdp/lscolors to color the output.

Fixes #28 

- Should other colors be changed based on `LSCOLOR`? I think `exa` does something like that.
- Option to override colors?