### PR TITLE
Fix broken grid layout when unicode characters are used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ terminal_size = "0.1.8"
 time = "0.1.40"
 users = "0.8.0"
 chrono-humanize = "0.0.11"
+unicode-width = "0.1.5"
 
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]

--- a/src/display.rs
+++ b/src/display.rs
@@ -113,7 +113,6 @@ mod tests {
     use super::*;
     use color;
     use color::Colors;
-    use flags::WhenFlag;
     use icon;
     use icon::Icons;
     use meta::{FileType, Name};

--- a/src/display.rs
+++ b/src/display.rs
@@ -107,3 +107,35 @@ impl Display {
         UnicodeWidthStr::width(input) - nb_invisible_char
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use super::*;
+    use color;
+    use color::Colors;
+    use flags::WhenFlag;
+    use icon;
+    use icon::Icons;
+    use meta::{FileType, Name};
+
+    #[test]
+    fn test_display_get_visible_width() {
+        let display = Display::new(Flags::default());
+        for (s, l) in &[
+            ("Ｈｅｌｌｏ,ｗｏｒｌｄ!", 22),
+            ("ASCII1234-_", 11),
+            ("制作样本。", 10),
+            ("日本語", 6),
+            ("샘플은 무료로 드리겠습니다", 26),
+            ("👩🐩", 4),
+            ("🔬", 2),
+        ] {
+            let path = Path::new(s);
+            let name = Name::new(&path, FileType::File);
+            let output = name.render(&Colors::new(color::Theme::Default), &Icons::new(icon::Theme::Default));
+            assert_eq!(display.get_visible_width(&output), *l);
+        }
+    }
+}

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,6 +3,7 @@ use flags::Flags;
 use std::io::Write;
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 use terminal_size::terminal_size;
+use unicode_width::UnicodeWidthStr;
 
 const EDGE: &str = "\u{251c}\u{2500}\u{2500}"; // "├──"
 const LINE: &str = "\u{2502}  "; // "├  "
@@ -103,6 +104,6 @@ impl Display {
 
         nb_invisible_char += 3; /* "[0m" */
 
-        input.chars().count() - nb_invisible_char
+        UnicodeWidthStr::width(input) - nb_invisible_char
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -108,10 +108,8 @@ impl Display {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use super::*;
     use color;
     use color::Colors;
@@ -119,6 +117,7 @@ mod tests {
     use icon;
     use icon::Icons;
     use meta::{FileType, Name};
+    use std::path::Path;
 
     #[test]
     fn test_display_get_visible_width() {
@@ -134,7 +133,10 @@ mod tests {
         ] {
             let path = Path::new(s);
             let name = Name::new(&path, FileType::File);
-            let output = name.render(&Colors::new(color::Theme::Default), &Icons::new(icon::Theme::Default));
+            let output = name.render(
+                &Colors::new(color::Theme::Default),
+                &Icons::new(icon::Theme::Default),
+            );
             assert_eq!(display.get_visible_width(&output), *l);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ extern crate tempdir;
 extern crate term_grid;
 extern crate terminal_size;
 extern crate time;
+extern crate unicode_width;
 extern crate users;
 
 mod app;


### PR DESCRIPTION
When filenames contain emoji, Japanese, Chinese, or etc., grid layout will be broken. So, please use [unicode-width](https://github.com/unicode-rs/unicode-width) crate to count each filename's width.