### PR TITLE
Add a depth parameter for the -R and --tree options

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,13 +58,22 @@ pub fn build() -> App<'static, 'static> {
                 .short("R")
                 .long("recursive")
                 .multiple(true)
+                .conflicts_with("tree")
                 .help("Recurse into directories"),
         )
         .arg(
             Arg::with_name("tree")
                 .long("tree")
                 .multiple(true)
+                .conflicts_with("recursive")
                 .help("Recurse into directories and present the result as a tree"),
+        )
+        .arg(
+            Arg::with_name("depth")
+                .long("depth")
+                .takes_value(true)
+                .value_name("NUM")
+                .help("Stop recursing into directories after reaching specified depth"),
         )
         .arg(
             Arg::with_name("date")

--- a/src/app.rs
+++ b/src/app.rs
@@ -72,7 +72,7 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("depth")
                 .long("depth")
                 .takes_value(true)
-                .value_name("NUM")
+                .value_name("num")
                 .help("Stop recursing into directories after reaching specified depth"),
         )
         .arg(

--- a/src/core.rs
+++ b/src/core.rs
@@ -56,6 +56,10 @@ impl Core {
     }
 
     fn run_inner(&self, paths: Vec<PathBuf>, depth: usize) {
+        if depth > self.flags.recursion_depth {
+            return;
+        }
+
         let mut dirs = Vec::new();
         let mut files = Vec::new();
 
@@ -101,7 +105,7 @@ impl Core {
                         })
                         .collect();
 
-                    self.run_inner(folder_dirs, depth);
+                    self.run_inner(folder_dirs, depth + 1);
                 } else {
                     self.display
                         .print_outputs(self.get_batch_outputs(&folder_batch));

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -40,7 +40,7 @@ impl Flags {
                 Ok(val) => val,
                 Err(_) => {
                     return Err(Error::with_description(
-                        "The argument '--depth' requires a valid number",
+                        "The argument '--depth' requires a valid positive number",
                         ErrorKind::ValueValidation,
                     ))
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,8 @@ fn main() {
         .map(PathBuf::from)
         .collect();
 
-    let core = Core::new(Flags::from(matches));
+    let flags = Flags::from_matches(&matches).unwrap_or_else(|err| err.exit());
+    let core = Core::new(flags);
 
     core.run(inputs);
 }

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -76,6 +76,7 @@ mod test {
             display_tree: true,
             display_indicators: true,
             recursive: true,
+            recursion_depth: usize::max_value(),
             sort_by: SortFlag::Name,
             sort_order: SortOrder::Default,
             date: DateFlag::Relative,


### PR DESCRIPTION
refs #3 

This adds new option `--depth` to limit recursion depth:

```
$ lsd --tree --depth 0 src
├──   meta
├──   app.rs
├──   batch.rs
├──   color.rs
├──   core.rs
├──   display.rs
├──   flags.rs
├──   icon.rs
└──   main.rs
```

I also added check that `--depth` is not used without `--recursive` or `--tree` (sadly clap does not have something like `requires_any()` modifier).