### PR TITLE
WIP: Fix directory icon with extensions

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -36,13 +36,10 @@ impl Icons {
         let mut res = String::with_capacity(4 + ICON_SPACE.len()); // 4 == max icon size
 
         // Check directory.
-        match name.file_type() {
-            FileType::Directory => {
-                res += "\u{f115}"; // 
-                res += ICON_SPACE;
-                return res;
-            }
-            _ => {}
+        if name.file_type() == FileType::Directory {
+            res += "\u{f115}"; // 
+            res += ICON_SPACE;
+            return res;
         }
 
         // Check the known names.

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -35,6 +35,16 @@ impl Icons {
 
         let mut res = String::with_capacity(4 + ICON_SPACE.len()); // 4 == max icon size
 
+        // Check directory.
+        match name.file_type() {
+            FileType::Directory => {
+                res += "\u{f115}"; // 
+                res += ICON_SPACE;
+                return res;
+            }
+            _ => {}
+        }
+
         // Check the known names.
         if let Some(icon) = self.icons_by_name.get(name.name().as_str()) {
             res += icon;
@@ -52,10 +62,7 @@ impl Icons {
         }
 
         // Use the default icons.
-        res += match name.file_type() {
-            FileType::Directory => "\u{f115}", // 
-            _ => "\u{f016}",                   // 
-        };
+        res += "\u{f016}"; // 
         res += ICON_SPACE;
         res
     }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -42,7 +42,7 @@ impl Icons {
             return res;
         }
 
-            // Check the known extensions.
+        // Check the known extensions.
         if let Some(extension) = name.extension() {
             if let Some(icon) = self.icons_by_extension.get(extension.as_str()) {
                 res += icon;

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -285,3 +285,105 @@ impl Icons {
         m
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::{Icons, Theme, ICON_SPACE};
+    use meta::{FileType, Name, Permissions};
+    use std::fs::File;
+    use tempdir::TempDir;
+
+    #[test]
+    fn get_no_icon() {
+        let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
+        let file_path = tmp_dir.path().join("file.txt");
+        File::create(&file_path).expect("failed to create file");
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let file_type = FileType::new(&meta, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+        let icon = Icons::new(Theme::NoIcon);
+        let icon = icon.get(&name);
+
+        assert_eq!(icon, "");
+    }
+
+    #[test]
+    fn get_default_file_icon() {
+        let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
+        let file_path = tmp_dir.path().join("file");
+        File::create(&file_path).expect("failed to create file");
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let file_type = FileType::new(&meta, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+        let icon = Icons::new(Theme::Default);
+        let icon = icon.get(&name);
+
+        assert_eq!(icon, format!("{}{}", "", ICON_SPACE));
+    }
+
+    #[test]
+    fn get_directory_icon() {
+        let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
+        let file_path = tmp_dir.path();
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let file_type = FileType::new(&meta, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+        let icon = Icons::new(Theme::Default);
+        let icon = icon.get(&name);
+
+        assert_eq!(icon, format!("{}{}", "", ICON_SPACE));
+    }
+
+    #[test]
+    fn get_directory_icon_with_ext() {
+        let tmp_dir = TempDir::new("test_file_type.rs").expect("failed to create temp dir");
+        let file_path = tmp_dir.path();
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let file_type = FileType::new(&meta, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+        let icon = Icons::new(Theme::Default);
+        let icon = icon.get(&name);
+
+        assert_eq!(icon, format!("{}{}", "", ICON_SPACE));
+    }
+
+    #[test]
+    fn get_icon_by_name() {
+        let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
+
+        for (file_name, file_icon) in &Icons::get_default_icons_by_name() {
+            let file_path = tmp_dir.path().join(file_name);
+            File::create(&file_path).expect("failed to create file");
+            let meta = file_path.metadata().expect("failed to get metas");
+
+            let file_type = FileType::new(&meta, &Permissions::from(&meta));
+            let name = Name::new(&file_path, file_type);
+            let icon = Icons::new(Theme::Default);
+            let icon = icon.get(&name);
+
+            assert_eq!(icon, format!("{}{}", file_icon, ICON_SPACE));
+        }
+    }
+
+    #[test]
+    fn get_icon_by_extension() {
+        let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
+
+        for (ext, file_icon) in &Icons::get_default_icons_by_extension() {
+            let file_path = tmp_dir.path().join(format!("file.{}", ext));
+            File::create(&file_path).expect("failed to create file");
+            let meta = file_path.metadata().expect("failed to get metas");
+
+            let file_type = FileType::new(&meta, &Permissions::from(&meta));
+            let name = Name::new(&file_path, file_type);
+            let icon = Icons::new(Theme::Default);
+            let icon = icon.get(&name);
+
+            assert_eq!(icon, format!("{}{}", file_icon, ICON_SPACE));
+        }
+    }
+}

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -272,7 +272,6 @@ impl Icons {
         m.insert("xml", "\u{e619}"); // ""
         m.insert("xul", "\u{e619}"); // ""
         m.insert("yaml", "\u{f481}"); // ""
-        m.insert("yarn.lock", "\u{e718}"); // ""
         m.insert("yml", "\u{f481}"); // ""
         m.insert("zip", "\u{f410}"); // ""
         m.insert("zsh", "\u{f489}"); // ""

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -320,7 +320,7 @@ mod test {
         let icon = Icons::new(Theme::Default);
         let icon = icon.get(&name);
 
-        assert_eq!(icon, format!("{}{}", "", ICON_SPACE));
+        assert_eq!(icon, format!("{}{}", "\u{f016}", ICON_SPACE)); // 
     }
 
     #[test]
@@ -334,7 +334,7 @@ mod test {
         let icon = Icons::new(Theme::Default);
         let icon = icon.get(&name);
 
-        assert_eq!(icon, format!("{}{}", "", ICON_SPACE));
+        assert_eq!(icon, format!("{}{}", "\u{f115}", ICON_SPACE)); // 
     }
 
     #[test]
@@ -348,7 +348,7 @@ mod test {
         let icon = Icons::new(Theme::Default);
         let icon = icon.get(&name);
 
-        assert_eq!(icon, format!("{}{}", "", ICON_SPACE));
+        assert_eq!(icon, format!("{}{}", "\u{f115}", ICON_SPACE)); // 
     }
 
     #[test]


### PR DESCRIPTION
Hi @Peltoche
I fixed a bug probably, and added some tests for `Icons::get`.
Please see below image. Is this expected works? (at master branch d1fdee3)
Directory with extensions shows extension icon.

<img width="776" alt="2018-12-23 14 17 26" src="https://user-images.githubusercontent.com/4659010/50380966-90d56300-06bd-11e9-8214-00c942fcb6aa.png">

I have two questions.

First, my added test is failed because `yarn.lock` key in `Icons::get_default_icons_by_extension()`.
`yarn.lock` is duplicate with `Icons::get_default_icons_by_name()`.
Could I remove `yarn.lock` key from `Icons::get_default_icons_by_extension()`?

Second, I don't have confidence for my implementation. Because I'm a novice of Rust :(
Would you point out if there is a bad implementation?

Thank you for reading my poor English.