### PR TITLE
Add console option to select icon theme

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -33,6 +33,15 @@ pub fn build() -> App<'static, 'static> {
                 .help("When to print the icons"),
         )
         .arg(
+            Arg::with_name("theme")
+                .long("theme")
+                .possible_value("default")
+                .possible_value("unicode")
+                .default_value("default")
+                .multiple(true)
+                .help("Whether to use extended or unicode icons"),
+        )
+        .arg(
             Arg::with_name("indicators")
                 .short("F")
                 .long("classify")

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,13 +33,13 @@ pub fn build() -> App<'static, 'static> {
                 .help("When to print the icons"),
         )
         .arg(
-            Arg::with_name("theme")
-                .long("theme")
-                .possible_value("default")
+            Arg::with_name("icon-theme")
+                .long("icon-theme")
+                .possible_value("fancy")
                 .possible_value("unicode")
-                .default_value("default")
+                .default_value("fancy")
                 .multiple(true)
-                .help("Whether to use extended or unicode icons"),
+                .help("Whether to use fancy or unicode icons"),
         )
         .arg(
             Arg::with_name("indicators")

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,7 @@
 use batch::Batch;
 use color::{self, Colors};
 use display::Display;
-use flags::{Flags, ThemeFlag, WhenFlag};
+use flags::{Flags, IconTheme, WhenFlag};
 use icon::{self, Icons};
 use meta::{FileType, Meta};
 use std::path::{Path, PathBuf};
@@ -22,16 +22,14 @@ impl Core {
         let mut inner_flags = flags;
 
         let color_theme = match (tty_available, flags.color) {
-            (true, WhenFlag::Never) => color::Theme::NoColor,
-            (false, WhenFlag::Auto) => color::Theme::NoColor,
-            (false, WhenFlag::Always) => color::Theme::Default,
+            (_, WhenFlag::Never) | (false, WhenFlag::Auto) => color::Theme::NoColor,
             _ => color::Theme::Default,
         };
 
         let icon_theme = match (tty_available, flags.icon, flags.icon_theme) {
             (_, WhenFlag::Never, _) | (false, WhenFlag::Auto, _) => icon::Theme::NoIcon,
-            (_, _, ThemeFlag::Default) => icon::Theme::Default,
-            (_, _, ThemeFlag::Unicode) => icon::Theme::Unicode,
+            (_, _, IconTheme::Fancy) => icon::Theme::Fancy,
+            (_, _, IconTheme::Unicode) => icon::Theme::Unicode,
         };
 
         if !tty_available {

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,7 +1,7 @@
 use batch::Batch;
 use color::{self, Colors};
 use display::Display;
-use flags::{Flags, WhenFlag};
+use flags::{Flags, ThemeFlag, WhenFlag};
 use icon::{self, Icons};
 use meta::{FileType, Meta};
 use std::path::{Path, PathBuf};
@@ -28,12 +28,10 @@ impl Core {
             _ => color::Theme::Default,
         };
 
-        let icon_theme = match (tty_available, flags.icon) {
-            (true, WhenFlag::Never) => icon::Theme::NoIcon,
-            (false, WhenFlag::Never) => icon::Theme::NoIcon,
-            (false, WhenFlag::Auto) => icon::Theme::NoIcon,
-            (false, WhenFlag::Always) => icon::Theme::Default,
-            _ => icon::Theme::Default,
+        let icon_theme = match (tty_available, flags.icon, flags.icon_theme) {
+            (_, WhenFlag::Never, _) | (false, WhenFlag::Auto, _) => icon::Theme::NoIcon,
+            (_, _, ThemeFlag::Default) => icon::Theme::Default,
+            (_, _, ThemeFlag::Unicode) => icon::Theme::Unicode,
         };
 
         if !tty_available {

--- a/src/display.rs
+++ b/src/display.rs
@@ -182,7 +182,7 @@ mod tests {
             let output = name
                 .render(
                     &Colors::new(color::Theme::NoColor),
-                    &Icons::new(icon::Theme::Default),
+                    &Icons::new(icon::Theme::Fancy),
                 )
                 .to_string();
             assert_eq!(display.get_visible_width(&output), *l);

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -14,6 +14,7 @@ pub struct Flags {
     pub date: DateFlag,
     pub color: WhenFlag,
     pub icon: WhenFlag,
+    pub icon_theme: ThemeFlag,
     pub recursion_depth: usize,
 }
 
@@ -21,6 +22,7 @@ impl Flags {
     pub fn from_matches(matches: &ArgMatches) -> Result<Self, Error> {
         let color_inputs: Vec<&str> = matches.values_of("color").unwrap().collect();
         let icon_inputs: Vec<&str> = matches.values_of("icon").unwrap().collect();
+        let icon_theme_inputs: Vec<&str> = matches.values_of("theme").unwrap().collect();
         let date_inputs: Vec<&str> = matches.values_of("date").unwrap().collect();
         let dir_order_inputs: Vec<&str> = matches.values_of("group-dirs").unwrap().collect();
 
@@ -70,6 +72,7 @@ impl Flags {
             date: DateFlag::from(date_inputs[date_inputs.len() - 1]),
             color: WhenFlag::from(color_inputs[color_inputs.len() - 1]),
             icon: WhenFlag::from(icon_inputs[icon_inputs.len() - 1]),
+            icon_theme: ThemeFlag::from(icon_theme_inputs[icon_inputs.len() - 1]),
             directory_order: DirOrderFlag::from(dir_order_inputs[dir_order_inputs.len() - 1]),
         })
     }
@@ -91,6 +94,7 @@ impl Default for Flags {
             date: DateFlag::Date,
             color: WhenFlag::Auto,
             icon: WhenFlag::Auto,
+            icon_theme: ThemeFlag::Default,
         }
     }
 }
@@ -155,6 +159,22 @@ impl<'a> From<&'a str> for DirOrderFlag {
             "first" => DirOrderFlag::First,
             "last" => DirOrderFlag::Last,
             _ => panic!("invalid \"when\" flag: {}", when),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum ThemeFlag {
+    Unicode,
+    Default,
+}
+
+impl<'a> From<&'a str> for ThemeFlag {
+    fn from(theme: &'a str) -> Self {
+        match theme {
+            "default" => ThemeFlag::Default,
+            "unicode" => ThemeFlag::Unicode,
+            _ => panic!("invalid \"theme\" flag: {}", theme),
         }
     }
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -14,7 +14,7 @@ pub struct Flags {
     pub date: DateFlag,
     pub color: WhenFlag,
     pub icon: WhenFlag,
-    pub icon_theme: ThemeFlag,
+    pub icon_theme: IconTheme,
     pub recursion_depth: usize,
 }
 
@@ -22,7 +22,7 @@ impl Flags {
     pub fn from_matches(matches: &ArgMatches) -> Result<Self, Error> {
         let color_inputs: Vec<&str> = matches.values_of("color").unwrap().collect();
         let icon_inputs: Vec<&str> = matches.values_of("icon").unwrap().collect();
-        let icon_theme_inputs: Vec<&str> = matches.values_of("theme").unwrap().collect();
+        let icon_theme_inputs: Vec<&str> = matches.values_of("icon-theme").unwrap().collect();
         let date_inputs: Vec<&str> = matches.values_of("date").unwrap().collect();
         let dir_order_inputs: Vec<&str> = matches.values_of("group-dirs").unwrap().collect();
 
@@ -72,7 +72,7 @@ impl Flags {
             date: DateFlag::from(date_inputs[date_inputs.len() - 1]),
             color: WhenFlag::from(color_inputs[color_inputs.len() - 1]),
             icon: WhenFlag::from(icon_inputs[icon_inputs.len() - 1]),
-            icon_theme: ThemeFlag::from(icon_theme_inputs[icon_inputs.len() - 1]),
+            icon_theme: IconTheme::from(icon_theme_inputs[icon_inputs.len() - 1]),
             directory_order: DirOrderFlag::from(dir_order_inputs[dir_order_inputs.len() - 1]),
         })
     }
@@ -94,7 +94,7 @@ impl Default for Flags {
             date: DateFlag::Date,
             color: WhenFlag::Auto,
             icon: WhenFlag::Auto,
-            icon_theme: ThemeFlag::Default,
+            icon_theme: IconTheme::Fancy,
         }
     }
 }
@@ -164,17 +164,17 @@ impl<'a> From<&'a str> for DirOrderFlag {
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
-pub enum ThemeFlag {
+pub enum IconTheme {
     Unicode,
-    Default,
+    Fancy,
 }
 
-impl<'a> From<&'a str> for ThemeFlag {
+impl<'a> From<&'a str> for IconTheme {
     fn from(theme: &'a str) -> Self {
         match theme {
-            "default" => ThemeFlag::Default,
-            "unicode" => ThemeFlag::Unicode,
-            _ => panic!("invalid \"theme\" flag: {}", theme),
+            "fancy" => IconTheme::Fancy,
+            "unicode" => IconTheme::Unicode,
+            _ => panic!("invalid \"icon-theme\" flag: {}", theme),
         }
     }
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -10,7 +10,7 @@ pub struct Icons {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Theme {
     NoIcon,
-    Default,
+    Fancy,
     Unicode,
 }
 
@@ -22,8 +22,8 @@ const ICON_SPACE: &str = "  ";
 // s#\\u[0-9a-f]*#\=eval('"'.submatch(0).'"')#
 impl Icons {
     pub fn new(theme: Theme) -> Self {
-        let display_icons = theme == Theme::Default || theme == Theme::Unicode;
-        let (icons_by_name, icons_by_extension) = if theme == Theme::Default {
+        let display_icons = theme == Theme::Fancy || theme == Theme::Unicode;
+        let (icons_by_name, icons_by_extension) = if theme == Theme::Fancy {
             (
                 Self::get_default_icons_by_name(),
                 Self::get_default_icons_by_extension(),
@@ -324,7 +324,7 @@ mod test {
 
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&file_path, file_type);
-        let icon = Icons::new(Theme::Default);
+        let icon = Icons::new(Theme::Fancy);
         let icon = icon.get(&name);
 
         assert_eq!(icon, format!("{}{}", "\u{f016}", ICON_SPACE)); // 
@@ -338,7 +338,7 @@ mod test {
 
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&file_path, file_type);
-        let icon = Icons::new(Theme::Default);
+        let icon = Icons::new(Theme::Fancy);
         let icon = icon.get(&name);
 
         assert_eq!(icon, format!("{}{}", "\u{f115}", ICON_SPACE)); // 
@@ -352,7 +352,7 @@ mod test {
 
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&file_path, file_type);
-        let icon = Icons::new(Theme::Default);
+        let icon = Icons::new(Theme::Fancy);
         let icon = icon.get(&name);
 
         assert_eq!(icon, format!("{}{}", "\u{f115}", ICON_SPACE)); // 
@@ -369,7 +369,7 @@ mod test {
 
             let file_type = FileType::new(&meta, &Permissions::from(&meta));
             let name = Name::new(&file_path, file_type);
-            let icon = Icons::new(Theme::Default);
+            let icon = Icons::new(Theme::Fancy);
             let icon = icon.get(&name);
 
             assert_eq!(icon, format!("{}{}", file_icon, ICON_SPACE));
@@ -387,7 +387,7 @@ mod test {
 
             let file_type = FileType::new(&meta, &Permissions::from(&meta));
             let name = Name::new(&file_path, file_type);
-            let icon = Icons::new(Theme::Default);
+            let icon = Icons::new(Theme::Fancy);
             let icon = icon.get(&name);
 
             assert_eq!(icon, format!("{}{}", file_icon, ICON_SPACE));

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -30,11 +30,16 @@ impl Icons {
                 (
                     Self::get_default_icons_by_name(),
                     Self::get_default_icons_by_extension(),
-                    "\u{f016}",
-                    "\u{f115}",
+                    "\u{f016}", // 
+                    "\u{f115}", // 
                 )
             } else {
-                (HashMap::new(), HashMap::new(), "\u{1F5CB}", "\u{1F5C1}")
+                (
+                HashMap::new(),
+                HashMap::new(),
+                "\u{1f5cb}", // 🗋
+                "\u{1f5c1}", // 🗁
+                )
             };
 
         Self {
@@ -349,7 +354,7 @@ mod test {
         let icon = Icons::new(Theme::Unicode);
         let icon = icon.get(&name);
 
-        assert_eq!(icon, format!("{}{}", "\u{1F5CB}", ICON_SPACE));
+        assert_eq!(icon, format!("{}{}", "\u{1f5cb}", ICON_SPACE));
     }
 
     #[test]
@@ -377,7 +382,7 @@ mod test {
         let icon = Icons::new(Theme::Unicode);
         let icon = icon.get(&name);
 
-        assert_eq!(icon, format!("{}{}", "\u{1F5C1}", ICON_SPACE));
+        assert_eq!(icon, format!("{}{}", "\u{1f5c1}", ICON_SPACE));
     }
 
     #[test]

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -11,6 +11,7 @@ pub struct Icons {
 pub enum Theme {
     NoIcon,
     Default,
+    Unicode,
 }
 
 const ICON_SPACE: &str = "  ";
@@ -21,10 +22,17 @@ const ICON_SPACE: &str = "  ";
 // s#\\u[0-9a-f]*#\=eval('"'.submatch(0).'"')#
 impl Icons {
     pub fn new(theme: Theme) -> Self {
+        let display_icons = theme == Theme::Default || theme == Theme::Unicode;
+        let (icons_by_name, icons_by_extension) = if theme == Theme::Default {
+            (Self::get_default_icons_by_name(), Self::get_default_icons_by_extension())
+        } else {
+            (HashMap::new(), HashMap::new())
+        };
+
         Self {
-            display_icons: theme == Theme::Default,
-            icons_by_name: Self::get_default_icons_by_name(),
-            icons_by_extension: Self::get_default_icons_by_extension(),
+            display_icons,
+            icons_by_name,
+            icons_by_extension,
         }
     }
 

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -24,7 +24,10 @@ impl Icons {
     pub fn new(theme: Theme) -> Self {
         let display_icons = theme == Theme::Default || theme == Theme::Unicode;
         let (icons_by_name, icons_by_extension) = if theme == Theme::Default {
-            (Self::get_default_icons_by_name(), Self::get_default_icons_by_extension())
+            (
+                Self::get_default_icons_by_name(),
+                Self::get_default_icons_by_extension(),
+            )
         } else {
             (HashMap::new(), HashMap::new())
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
-#![cfg_attr(feature = "cargo-clippy", allow(
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss,
-    clippy::match_same_arms,
-    clippy::cast_possible_wrap
-))]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        clippy::match_same_arms,
+        clippy::cast_possible_wrap
+    )
+)]
 
 #[macro_use]
 extern crate clap;

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -107,7 +107,7 @@ mod test {
     #[test]
     fn test_print_file_name() {
         let tmp_dir = TempDir::new("test_print_file_name").expect("failed to create temp dir");
-        let icons = Icons::new(icon::Theme::Default);
+        let icons = Icons::new(icon::Theme::Fancy);
 
         // Create the file;
         let file_path = tmp_dir.path().join("file.txt");
@@ -127,7 +127,7 @@ mod test {
     #[test]
     fn test_print_dir_name() {
         let tmp_dir = TempDir::new("test_print_dir_name").expect("failed to create temp dir");
-        let icons = Icons::new(icon::Theme::Default);
+        let icons = Icons::new(icon::Theme::Fancy);
 
         // Chreate the directory
         let dir_path = tmp_dir.path().join("directory");
@@ -147,7 +147,7 @@ mod test {
     #[test]
     fn test_print_symlink_name() {
         let tmp_dir = TempDir::new("test_symlink_name").expect("failed to create temp dir");
-        let icons = Icons::new(icon::Theme::Default);
+        let icons = Icons::new(icon::Theme::Fancy);
 
         // Create the file;
         let file_path = tmp_dir.path().join("file.tmp");
@@ -173,7 +173,7 @@ mod test {
     #[test]
     fn test_print_other_type_name() {
         let tmp_dir = TempDir::new("test_other_type_name").expect("failed to create temp dir");
-        let icons = Icons::new(icon::Theme::Default);
+        let icons = Icons::new(icon::Theme::Fancy);
 
         // Create the pipe;
         let pipe_path = tmp_dir.path().join("pipe.tmp");


### PR DESCRIPTION
I’ve added a console option called `theme` to select an icon set. The possible values are `default` for the current behavior and `unicode` to use only the default unicode icons. Unfortunately, the unicode icons don’t show up correctly on my machine, so I can’t really verify.

This fixes #40.