### PR TITLE
Added `SetuidDir` and `SetuidFile` variants to `Elem` and `FileType`

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -141,19 +141,19 @@ fn sort_by_meta(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
     match flags.sort_by {
         SortFlag::Name => match flags.directory_order {
             DirOrderFlag::First => sort_by_name_with_dirs_first(a, b, flags),
-            DirOrderFlag::None => sort_by_name_with_dirs_unordored(a, b, flags),
+            DirOrderFlag::None => sort_by_name_with_dirs_unordered(a, b, flags),
             DirOrderFlag::Last => sort_by_name_with_files_first(a, b, flags),
         },
 
         SortFlag::Time => match flags.directory_order {
             DirOrderFlag::First => sort_by_date_with_dirs_first(a, b, flags),
-            DirOrderFlag::None => sort_by_date_with_dirs_unordored(a, b, flags),
+            DirOrderFlag::None => sort_by_date_with_dirs_unordered(a, b, flags),
             DirOrderFlag::Last => sort_by_date_with_files_first(a, b, flags),
         },
     }
 }
 
-fn sort_by_name_with_dirs_unordored(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn sort_by_name_with_dirs_unordered(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
     if flags.sort_order == SortOrder::Default {
         a.name.cmp(&b.name)
     } else {
@@ -162,34 +162,28 @@ fn sort_by_name_with_dirs_unordored(a: &Meta, b: &Meta, flags: Flags) -> Orderin
 }
 
 fn sort_by_name_with_dirs_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
-    if a.file_type == FileType::Directory && b.file_type != FileType::Directory {
-        Ordering::Less
-    } else if b.file_type == FileType::Directory && a.file_type != FileType::Directory {
-        Ordering::Greater
-    } else {
-        if flags.sort_order == SortOrder::Default {
-            a.name.cmp(&b.name)
-        } else {
-            b.name.cmp(&a.name)
+    match (a.file_type, b.file_type) {
+        (FileType::Directory { .. }, FileType::Directory { .. }) => {
+            sort_by_name_with_dirs_unordered(a, b, flags)
         }
+        (FileType::Directory { .. }, _) => Ordering::Less,
+        (_, FileType::Directory { .. }) => Ordering::Greater,
+        _ => sort_by_name_with_dirs_unordered(a, b, flags),
     }
 }
 
 fn sort_by_name_with_files_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
-    if a.file_type == FileType::Directory && b.file_type != FileType::Directory {
-        Ordering::Greater
-    } else if b.file_type == FileType::Directory && a.file_type != FileType::Directory {
-        Ordering::Less
-    } else {
-        if flags.sort_order == SortOrder::Default {
-            a.name.cmp(&b.name)
-        } else {
-            b.name.cmp(&a.name)
+    match (a.file_type, b.file_type) {
+        (FileType::Directory { .. }, FileType::Directory { .. }) => {
+            sort_by_name_with_dirs_unordered(a, b, flags)
         }
+        (FileType::Directory { .. }, _) => Ordering::Greater,
+        (_, FileType::Directory { .. }) => Ordering::Less,
+        _ => sort_by_name_with_dirs_unordered(a, b, flags),
     }
 }
 
-fn sort_by_date_with_dirs_unordored(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn sort_by_date_with_dirs_unordered(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
     if flags.sort_order == SortOrder::Default {
         b.date.cmp(&a.date).then(a.name.cmp(&b.name))
     } else {
@@ -198,30 +192,24 @@ fn sort_by_date_with_dirs_unordored(a: &Meta, b: &Meta, flags: Flags) -> Orderin
 }
 
 fn sort_by_date_with_dirs_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
-    if a.file_type == FileType::Directory && b.file_type != FileType::Directory {
-        Ordering::Less
-    } else if b.file_type == FileType::Directory && a.file_type != FileType::Directory {
-        Ordering::Greater
-    } else {
-        if flags.sort_order == SortOrder::Default {
-            b.date.cmp(&a.date).then(a.name.cmp(&b.name))
-        } else {
-            a.date.cmp(&b.date).then(b.name.cmp(&a.name))
+    match (a.file_type, b.file_type) {
+        (FileType::Directory { .. }, FileType::Directory { .. }) => {
+            sort_by_date_with_dirs_unordered(a, b, flags)
         }
+        (FileType::Directory { .. }, _) => Ordering::Less,
+        (_, FileType::Directory { .. }) => Ordering::Greater,
+        _ => sort_by_date_with_dirs_unordered(a, b, flags),
     }
 }
 
 fn sort_by_date_with_files_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
-    if a.file_type == FileType::Directory && b.file_type != FileType::Directory {
-        Ordering::Greater
-    } else if b.file_type == FileType::Directory && a.file_type != FileType::Directory {
-        Ordering::Less
-    } else {
-        if flags.sort_order == SortOrder::Default {
-            b.date.cmp(&a.date).then(a.name.cmp(&b.name))
-        } else {
-            a.date.cmp(&b.date).then(b.name.cmp(&a.name))
+    match (a.file_type, b.file_type) {
+        (FileType::Directory { .. }, FileType::Directory { .. }) => {
+            sort_by_date_with_dirs_unordered(a, b, flags)
         }
+        (FileType::Directory { .. }, _) => Ordering::Greater,
+        (_, FileType::Directory { .. }) => Ordering::Less,
+        _ => sort_by_date_with_dirs_unordered(a, b, flags),
     }
 }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -9,7 +9,9 @@ pub enum Elem {
     SymLink,
     BrokenSymLink,
     Dir,
+    SetuidDir,
     ExecutableFile,
+    SetuidFile,
     Pipe,
     BlockDevice,
     CharDevice,
@@ -62,10 +64,18 @@ impl Colors {
     }
 
     pub fn colorize<'a>(&self, input: String, elem: &Elem) -> ColoredString<'a> {
+        self.style(elem).paint(input)
+    }
+
+    fn style(&self, elem: &Elem) -> Style {
         if let Some(ref colors) = self.colors {
-            colors[elem].paint(input)
+            let style_fg = Style::default().fg(colors[elem]);
+            match elem {
+                Elem::SetuidFile | Elem::SetuidDir => style_fg.on(Colour::Fixed(124)),
+                _ => style_fg,
+            }
         } else {
-            Style::default().paint(input)
+            Style::default()
         }
     }
 
@@ -82,13 +92,15 @@ impl Colors {
         m.insert(Elem::Read, Colour::Fixed(40)); // Green3
         m.insert(Elem::Write, Colour::Fixed(192)); // DarkOliveGreen1
         m.insert(Elem::Exec, Colour::Fixed(124)); // Red3
-        m.insert(Elem::ExecSticky, Colour::Fixed(13)); // Fuschsia
+        m.insert(Elem::ExecSticky, Colour::Fixed(13)); // Fuchsia
         m.insert(Elem::NoAccess, Colour::Fixed(168)); // HotPink3
 
         // File Types
         m.insert(Elem::File, Colour::Fixed(184)); // Yellow3
         m.insert(Elem::Dir, Colour::Fixed(33)); // DodgerBlue1
+        m.insert(Elem::SetuidDir, Colour::Fixed(33)); // DodgerBlue1
         m.insert(Elem::ExecutableFile, Colour::Fixed(40)); // Green3
+        m.insert(Elem::SetuidFile, Colour::Fixed(184)); // Yellow3
         m.insert(Elem::Pipe, Colour::Fixed(44)); // DarkTurquoise
         m.insert(Elem::SymLink, Colour::Fixed(44)); // DarkTurquoise
         m.insert(Elem::BrokenSymLink, Colour::Fixed(124)); // Red3

--- a/src/core.rs
+++ b/src/core.rs
@@ -94,7 +94,7 @@ impl Core {
                     let folder_dirs = folder_batch
                         .into_iter()
                         .filter_map(|x| {
-                            if x.file_type == FileType::Directory {
+                            if let FileType::Directory { .. } = x.file_type {
                                 Some(x.path)
                             } else {
                                 None
@@ -118,7 +118,7 @@ impl Core {
         for (idx, elem) in batch.into_iter().enumerate() {
             let last = idx + 1 != last_idx;
 
-            if elem.file_type == FileType::Directory {
+            if let FileType::Directory { .. } = elem.file_type {
                 output += &self.display.print_tree_row(
                     &elem.name.render(&self.colors, &self.icons),
                     depth,

--- a/src/display.rs
+++ b/src/display.rs
@@ -155,7 +155,13 @@ mod tests {
             ("🔬", 2),
         ] {
             let path = Path::new(s);
-            let name = Name::new(&path, FileType::File);
+            let name = Name::new(
+                &path,
+                FileType::File {
+                    exec: false,
+                    uid: false,
+                },
+            );
             let output = name.render(
                 &Colors::new(color::Theme::NoColor),
                 &Icons::new(icon::Theme::NoIcon),
@@ -178,7 +184,13 @@ mod tests {
             ("🔬", 5),
         ] {
             let path = Path::new(s);
-            let name = Name::new(&path, FileType::File);
+            let name = Name::new(
+                &path,
+                FileType::File {
+                    exec: false,
+                    uid: false,
+                },
+            );
             let output = name
                 .render(
                     &Colors::new(color::Theme::NoColor),
@@ -202,7 +214,13 @@ mod tests {
             ("🔬", 2),
         ] {
             let path = Path::new(s);
-            let name = Name::new(&path, FileType::File);
+            let name = Name::new(
+                &path,
+                FileType::File {
+                    exec: false,
+                    uid: false,
+                },
+            );
             let output = name
                 .render(
                     &Colors::new(color::Theme::Default),

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -35,10 +35,10 @@ impl Icons {
                 )
             } else {
                 (
-                HashMap::new(),
-                HashMap::new(),
-                "\u{1f5cb}", // 🗋
-                "\u{1f5c1}", // 🗁
+                    HashMap::new(),
+                    HashMap::new(),
+                    "\u{1f5cb}", // 🗋
+                    "\u{1f5c1}", // 🗁
                 )
             };
 
@@ -59,7 +59,7 @@ impl Icons {
         let mut res = String::with_capacity(4 + ICON_SPACE.len()); // 4 == max icon size
 
         // Check directory.
-        if name.file_type() == FileType::Directory {
+        if let FileType::Directory { .. } = name.file_type() {
             res += self.default_folder_icon;
             res += ICON_SPACE;
             return res;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
-#![cfg_attr(feature = "cargo-clippy", allow(
-    clippy::cast_precision_loss,
-    clippy::cast_sign_loss,
-    clippy::match_same_arms,
-    clippy::cast_possible_wrap
-))]
+#![cfg_attr(
+    feature = "cargo-clippy",
+    allow(
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        clippy::match_same_arms,
+        clippy::cast_possible_wrap
+    )
+)]
 
 #[macro_use]
 extern crate clap;

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -9,8 +9,8 @@ pub struct Indicator(&'static str);
 impl From<FileType> for Indicator {
     fn from(file_type: FileType) -> Self {
         let res = match file_type {
-            FileType::Directory => "/",
-            FileType::ExecutableFile => "*",
+            FileType::Directory { .. } => "/",
+            FileType::File { exec: true, .. } => "*",
             FileType::Pipe => "|",
             FileType::Socket => "=",
             FileType::SymLink => "@",
@@ -42,7 +42,7 @@ mod test {
         let mut flags = Flags::default();
         flags.display_indicators = true;
 
-        let file_type = Indicator::from(FileType::Directory);
+        let file_type = Indicator::from(FileType::Directory { uid: false });
 
         assert_eq!("/", file_type.render(flags).to_string().as_str());
     }
@@ -52,7 +52,10 @@ mod test {
         let mut flags = Flags::default();
         flags.display_indicators = true;
 
-        let file_type = Indicator::from(FileType::ExecutableFile);
+        let file_type = Indicator::from(FileType::File {
+            uid: false,
+            exec: true,
+        });
 
         assert_eq!("*", file_type.render(flags).to_string().as_str());
     }
@@ -83,7 +86,10 @@ mod test {
         flags.display_indicators = true;
 
         // The File type doesn't have any indicator
-        let file_type = Indicator::from(FileType::File);
+        let file_type = Indicator::from(FileType::File {
+            exec: false,
+            uid: false,
+        });
 
         assert_eq!("", file_type.render(flags).to_string().as_str());
     }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -42,18 +42,19 @@ impl Name {
         content += icon.as_str();
 
         let elem = match self.file_type {
-            FileType::CharDevice => &Elem::CharDevice,
-            FileType::SetuidDirectory => &Elem::SetuidDir,
-            FileType::Directory => &Elem::Dir,
-            FileType::SymLink => &Elem::SymLink,
-            FileType::ExecutableFile => &Elem::ExecutableFile,
-            FileType::SetuidFile => &Elem::SetuidFile,
-            _ => &Elem::File,
+            FileType::CharDevice => Elem::CharDevice,
+            FileType::Directory { uid } => Elem::Dir { uid },
+            FileType::SymLink => Elem::SymLink,
+            FileType::File { uid, exec } => Elem::File { uid, exec },
+            _ => Elem::File {
+                exec: false,
+                uid: false,
+            },
         };
 
         content += &self.name;
 
-        colors.colorize(content, elem)
+        colors.colorize(content, &elem)
     }
 
     pub fn name(&self) -> String {
@@ -222,7 +223,13 @@ mod test {
     fn test_extensions_with_valid_file() {
         let path = Path::new("some-file.txt");
 
-        let name = Name::new(&path, FileType::File);
+        let name = Name::new(
+            &path,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(Some(String::from("txt")), name.extension());
     }
@@ -231,7 +238,13 @@ mod test {
     fn test_extensions_with_file_without_extension() {
         let path = Path::new(".gitignore");
 
-        let name = Name::new(&path, FileType::File);
+        let name = Name::new(
+            &path,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(None, name.extension());
     }
@@ -240,7 +253,13 @@ mod test {
     fn test_is_hidder_with_hidden_file() {
         let path = Path::new(".gitignore");
 
-        let name = Name::new(&path, FileType::File);
+        let name = Name::new(
+            &path,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(true, name.is_hidden());
     }
@@ -249,7 +268,13 @@ mod test {
     fn test_is_hidder_with_visible_file() {
         let path = Path::new("some-file.txt");
 
-        let name = Name::new(&path, FileType::File);
+        let name = Name::new(
+            &path,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(false, name.is_hidden());
     }
@@ -257,10 +282,22 @@ mod test {
     #[test]
     fn test_order_impl_is_case_insensitive() {
         let path_1 = Path::new("AAAA");
-        let name_1 = Name::new(&path_1, FileType::File);
+        let name_1 = Name::new(
+            &path_1,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         let path_2 = Path::new("aaaa");
-        let name_2 = Name::new(&path_2, FileType::File);
+        let name_2 = Name::new(
+            &path_2,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(Ordering::Equal, name_1.cmp(&name_2));
     }
@@ -268,10 +305,22 @@ mod test {
     #[test]
     fn test_partial_order_impl() {
         let path_a = Path::new("aaaa");
-        let name_a = Name::new(&path_a, FileType::File);
+        let name_a = Name::new(
+            &path_a,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         let path_z = Path::new("zzzz");
-        let name_z = Name::new(&path_z, FileType::File);
+        let name_z = Name::new(
+            &path_z,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(true, name_a < name_z);
     }
@@ -279,10 +328,22 @@ mod test {
     #[test]
     fn test_partial_order_impl_is_case_insensitive() {
         let path_a = Path::new("aaaa");
-        let name_a = Name::new(&path_a, FileType::File);
+        let name_a = Name::new(
+            &path_a,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         let path_z = Path::new("ZZZZ");
-        let name_z = Name::new(&path_z, FileType::File);
+        let name_z = Name::new(
+            &path_z,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(true, name_a < name_z);
     }
@@ -290,10 +351,22 @@ mod test {
     #[test]
     fn test_partial_eq_impl() {
         let path_1 = Path::new("aaaa");
-        let name_1 = Name::new(&path_1, FileType::File);
+        let name_1 = Name::new(
+            &path_1,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         let path_2 = Path::new("aaaa");
-        let name_2 = Name::new(&path_2, FileType::File);
+        let name_2 = Name::new(
+            &path_2,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(true, name_1 == name_2);
     }
@@ -301,10 +374,22 @@ mod test {
     #[test]
     fn test_partial_eq_impl_is_case_insensitive() {
         let path_1 = Path::new("AAAA");
-        let name_1 = Name::new(&path_1, FileType::File);
+        let name_1 = Name::new(
+            &path_1,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         let path_2 = Path::new("aaaa");
-        let name_2 = Name::new(&path_2, FileType::File);
+        let name_2 = Name::new(
+            &path_2,
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
 
         assert_eq!(true, name_1 == name_2);
     }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -43,9 +43,11 @@ impl Name {
 
         let elem = match self.file_type {
             FileType::CharDevice => &Elem::CharDevice,
+            FileType::SetuidDirectory => &Elem::SetuidDir,
             FileType::Directory => &Elem::Dir,
             FileType::SymLink => &Elem::SymLink,
             FileType::ExecutableFile => &Elem::ExecutableFile,
+            FileType::SetuidFile => &Elem::SetuidFile,
             _ => &Elem::File,
         };
 


### PR DESCRIPTION
This allows us to display files and directories that have the uid flag set with a red background.

This fixes #44.