### PR TITLE
Remove Cargo "homepage" manifest attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ authors = ["Peltoche <dev@halium.fr>"]
 build = "build.rs"
 categories = ["command-line-utilities"]
 description = "A ls command with a lot of pretty colors."
-homepage = "https://github.com/Peltoche/lsd"
 keywords = ["ls"]
 license = "Apache-2.0"
 name = "lsd"


### PR DESCRIPTION
The [C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#c-metadata) guideline suggests that the `homepage` field should only be defined when the crate has a dedicated website other than the repository or documentation sites. As such, it is best to leave it out for the time being.