### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,12 @@ libc = "0.2.44"
 term_grid = "0.1.7"
 terminal_size = "0.1.8"
 time = "0.1.40"
-users = "0.8.0"
 chrono-humanize = "0.0.11"
 unicode-width = "0.1.5"
 lscolors = "0.5.0"
+
+[target.'cfg(unix)'.dependencies]
+users = "0.8.0"
 
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ lscolors = "0.5.0"
 users = "0.8.0"
 
 [target.'cfg(windows)'.dependencies]
-winapi = {version = "0.3.6", features = []}
+winapi = {version = "0.3.6", features = ["aclapi", "accctrl", "winnt", "winerror", "securitybaseapi", "winbase"]}
 
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ lscolors = "0.5.0"
 [target.'cfg(unix)'.dependencies]
 users = "0.8.0"
 
+[target.'cfg(windows)'.dependencies]
+winapi = {version = "0.3.6", features = []}
+
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]
 version = "2.32.0"

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -305,7 +305,7 @@ impl Icons {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test,unix))]
 mod test {
     use super::{Icons, Theme, ICON_SPACE};
     use crate::meta::{FileType, Name, Permissions};

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -305,10 +305,10 @@ impl Icons {
     }
 }
 
-#[cfg(all(test,unix))]
+#[cfg(test)]
 mod test {
     use super::{Icons, Theme, ICON_SPACE};
-    use crate::meta::{FileType, Name, Permissions};
+    use crate::meta::Meta;
     use std::fs::File;
     use tempdir::TempDir;
 
@@ -317,12 +317,10 @@ mod test {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path).unwrap();
 
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
         let icon = Icons::new(Theme::NoIcon);
-        let icon = icon.get(&name);
+        let icon = icon.get(&meta.name);
 
         assert_eq!(icon, "");
     }
@@ -332,12 +330,10 @@ mod test {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path).unwrap();
 
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
         let icon = Icons::new(Theme::Fancy);
-        let icon = icon.get(&name);
+        let icon = icon.get(&meta.name);
 
         assert_eq!(icon, format!("{}{}", "\u{f016}", ICON_SPACE)); // 
     }
@@ -347,12 +343,10 @@ mod test {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path).unwrap();
 
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
         let icon = Icons::new(Theme::Unicode);
-        let icon = icon.get(&name);
+        let icon = icon.get(&meta.name);
 
         assert_eq!(icon, format!("{}{}", "\u{1f5cb}", ICON_SPACE));
     }
@@ -361,12 +355,10 @@ mod test {
     fn get_directory_icon() {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path.to_path_buf()).unwrap();
 
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
         let icon = Icons::new(Theme::Fancy);
-        let icon = icon.get(&name);
+        let icon = icon.get(&meta.name);
 
         assert_eq!(icon, format!("{}{}", "\u{f115}", ICON_SPACE)); // 
     }
@@ -375,12 +367,10 @@ mod test {
     fn get_directory_icon_unicode() {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path.to_path_buf()).unwrap();
 
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
         let icon = Icons::new(Theme::Unicode);
-        let icon = icon.get(&name);
+        let icon = icon.get(&meta.name);
 
         assert_eq!(icon, format!("{}{}", "\u{1f5c1}", ICON_SPACE));
     }
@@ -389,12 +379,10 @@ mod test {
     fn get_directory_icon_with_ext() {
         let tmp_dir = TempDir::new("test_file_type.rs").expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path.to_path_buf()).unwrap();
 
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
         let icon = Icons::new(Theme::Fancy);
-        let icon = icon.get(&name);
+        let icon = icon.get(&meta.name);
 
         assert_eq!(icon, format!("{}{}", "\u{f115}", ICON_SPACE)); // 
     }
@@ -406,12 +394,10 @@ mod test {
         for (file_name, file_icon) in &Icons::get_default_icons_by_name() {
             let file_path = tmp_dir.path().join(file_name);
             File::create(&file_path).expect("failed to create file");
-            let meta = file_path.metadata().expect("failed to get metas");
+            let meta = Meta::from_path(&file_path).unwrap();
 
-            let file_type = FileType::new(&meta, &Permissions::from(&meta));
-            let name = Name::new(&file_path, file_type);
             let icon = Icons::new(Theme::Fancy);
-            let icon = icon.get(&name);
+            let icon = icon.get(&meta.name);
 
             assert_eq!(icon, format!("{}{}", file_icon, ICON_SPACE));
         }
@@ -424,12 +410,10 @@ mod test {
         for (ext, file_icon) in &Icons::get_default_icons_by_extension() {
             let file_path = tmp_dir.path().join(format!("file.{}", ext));
             File::create(&file_path).expect("failed to create file");
-            let meta = file_path.metadata().expect("failed to get metas");
+            let meta = Meta::from_path(&file_path).unwrap();
 
-            let file_type = FileType::new(&meta, &Permissions::from(&meta));
-            let name = Name::new(&file_path, file_type);
             let icon = Icons::new(Theme::Fancy);
-            let icon = icon.get(&name);
+            let icon = icon.get(&meta.name);
 
             assert_eq!(icon, format!("{}{}", file_icon, ICON_SPACE));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,8 @@ extern crate term_grid;
 extern crate terminal_size;
 extern crate time;
 extern crate unicode_width;
+
+#[cfg(unix)]
 extern crate users;
 
 mod app;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ extern crate unicode_width;
 #[cfg(unix)]
 extern crate users;
 
+#[cfg(windows)]
+extern crate winapi;
+
 mod app;
 mod color;
 mod core;

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -58,15 +58,51 @@ impl Date {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod test {
     use super::Date;
     use crate::color::{Colors, Theme};
     use crate::flags::{DateFlag, Flags};
     use ansi_term::Colour;
-    use std::process::Command;
     use std::{env, fs};
+    use std::process::{Command, ExitStatus};
+    use std::path::Path;
+    use std::io;
     use time;
+
+    #[cfg(unix)]
+    fn cross_platform_touch(path: &Path, date: &time::Tm) -> io::Result<ExitStatus> {
+        Command::new("touch")
+            .arg("-t")
+            .arg(date.strftime("%Y%m%d%H%M.%S").unwrap().to_string())
+            .arg(&path)
+            .status()
+    }
+
+    #[cfg(windows)]
+    fn cross_platform_touch(path: &Path, date: &time::Tm) -> io::Result<ExitStatus> {
+        use std::process::Stdio;
+
+        let copy_success = Command::new("cmd")
+            .arg("/C")
+            .arg("copy")
+            .arg("NUL")
+            .arg(path)
+            .stdout(Stdio::null()) // Windows doesn't have a quiet flag
+            .status()?
+            .success();
+
+        assert!(copy_success, "failed to create empty file");
+
+        Command::new("powershell")
+            .arg("-Command")
+            .arg("$(Get-Item")
+            .arg(path)
+            .arg(").lastwritetime=$(Get-Date \"")
+            .arg(date.strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string())
+            .arg("\")")
+            .status()
+    }
 
     #[test]
     fn test_an_hour_old_file_color() {
@@ -75,14 +111,10 @@ mod test {
 
         let creation_date = (time::now() - time::Duration::seconds(4)).to_local();
 
-        let success = Command::new("touch")
-            .arg("-t")
-            .arg(creation_date.strftime("%Y%m%d%H%M.%S").unwrap().to_string())
-            .arg(&file_path)
-            .status()
+        let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(Theme::Default);
         let date = Date::from(&file_path.metadata().unwrap());
@@ -103,14 +135,10 @@ mod test {
 
         let creation_date = (time::now() - time::Duration::hours(4)).to_local();
 
-        let success = Command::new("touch")
-            .arg("-t")
-            .arg(creation_date.strftime("%Y%m%d%H%M.%S").unwrap().to_string())
-            .arg(&file_path)
-            .status()
+        let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(Theme::Default);
         let date = Date::from(&file_path.metadata().unwrap());
@@ -129,22 +157,12 @@ mod test {
         let mut file_path = env::temp_dir();
         file_path.push("test_a_several_days_old_file_color.tmp");
 
-        let creation_date = time::now() - time::Duration::days(2);
+        let creation_date = time::now_utc() - time::Duration::days(2);
 
-        let success = Command::new("touch")
-            .arg("-t")
-            .arg(
-                creation_date
-                    .to_local()
-                    .strftime("%Y%m%d%H%M.%S")
-                    .unwrap()
-                    .to_string(),
-            )
-            .arg(&file_path)
-            .status()
+        let success = cross_platform_touch(&file_path, &creation_date.to_local())
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(Theme::Default);
         let date = Date::from(&file_path.metadata().unwrap());
@@ -165,20 +183,10 @@ mod test {
 
         let creation_date = time::now() - time::Duration::days(2);
 
-        let success = Command::new("touch")
-            .arg("-t")
-            .arg(
-                creation_date
-                    .to_local()
-                    .strftime("%Y%m%d%H%M.%S")
-                    .unwrap()
-                    .to_string(),
-            )
-            .arg(&file_path)
-            .status()
+        let success = cross_platform_touch(&file_path, &creation_date.to_local())
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(Theme::Default);
         let date = Date::from(&file_path.metadata().unwrap());

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -58,7 +58,7 @@ impl Date {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod test {
     use super::Date;
     use crate::color::{Colors, Theme};

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -3,6 +3,7 @@ use crate::meta::Permissions;
 use std::fs::Metadata;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[cfg_attr(windows, allow(dead_code))]
 pub enum FileType {
     BlockDevice,
     CharDevice,

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -47,7 +47,22 @@ impl FileType {
 
     #[cfg(windows)]
     pub fn new(meta: &Metadata, permissions: &Permissions) -> Self {
-        unimplemented!()
+        let file_type = meta.file_type();
+
+        if file_type.is_file() {
+            FileType::File {
+                exec: permissions.is_executable(),
+                uid: permissions.setuid,
+            }
+        } else if file_type.is_dir() {
+            FileType::Directory {
+                uid: permissions.setuid,
+            }
+        } else if file_type.is_symlink() {
+            FileType::SymLink
+        } else {
+            FileType::Special
+        }
     }
 }
 

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -1,7 +1,6 @@
 use crate::color::{ColoredString, Colors, Elem};
 use crate::meta::Permissions;
 use std::fs::Metadata;
-use std::os::unix::fs::FileTypeExt;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum FileType {
@@ -16,7 +15,10 @@ pub enum FileType {
 }
 
 impl FileType {
+    #[cfg(unix)]
     pub fn new(meta: &Metadata, permissions: &Permissions) -> Self {
+        use std::os::unix::fs::FileTypeExt;
+
         let file_type = meta.file_type();
 
         if file_type.is_file() {
@@ -41,6 +43,11 @@ impl FileType {
         } else {
             FileType::Special
         }
+    }
+
+    #[cfg(windows)]
+    pub fn new(meta: &Metadata, permissions: &Permissions) -> Self {
+        unimplemented!()
     }
 }
 

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -70,7 +70,7 @@ impl FileType {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod test {
     use super::FileType;
     use crate::color::{Colors, Theme};

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -7,6 +7,9 @@ mod permissions;
 mod size;
 mod symlink;
 
+#[cfg(windows)]
+mod windows_utils;
+
 pub use self::date::Date;
 pub use self::filetype::FileType;
 pub use self::indicator::Indicator;
@@ -102,7 +105,14 @@ impl Meta {
             path.metadata()?
         };
 
+        #[cfg(unix)]
+        let owner = Owner::from(&metadata);
+        #[cfg(unix)]
         let permissions = Permissions::from(&metadata);
+
+        #[cfg(windows)]
+        let (owner, permissions) = windows_utils::get_file_data(&path)?;
+
         let file_type = FileType::new(&metadata, &permissions);
         let name = Name::new(&path, file_type);
 
@@ -112,7 +122,7 @@ impl Meta {
             size: Size::from(&metadata),
             date: Date::from(&metadata),
             indicator: Indicator::from(file_type),
-            owner: Owner::from(&metadata),
+            owner,
             permissions,
             name,
             file_type,

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -90,7 +90,7 @@ impl PartialEq for Name {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod test {
     use super::Name;
     use crate::color::{self, Colors};

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -90,22 +90,27 @@ impl PartialEq for Name {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod test {
     use super::Name;
     use crate::color::{self, Colors};
     use crate::icon::{self, Icons};
+    use crate::meta::Meta;
     use crate::meta::FileType;
+    #[cfg(unix)]
     use crate::meta::Permissions;
     use ansi_term::Colour;
     use std::cmp::Ordering;
     use std::fs::{self, File};
+    #[cfg(unix)]
     use std::os::unix::fs::symlink;
     use std::path::Path;
+    #[cfg(unix)]
     use std::process::Command;
     use tempdir::TempDir;
 
     #[test]
+    #[cfg(unix)] // Windows uses different default permissions
     fn test_print_file_name() {
         let tmp_dir = TempDir::new("test_print_file_name").expect("failed to create temp dir");
         let icons = Icons::new(icon::Theme::Fancy);
@@ -133,19 +138,18 @@ mod test {
         // Chreate the directory
         let dir_path = tmp_dir.path().join("directory");
         fs::create_dir(&dir_path).expect("failed to create the dir");
-        let meta = dir_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&dir_path).unwrap();
 
         let colors = Colors::new(color::Theme::NoLscolors);
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&dir_path, file_type);
 
         assert_eq!(
             Colour::Fixed(33).paint("  directory"),
-            name.render(&colors, &icons)
+            meta.name.render(&colors, &icons)
         );
     }
 
     #[test]
+    #[cfg(unix)] // Symlinks are hard on Windows
     fn test_print_symlink_name() {
         let tmp_dir = TempDir::new("test_symlink_name").expect("failed to create temp dir");
         let icons = Icons::new(icon::Theme::Fancy);
@@ -172,6 +176,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_print_other_type_name() {
         let tmp_dir = TempDir::new("test_other_type_name").expect("failed to create temp dir");
         let icons = Icons::new(icon::Theme::Fancy);
@@ -205,15 +210,13 @@ mod test {
         // Create the file;
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = file_path.metadata().expect("failed to get metas");
+        let meta = Meta::from_path(&file_path).unwrap();
 
         let colors = Colors::new(color::Theme::NoColor);
-        let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&file_path, file_type);
 
         assert_eq!(
             "file.txt",
-            name.render(&colors, &icons).to_string().as_str()
+            meta.name.render(&colors, &icons).to_string().as_str()
         );
     }
 

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -1,7 +1,5 @@
 use crate::color::{ColoredString, Colors, Elem};
 use std::fs::Metadata;
-use std::os::unix::fs::MetadataExt;
-use users::{get_group_by_gid, get_user_by_uid};
 
 #[derive(Debug)]
 pub struct Owner {
@@ -9,8 +7,12 @@ pub struct Owner {
     group: String,
 }
 
+#[cfg(unix)]
 impl<'a> From<&'a Metadata> for Owner {
     fn from(meta: &Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt;
+        use users::{get_group_by_gid, get_user_by_uid};
+
         let user = match get_user_by_uid(meta.uid()) {
             Some(res) => res.name().to_string_lossy().to_string(),
             None => meta.uid().to_string(),

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -7,6 +7,15 @@ pub struct Owner {
     group: String,
 }
 
+impl Owner {
+    pub fn new(user: String, group: String) -> Owner {
+        Owner {
+            user,
+            group,
+        }
+    }
+}
+
 #[cfg(unix)]
 impl<'a> From<&'a Metadata> for Owner {
     fn from(meta: &Metadata) -> Self {

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -10,8 +10,8 @@ pub struct Owner {
 
 impl Owner {
     #[cfg_attr(unix, allow(dead_code))]
-    pub fn new(user: String, group: String) -> Owner {
-        Owner {
+    pub fn new(user: String, group: String) -> Self {
+        Self {
             user,
             group,
         }

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -1,4 +1,5 @@
 use crate::color::{ColoredString, Colors, Elem};
+#[cfg(unix)]
 use std::fs::Metadata;
 
 #[derive(Debug)]
@@ -8,6 +9,7 @@ pub struct Owner {
 }
 
 impl Owner {
+    #[cfg_attr(unix, allow(dead_code))]
     pub fn new(user: String, group: String) -> Owner {
         Owner {
             user,

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -21,8 +21,8 @@ pub struct Permissions {
     pub setuid: bool,
 }
 
-#[cfg(unix)]
 impl<'a> From<&'a Metadata> for Permissions {
+    #[cfg(unix)]
     fn from(meta: &Metadata) -> Self {
         use std::os::unix::fs::PermissionsExt;
 
@@ -46,6 +46,11 @@ impl<'a> From<&'a Metadata> for Permissions {
             setgid: has_bit(modes::SETGID),
             setuid: has_bit(modes::SETUID),
         }
+    }
+
+    #[cfg(windows)]
+    fn from(_: &Metadata) -> Self {
+        panic!("Cannot get permissions from metadata on Windows")
     }
 }
 

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -1,7 +1,6 @@
 use crate::color::{ColoredString, Colors, Elem};
 use ansi_term::ANSIStrings;
 use std::fs::Metadata;
-use std::os::unix::fs::PermissionsExt;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub struct Permissions {
@@ -22,8 +21,11 @@ pub struct Permissions {
     pub setuid: bool,
 }
 
+#[cfg(unix)]
 impl<'a> From<&'a Metadata> for Permissions {
     fn from(meta: &Metadata) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+
         let bits = meta.permissions().mode();
         let has_bit = |bit| bits & bit == bit;
 
@@ -98,6 +100,7 @@ impl Permissions {
 
 // More readable aliases for the permission bits exposed by libc.
 #[allow(trivial_numeric_casts)]
+#[cfg(unix)]
 mod modes {
     use libc;
 

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -1,11 +1,262 @@
 use std::io;
 use std::path::PathBuf;
 use std::ffi::{OsStr, OsString};
+use std::ptr::null_mut;
 use std::os::windows::ffi::{OsStringExt, OsStrExt};
+
+use winapi::um::winnt;
+use winapi::um::accctrl::TRUSTEE_W;
+use winapi::shared::winerror;
+use winapi::ctypes::c_void;
+
 use super::{Owner, Permissions};
 
+const BUF_SIZE: u32 = 256;
+
+
 pub fn get_file_data(path: &PathBuf) -> Result<(Owner, Permissions), io::Error> {
-    unimplemented!()
+    // Overall design:
+    // This function allocates some data with GetNamedSecurityInfoW,
+    // manipulates it only through WinAPI calls (treating the pointers as
+    // opaque) and then frees it at the end with LocalFree.
+    //
+    // For memory safety, the critical things are:
+    // - No pointer is valid before the return value of GetNamedSecurityInfoW
+    //   is checked
+    // - LocalFree must be called before returning
+    // - No pointer is valid after the call to LocalFree
+
+    let mut windows_path = buf_from_os(path.as_os_str());
+
+    // These pointers will be populated by GetNamedSecurityInfoW
+    // sd_ptr points at a new buffer that must be freed
+    // The others point at (opaque) things inside that buffer
+    let mut owner_sid_ptr = null_mut();
+    let mut group_sid_ptr = null_mut();
+    let mut dacl_ptr = null_mut();
+    let mut sd_ptr = null_mut();
+
+    // Assumptions:
+    // - windows_path is a null-terminated WTF-16-encoded string
+    // - The return value is checked against ERROR_SUCCESS before pointers are used
+    // - All pointers are opaque and should only be used with WinAPI calls
+    // - Pointers are only valid if their corresponding X_SECURITY_INFORMATION
+    //   flags are set
+    // - sd_ptr must be freed with LocalFree
+    let error_code = unsafe {
+        winapi::um::aclapi::GetNamedSecurityInfoW(
+            windows_path.as_ptr(),
+            winapi::um::accctrl::SE_FILE_OBJECT,
+            winnt::OWNER_SECURITY_INFORMATION
+                | winnt::GROUP_SECURITY_INFORMATION
+                | winnt::DACL_SECURITY_INFORMATION,
+            &mut owner_sid_ptr,
+            &mut group_sid_ptr,
+            &mut dacl_ptr,
+            null_mut(),
+            &mut sd_ptr
+        )
+    };
+
+    if error_code != winerror::ERROR_SUCCESS {
+        return Err(std::io::Error::from_raw_os_error(error_code as i32))
+    }
+
+    // Assumptions:
+    // - owner_sid_ptr is valid
+    // - group_sid_ptr is valid
+    // (both OK because GetNamedSecurityInfoW returned success)
+    let (owner_name, owner_domain) = unsafe { lookup_account_sid(owner_sid_ptr) }?;
+    let (group_name, group_domain) = unsafe { lookup_account_sid(group_sid_ptr) }?;
+
+    let owner_name = os_from_buf(&owner_name);
+    let owner_domain = os_from_buf(&owner_domain);
+    let group_name = os_from_buf(&group_name);
+    let group_domain = os_from_buf(&group_domain);
+
+    // Format into domain\name format
+    let mut owner = owner_domain.to_string_lossy().into_owned();
+    owner.push('\\');
+    owner.push_str(&owner_name.to_string_lossy());
+
+    let mut group = group_domain.to_string_lossy().into_owned();
+    group.push('\\');
+    group.push_str(&group_name.to_string_lossy());
+
+    // This structure will be returned
+    let owner = Owner::new(owner, group);
+
+    // Get the size and allocate bytes for a 1-sub-authority SID
+    // 1 sub-authority because the Windows World SID is always S-1-1-0, with
+    // only a single sub-authority.
+    //
+    // Assumptions: None
+    // "This function cannot fail"
+    //     -- Windows Dev Center docs
+    let mut world_sid_len: u32 = unsafe { winapi::um::securitybaseapi::GetSidLengthRequired(1) };
+    let mut world_sid = vec![0u8; world_sid_len as usize];
+
+    // Assumptions:
+    // - world_sid_len is no larger than the number of bytes available at
+    //   world_sid
+    // - world_sid is appropriately aligned (if there are strange crashes this
+    //   might be why)
+    let result = unsafe {
+        winapi::um::securitybaseapi::CreateWellKnownSid(
+            winnt::WinWorldSid,
+            null_mut(),
+            world_sid.as_mut_ptr() as *mut _,
+            &mut world_sid_len)
+    };
+
+    if result == 0 {
+        // Failed to create the SID
+        // Assumptions: Same as the other identical calls
+        unsafe { winapi::um::winbase::LocalFree(sd_ptr); }
+
+        // Assumptions: None (GetLastError shouldn't ever fail)
+        return Err(io::Error::from_raw_os_error(
+                unsafe { winapi::um::errhandlingapi::GetLastError() } as i32));
+    }
+
+    // Assumptions:
+    // - xxxxx_sid_ptr are valid pointers to SIDs
+    // - xxxxx_trustee is only valid as long as its SID pointer is
+    let mut owner_trustee = unsafe { trustee_from_sid(owner_sid_ptr) };
+    let mut group_trustee = unsafe { trustee_from_sid(group_sid_ptr) };
+    let mut world_trustee = unsafe { trustee_from_sid(world_sid.as_mut_ptr() as *mut _) };
+
+    // Assumptions:
+    // - xxxxx_trustee are still valid (including underlying SID)
+    // - dacl_ptr is still valid
+    let mut owner_access_mask = unsafe {
+        get_acl_access_mask(dacl_ptr as *mut _, &mut owner_trustee)
+    }?;
+
+    let mut group_access_mask = unsafe {
+        get_acl_access_mask(dacl_ptr as *mut _, &mut group_trustee)
+    }?;
+
+    let mut world_access_mask = unsafe {
+        get_acl_access_mask(dacl_ptr as *mut _, &mut world_trustee)
+    }?;
+
+    let has_bit = |field: u32, bit: u32| field & bit != 0;
+
+    let permissions = Permissions {
+        user_read: has_bit(owner_access_mask, winnt::FILE_GENERIC_READ),
+        user_write: has_bit(owner_access_mask, winnt::FILE_GENERIC_WRITE),
+        user_execute: has_bit(owner_access_mask, winnt::FILE_GENERIC_EXECUTE),
+
+        group_read: has_bit(group_access_mask, winnt::FILE_GENERIC_READ),
+        group_write: has_bit(group_access_mask, winnt::FILE_GENERIC_WRITE),
+        group_execute: has_bit(group_access_mask, winnt::FILE_GENERIC_EXECUTE),
+
+        other_read: has_bit(world_access_mask, winnt::FILE_GENERIC_READ),
+        other_write: has_bit(world_access_mask, winnt::FILE_GENERIC_WRITE),
+        other_execute: has_bit(world_access_mask, winnt::FILE_GENERIC_EXECUTE),
+
+        sticky: false,
+        setuid: false,
+        setgid: false,
+    };
+
+    // Assumptions:
+    // - sd_ptr was previously allocated with WinAPI functions
+    // - All pointers into the memory are now invalid
+    // - The free succeeds (currently unchecked -- there's no real recovery
+    //   options. It's not much memory, so leaking it on failure is
+    //   *probably* fine)
+    unsafe { winapi::um::winbase::LocalFree(sd_ptr); }
+
+    Ok((owner, permissions))
+}
+
+/// Evaluate an ACL for a particular trustee and get its access rights
+///
+/// Assumptions:
+/// - acl_ptr points to a valid ACL data structure
+/// - trustee_ptr points to a valid trustee data structure
+/// - Both remain valid through the function call (no long-term requirement)
+unsafe fn get_acl_access_mask(acl_ptr: *mut c_void, trustee_ptr: *mut TRUSTEE_W) -> Result<u32, io::Error> {
+    let mut access_mask = 0;
+
+    // Assumptions:
+    // - All function assumptions
+    // - Result is not valid until return value is checked
+    let err_code = winapi::um::aclapi::GetEffectiveRightsFromAclW(
+        acl_ptr as *mut _,
+        trustee_ptr,
+        &mut access_mask);
+
+    if err_code == winerror::ERROR_SUCCESS {
+        Ok(access_mask)
+    } else {
+        Err(io::Error::from_raw_os_error(err_code as i32))
+    }
+}
+
+/// Get a trustee buffer from a SID
+///
+/// Assumption: sid is valid, and the trustee is only valid as long as the SID
+/// is
+///
+/// Note: winapi's TRUSTEE_W looks different from the one in the MS docs because
+/// of some unusal pre-processor macros in the original .h file. The winapi
+/// version is correct (MS's doc generator messed up)
+unsafe fn trustee_from_sid(sid_ptr: *mut c_void) -> TRUSTEE_W {
+    let mut trustee: TRUSTEE_W = std::mem::zeroed();
+
+    winapi::um::aclapi::BuildTrusteeWithSidW(&mut trustee, sid_ptr);
+
+    trustee
+}
+
+/// Get a username and domain name from a SID
+///
+/// Assumption: sid is a valid pointer that remains valid through the entire
+/// function execution
+///
+/// Returns null-terminated Vec's, one for the name and one for the domain.
+unsafe fn lookup_account_sid(sid: *mut c_void) -> Result<(Vec<u16>, Vec<u16>), std::io::Error> {
+    let mut name_size: u32 = BUF_SIZE;
+    let mut domain_size: u32 = BUF_SIZE;
+
+    loop {
+        let mut name: Vec<u16> = vec![0; name_size as usize];
+        let mut domain: Vec<u16> = vec![0; domain_size as usize];
+
+        let old_name_size = name_size;
+        let old_domain_size = domain_size;
+
+        let mut sid_name_use = 0;
+
+        // Assumptions:
+        // - sid is a valid pointer to a SID data structure
+        // - name_size and domain_size accurately reflect the sizes
+        let result = winapi::um::winbase::LookupAccountSidW(
+            null_mut(),
+            sid,
+            name.as_mut_ptr(),
+            &mut name_size,
+            domain.as_mut_ptr(),
+            &mut domain_size,
+            &mut sid_name_use,
+        );
+
+        if result != 0 {
+            // Success!
+            return Ok((name, domain));
+        } else if name_size != old_name_size || domain_size != old_domain_size {
+            // Need bigger buffers
+            // name_size and domain_size are already set, just loop
+            continue;
+        } else {
+            // Some other failure
+            // Assumptions: None (GetLastError shouldn't ever fail)
+            return Err(io::Error::from_raw_os_error(winapi::um::errhandlingapi::GetLastError() as i32));
+        }
+    }
 }
 
 /// Create an `OsString` from a NUL-terminated buffer
@@ -33,6 +284,13 @@ fn buf_from_os(os: &OsStr) -> Vec<u16> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn throwaway() {
+        let mut manifest_path = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
+
+        get_file_data(&manifest_path);
+    }
 
     #[test]
     fn basic_wtf16_behavior() {

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -26,7 +26,7 @@ pub fn get_file_data(path: &PathBuf) -> Result<(Owner, Permissions), io::Error> 
     // - LocalFree must be called before returning
     // - No pointer is valid after the call to LocalFree
 
-    let mut windows_path = buf_from_os(path.as_os_str());
+    let windows_path = buf_from_os(path.as_os_str());
 
     // These pointers will be populated by GetNamedSecurityInfoW
     // sd_ptr points at a new buffer that must be freed
@@ -129,15 +129,15 @@ pub fn get_file_data(path: &PathBuf) -> Result<(Owner, Permissions), io::Error> 
     // Assumptions:
     // - xxxxx_trustee are still valid (including underlying SID)
     // - dacl_ptr is still valid
-    let mut owner_access_mask = unsafe {
+    let owner_access_mask = unsafe {
         get_acl_access_mask(dacl_ptr as *mut _, &mut owner_trustee)
     }?;
 
-    let mut group_access_mask = unsafe {
+    let group_access_mask = unsafe {
         get_acl_access_mask(dacl_ptr as *mut _, &mut group_trustee)
     }?;
 
-    let mut world_access_mask = unsafe {
+    let world_access_mask = unsafe {
         get_acl_access_mask(dacl_ptr as *mut _, &mut world_trustee)
     }?;
 
@@ -284,13 +284,6 @@ fn buf_from_os(os: &OsStr) -> Vec<u16> {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn throwaway() {
-        let mut manifest_path = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("Cargo.toml");
-
-        get_file_data(&manifest_path);
-    }
 
     #[test]
     fn basic_wtf16_behavior() {

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -1,7 +1,75 @@
 use std::io;
 use std::path::PathBuf;
+use std::ffi::{OsStr, OsString};
+use std::os::windows::ffi::{OsStringExt, OsStrExt};
 use super::{Owner, Permissions};
 
 pub fn get_file_data(path: &PathBuf) -> Result<(Owner, Permissions), io::Error> {
     unimplemented!()
+}
+
+/// Create an `OsString` from a NUL-terminated buffer
+///
+/// Decodes the WTF-16 encoded buffer until it hits a NUL (code point 0).
+/// Everything after and including that code point is not included.
+fn os_from_buf(buf: &[u16]) -> OsString {
+    OsString::from_wide(
+        &buf.iter()
+            .cloned()
+            .take_while(|&n| n != 0)
+            .collect::<Vec<u16>>(),
+    )
+}
+
+/// Create a WTF-16-encoded NUL-terminated buffer from an `OsStr`.
+///
+/// Decodes the `OsStr`, then appends a NUL.
+fn buf_from_os(os: &OsStr) -> Vec<u16> {
+    let mut buf: Vec<u16> = os.encode_wide().collect();
+    buf.push(0);
+    buf
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn basic_wtf16_behavior() {
+        let basic_os = OsString::from("TeSt");
+        let basic_buf = vec![0x54, 0x65, 0x53, 0x74, 0x00];
+        let basic_buf_nuls = vec![0x54, 0x65, 0x53, 0x74, 0x00, 0x00, 0x00, 0x00];
+
+        assert_eq!(os_from_buf(&basic_buf), basic_os);
+        assert_eq!(buf_from_os(&basic_os), basic_buf);
+        assert_eq!(os_from_buf(&basic_buf_nuls), basic_os);
+
+        let unicode_os = OsString::from("💩");
+        let unicode_buf = vec![0xd83d, 0xdca9, 0x0];
+        let unicode_buf_nuls = vec![0xd83d, 0xdca9, 0x0, 0x0, 0x0, 0x0, 0x0];
+
+        assert_eq!(os_from_buf(&unicode_buf), unicode_os);
+        assert_eq!(buf_from_os(&unicode_os), unicode_buf);
+        assert_eq!(os_from_buf(&unicode_buf_nuls), unicode_os);
+    }
+
+    #[test]
+    fn every_wtf16_codepair_roundtrip() {
+        for lsb in 0..256u16 {
+            let mut vec: Vec<u16> = Vec::with_capacity(257);
+
+            for msb in 0..=256u16 {
+                let val = msb << 8 | lsb;
+
+                if val != 0 { vec.push(val) }
+            }
+
+            vec.push(0);
+
+            let os = os_from_buf(&vec);
+            let new_vec = buf_from_os(&os);
+
+            assert_eq!(&vec, &new_vec);
+        }
+    }
 }

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -1,0 +1,7 @@
+use std::io;
+use std::path::PathBuf;
+use super::{Owner, Permissions};
+
+pub fn get_file_data(path: &PathBuf) -> Result<(Owner, Permissions), io::Error> {
+    unimplemented!()
+}

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -193,6 +193,8 @@ mod tests {
         // Create the file;
         let path_z = tmp_dir.path().join("zzz");
         File::create(&path_z).expect("failed to create file");
+
+        #[cfg(unix)]
         let success = Command::new("touch")
             .arg("-t")
             .arg("198511160000")
@@ -200,7 +202,18 @@ mod tests {
             .status()
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec mkfifo");
+
+        #[cfg(windows)]
+        let success = Command::new("powershell")
+            .arg("-Command")
+            .arg("$(Get-Item")
+            .arg(&path_z)
+            .arg(").lastwritetime=$(Get-Date \"11/16/1985\")")
+            .status()
+            .unwrap()
+            .success();
+
+        assert_eq!(true, success, "failed to change file timestamp");
         let meta_z = Meta::from_path(&path_z).expect("failed to get meta");
 
         let mut flags = Flags::default();


### PR DESCRIPTION
I apologize for the size of this PR, but there are a bunch of changes that have to be made at the same time.

The fundamental issue is that Windows has a completely different model for permissions from Unix. Rather than using UIDs and GIDs, Windows uses a structure called a Security Identifier or [SID](https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-_sid), which ~can~ should only be created or modified using WinAPI functions. And rather than the simple permission bits, Windows uses a structure called an Access Control List or [ACL](https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-acl). An ACL can be compared to a SID to get that SID's access rights, which we can translate into Unix-style access bits. The owner and group SIDs and the file's ACL are contained in a structure called a [Security Descriptor](https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ns-winnt-security_descriptor). So the general workflow is:

- Get the file's security descriptor, including the owner SID, group SID, and ACL
- Look up the account name and domain associated with the owner SID
- Look up the account name and domain associated with the group SID
- Create a SID that represents "everyone on the system" (the [WinWorldSid](https://docs.microsoft.com/en-us/windows/desktop/api/winnt/ne-winnt-well_known_sid_type))
- Evaluate the ACL with each of those SIDs to determine that SID's access rights
- Translate those access rights into Unix access bits

All of these (except the last one) rely on the Windows API. Unfortunately, there aren't any existing safe wrappers for this part of the WinAPI, so we have to fall back on the unsafe functions provided by the [winapi](https://docs.rs/winapi/*/x86_64-pc-windows-msvc/winapi/) crate. Therefore, I created a new module, `windows_utils`, which wraps all of the unsafe bits in a safe-to-call function that handles all of the unsafe API calls and memory management.

The other issue is that Windows doesn't allow you to easily separate getting the owner/group of a file from getting the permissions. Both of them use the same unsafe API call ([GetNamedSecurityInfoW](https://docs.microsoft.com/en-us/windows/desktop/api/aclapi/nf-aclapi-getnamedsecurityinfow)) to get the security descriptor. Therefore, I created a single function that generates both the Owner and the Permissions data structures. Every unsafe block has a comment listing the soundness assumptions it makes.

Additionally device files and pipes aren't in the main Windows file system tree, and symlinks are rare to see on Windows, so those aren't implemented for `FileType`.

Most of the rest of the changes fall into a few categories:
- Added an API for creating `Owner` structures directly from `String`s
- Porting tests to Windows (lots of them use `touch` and other non-Windows utilities which have Windows equivalents)
- Disabling a few tests on Windows (pipes, device files, and symlinks)