### PR TITLE
Update the snapcraft.yaml

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -5,9 +5,8 @@ description: lsd is a ls command including pretty icons based on nerd-font.
 
 architectures:
   - amd64
-  - i386
 grade: stable
-confinement: strict
+confinement: classic
 
 parts:
   lsd:


### PR DESCRIPTION
- Enforce the use of --classic required to access the filesystem
- Remove the i386 support because it doesn't build