### PR TITLE
Use package description in clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Peltoche <dev@halium.fr>"]
 build = "build.rs"
 categories = ["command-line-utilities"]
-description = "A ls command with a lot of pretty colors."
+description = "An ls command with a lot of pretty colors and some other stuff."
 keywords = ["ls"]
 license = "Apache-2.0"
 name = "lsd"

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use clap::{App, Arg};
 pub fn build() -> App<'static, 'static> {
     App::new("lsd")
         .version(crate_version!())
-        .about("An ls comment with a lot of pretty colors and some other stuff.")
+        .about(crate_description!())
         .arg(Arg::with_name("FILE").multiple(true).default_value("."))
         .arg(
             Arg::with_name("all")


### PR DESCRIPTION
Use the `crate_description!()` macro to sync crate description and `clap.about()`. Also fixes a typo in the `app` module.

This is my first PR, but I hope to contribute more.