### PR TITLE
Add "manual" clap alias for -A

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,6 +13,12 @@ pub fn build() -> App<'static, 'static> {
                 .help("Do not ignore entries starting with ."),
         )
         .arg(
+            Arg::with_name("almost-all")
+                .short("A")
+                .multiple(true)
+                .help("Alias of -a"),
+        )
+        .arg(
             Arg::with_name("color")
                 .long("color")
                 .possible_value("always")

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -65,7 +65,7 @@ impl Flags {
         };
 
         Ok(Self {
-            display_all: matches.is_present("all"),
+            display_all: matches.is_present("all") || matches.is_present("almost-all"),
             layout,
             display_indicators: matches.is_present("indicators"),
             recursive,


### PR DESCRIPTION
This is requested as a feature, but because clap does not support
"short" aliases, we have to create another clap argument for this.

Not the best possible way to implement this (because the best way would
be to patch clap itself to allow short aliases) but the fastest one.

---

Closes #147