### PR TITLE
Build hashmaps at compiletime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bitflags"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +58,19 @@ dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -99,6 +117,8 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "lscolors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "terminal_size 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -122,6 +142,40 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +183,110 @@ dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -151,6 +309,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "siphasher"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
@@ -277,10 +440,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum chrono-humanize 0.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2ff48a655fe8d2dae9a39e66af7fd8ff32a879e8c4e27422c25596a8b5e90d"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
@@ -288,10 +454,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lscolors 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9938fd8c379393454f73ec4c9c5b40f3d8332d80b25a29da05e41ee0ecbb559"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+"checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+"checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
+"checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
+"checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+"checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "679da7508e9a6390aeaf7fbd02a800fdc64b73fe2204dd2c8ae66d22d9d5ad5d"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "230d3e804faaed5a39b08319efb797783df2fd9671b39b7596490cb486d702cf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [build-dependencies]
 clap = "2.32.0"
 version_check = "0.1.3"
+phf_codegen = "0.7"
 
 [dependencies]
 ansi_term = "0.11.0"
@@ -29,6 +30,7 @@ users = "0.8.0"
 chrono-humanize = "0.0.11"
 unicode-width = "0.1.5"
 lscolors = "0.5.0"
+phf = "0.7"
 
 [dependencies.clap]
 features = ["suggestions", "color", "wrap_help"]

--- a/build.rs
+++ b/build.rs
@@ -9,10 +9,14 @@
 #[macro_use]
 extern crate clap;
 extern crate version_check;
+extern crate phf_codegen;
 
 use clap::Shell;
+use std::env;
+use std::fs::File;
 use std::fs;
-use std::io::{self, Write};
+use std::io::{self, Write, BufWriter};
+use std::path::Path;
 use std::process::exit;
 
 include!("src/app.rs");
@@ -39,4 +43,238 @@ fn main() {
     app.gen_completions("lsd", Shell::Fish, &outdir);
     app.gen_completions("lsd", Shell::Zsh, &outdir);
     app.gen_completions("lsd", Shell::PowerShell, &outdir);
+
+    {
+        let path = Path::new(&env::var("OUT_DIR").unwrap()).join("default_icons_by_name.rs");
+        let mut file = BufWriter::new(File::create(&path).unwrap());
+
+        write!(&mut file, "static DEFAULT_ICONS_BY_NAME: phf::Map<&'static str, &'static str> = ").unwrap();
+        phf_codegen::Map::new()
+            .entry(".Trash", "\"\u{f1f8}\"") // ""
+            .entry(".atom", "\"\u{e764}\"") // ""
+            .entry(".bashprofile", "\"\u{e615}\"") // ""
+            .entry(".bashrc", "\"\u{f489}\"") // ""
+            .entry(".git", "\"\u{f1d3}\"") // ""
+            .entry(".gitconfig", "\"\u{f1d3}\"") // ""
+            .entry(".github", "\"\u{f408}\"") // ""
+            .entry(".gitignore", "\"\u{f1d3}\"") // ""
+            .entry(".rvm", "\"\u{e21e}\"") // ""
+            .entry(".vimrc", "\"\u{e62b}\"") // ""
+            .entry(".vscode", "\"\u{e70c}\"") // ""
+            .entry(".zshrc", "\"\u{f489}\"") // ""
+            .entry("bin", "\"\u{e5fc}\"") // ""
+            .entry("config", "\"\u{e5fc}\"") // ""
+            .entry("docker-compose.yml", "\"\u{f308}\"") // ""
+            .entry("dockerfile", "\"\u{f308}\"") // ""
+            .entry("ds_store", "\"\u{f179}\"") // ""
+            .entry("gitignore_global", "\"\u{f1d3}\"") // ""
+            .entry("gradle", "\"\u{e70e}\"") // ""
+            .entry("gruntfile.coffee", "\"\u{e611}\"") // ""
+            .entry("gruntfile.js", "\"\u{e611}\"") // ""
+            .entry("gruntfile.ls", "\"\u{e611}\"") // ""
+            .entry("gulpfile.coffee", "\"\u{e610}\"") // ""
+            .entry("gulpfile.js", "\"\u{e610}\"") // ""
+            .entry("gulpfile.ls", "\"\u{e610}\"") // ""
+            .entry("hidden", "\"\u{f023}\"") // ""
+            .entry("include", "\"\u{e5fc}\"") // ""
+            .entry("lib", "\"\u{f121}\"") // ""
+            .entry("localized", "\"\u{f179}\"") // ""
+            .entry("node_modules", "\"\u{e718}\"") // ""
+            .entry("npmignore", "\"\u{e71e}\"") // ""
+            .entry("rubydoc", "\"\u{e73b}\"") // ""
+            .entry("yarn.lock", "\"\u{e718}\"") // ""
+            .build(&mut file)
+            .unwrap();
+        write!(&mut file, ";\n").unwrap();
+    }
+
+    {
+        let path = Path::new(&env::var("OUT_DIR").unwrap()).join("default_icons_by_extension.rs");
+        let mut file = BufWriter::new(File::create(&path).unwrap());
+
+        write!(&mut file, "static DEFAULT_ICONS_BY_EXTENSION: phf::Map<&'static str, &'static str> = ").unwrap();
+        phf_codegen::Map::new()
+            .entry("apk", "\"\u{e70e}\"") // ""
+            .entry("avi", "\"\u{f03d}\"") // ""
+            .entry("avro", "\"\u{e60b}\"") // ""
+            .entry("awk", "\"\u{f489}\"") // ""
+            .entry("bash", "\"\u{f489}\"") // ""
+            .entry("bash_history", "\"\u{f489}\"") // ""
+            .entry("bash_profile", "\"\u{f489}\"") // ""
+            .entry("bashrc", "\"\u{f489}\"") // ""
+            .entry("bat", "\"\u{f17a}\"") // ""
+            .entry("bmp", "\"\u{f1c5}\"") // ""
+            .entry("c", "\"\u{e61e}\"") // ""
+            .entry("c++", "\"\u{e61d}\"") // ""
+            .entry("cc", "\"\u{e61d}\"") // ""
+            .entry("cfg", "\"\u{e615}\"") // ""
+            .entry("clj", "\"\u{e768}\"") // ""
+            .entry("cljs", "\"\u{e76a}\"") // ""
+            .entry("cls", "\"\u{e600}\"") // ""
+            .entry("coffee", "\"\u{f0f4}\"") // ""
+            .entry("conf", "\"\u{e615}\"") // ""
+            .entry("cp", "\"\u{e61d}\"") // ""
+            .entry("cpp", "\"\u{e61d}\"") // ""
+            .entry("csh", "\"\u{f489}\"") // ""
+            .entry("css", "\"\u{e749}\"") // ""
+            .entry("csv", "\"\u{f1c3}\"") // ""
+            .entry("cxx", "\"\u{e61d}\"") // ""
+            .entry("d", "\"\u{e7af}\"") // ""
+            .entry("dart", "\"\u{e798}\"") // ""
+            .entry("db", "\"\u{f1c0}\"") // ""
+            .entry("diff", "\"\u{f440}\"") // ""
+            .entry("doc", "\"\u{f1c2}\"") // ""
+            .entry("docx", "\"\u{f1c2}\"") // ""
+            .entry("ds_store", "\"\u{f179}\"") // ""
+            .entry("dump", "\"\u{f1c0}\"") // ""
+            .entry("ebook", "\"\u{e28b}\"") // ""
+            .entry("editorconfig", "\"\u{e615}\"") // ""
+            .entry("ejs", "\"\u{e618}\"") // ""
+            .entry("env", "\"\u{f462}\"") // ""
+            .entry("eot", "\"\u{f031}\"") // ""
+            .entry("epub", "\"\u{e28a}\"") // ""
+            .entry("erb", "\"\u{e73b}\"") // ""
+            .entry("erl", "\"\u{e7b1}\"") // ""
+            .entry("exe", "\"\u{f17a}\"") // ""
+            .entry("fish", "\"\u{f489}\"") // ""
+            .entry("flac", "\"\u{f001}\"") // ""
+            .entry("flv", "\"\u{f03d}\"") // ""
+            .entry("font", "\"\u{f031}\"") // ""
+            .entry("gdoc", "\"\u{f1c2}\"") // ""
+            .entry("gemfile", "\"\u{e21e}\"") // ""
+            .entry("gemspec", "\"\u{e21e}\"") // ""
+            .entry("gform", "\"\u{f298}\"") // ""
+            .entry("gif", "\"\u{f1c5}\"") // ""
+            .entry("git", "\"\u{f1d3}\"") // ""
+            .entry("go", "\"\u{e626}\"") // ""
+            .entry("gradle", "\"\u{e70e}\"") // ""
+            .entry("gsheet", "\"\u{f1c3}\"") // ""
+            .entry("gslides", "\"\u{f1c4}\"") // ""
+            .entry("guardfile", "\"\u{e21e}\"") // ""
+            .entry("gz", "\"\u{f410}\"") // ""
+            .entry("h", "\"\u{f0fd}\"") // ""
+            .entry("hbs", "\"\u{e60f}\"") // ""
+            .entry("hpp", "\"\u{f0fd}\"") // ""
+            .entry("hs", "\"\u{e777}\"") // ""
+            .entry("htm", "\"\u{f13b}\"") // ""
+            .entry("html", "\"\u{f13b}\"") // ""
+            .entry("hxx", "\"\u{f0fd}\"") // ""
+            .entry("ico", "\"\u{f1c5}\"") // ""
+            .entry("image", "\"\u{f1c5}\"") // ""
+            .entry("iml", "\"\u{e7b5}\"") // ""
+            .entry("ini", "\"\u{f17a}\"") // ""
+            .entry("ipynb", "\"\u{e606}\"") // ""
+            .entry("jar", "\"\u{e204}\"") // ""
+            .entry("java", "\"\u{e204}\"") // ""
+            .entry("jpeg", "\"\u{f1c5}\"") // ""
+            .entry("jpg", "\"\u{f1c5}\"") // ""
+            .entry("js", "\"\u{e74e}\"") // ""
+            .entry("json", "\"\u{e60b}\"") // ""
+            .entry("jsx", "\"\u{e7ba}\"") // ""
+            .entry("ksh", "\"\u{f489}\"") // ""
+            .entry("less", "\"\u{e758}\"") // ""
+            .entry("lhs", "\"\u{e777}\"") // ""
+            .entry("license", "\"\u{f48a}\"") // ""
+            .entry("localized", "\"\u{f179}\"") // ""
+            .entry("lock", "\"\u{e21e}\"") // ""
+            .entry("log", "\"\u{f18d}\"") // ""
+            .entry("lua", "\"\u{e620}\"") // ""
+            .entry("m4a", "\"\u{f001}\"") // ""
+            .entry("markdown", "\"\u{f48a}\"") // ""
+            .entry("md", "\"\u{f48a}\"") // ""
+            .entry("mkd", "\"\u{f48a}\"") // ""
+            .entry("mkv", "\"\u{f03d}\"") // ""
+            .entry("mobi", "\"\u{e28b}\"") // ""
+            .entry("mov", "\"\u{f03d}\"") // ""
+            .entry("mp3", "\"\u{f001}\"") // ""
+            .entry("mp4", "\"\u{f03d}\"") // ""
+            .entry("mustache", "\"\u{e60f}\"") // ""
+            .entry("npmignore", "\"\u{e71e}\"") // ""
+            .entry("ogg", "\"\u{f001}\"") // ""
+            .entry("ogv", "\"\u{f03d}\"") // ""
+            .entry("otf", "\"\u{f031}\"") // ""
+            .entry("pdf", "\"\u{f1c1}\"") // ""
+            .entry("php", "\"\u{e73d}\"") // ""
+            .entry("pl", "\"\u{e769}\"") // ""
+            .entry("png", "\"\u{f1c5}\"") // ""
+            .entry("ppt", "\"\u{f1c4}\"") // ""
+            .entry("pptx", "\"\u{f1c4}\"") // ""
+            .entry("procfile", "\"\u{e21e}\"") // ""
+            .entry("properties", "\"\u{e60b}\"") // ""
+            .entry("ps1", "\"\u{f489}\"") // ""
+            .entry("psd", "\"\u{e7b8}\"") // ""
+            .entry("pxm", "\"\u{f1c5}\"") // ""
+            .entry("py", "\"\u{e606}\"") // ""
+            .entry("pyc", "\"\u{e606}\"") // ""
+            .entry("r", "\"\u{f25d}\"") // ""
+            .entry("rakefile", "\"\u{e21e}\"") // ""
+            .entry("rar", "\"\u{f410}\"") // ""
+            .entry("rb", "\"\u{e21e}\"") // ""
+            .entry("rdata", "\"\u{f25d}\"") // ""
+            .entry("rdb", "\"\u{e76d}\"") // ""
+            .entry("rdoc", "\"\u{f48a}\"") // ""
+            .entry("rds", "\"\u{f25d}\"") // ""
+            .entry("readme", "\"\u{f48a}\"") // ""
+            .entry("rlib", "\"\u{e7a8}\"") // ""
+            .entry("rmd", "\"\u{f48a}\"") // ""
+            .entry("rs", "\"\u{e7a8}\"") // ""
+            .entry("rspec", "\"\u{e21e}\"") // ""
+            .entry("rspec_parallel", "\"\u{e21e}\"") // ""
+            .entry("rspec_status", "\"\u{e21e}\"") // ""
+            .entry("rss", "\"\u{f09e}\"") // ""
+            .entry("ru", "\"\u{e21e}\"") // ""
+            .entry("rubydoc", "\"\u{e73b}\"") // ""
+            .entry("sass", "\"\u{e603}\"") // ""
+            .entry("scala", "\"\u{e737}\"") // ""
+            .entry("scss", "\"\u{e749}\"") // ""
+            .entry("sh", "\"\u{f489}\"") // ""
+            .entry("shell", "\"\u{f489}\"") // ""
+            .entry("slim", "\"\u{e73b}\"") // ""
+            .entry("sql", "\"\u{f1c0}\"") // ""
+            .entry("sqlite3", "\"\u{e7c4}\"") // ""
+            .entry("styl", "\"\u{e600}\"") // ""
+            .entry("stylus", "\"\u{e600}\"") // ""
+            .entry("svg", "\"\u{f1c5}\"") // ""
+            .entry("swift", "\"\u{e755}\"") // ""
+            .entry("tar", "\"\u{f410}\"") // ""
+            .entry("tex", "\"\u{e600}\"") // ""
+            .entry("tiff", "\"\u{f1c5}\"") // ""
+            .entry("ts", "\"\u{e628}\"") // ""
+            .entry("tsx", "\"\u{e7ba}\"") // ""
+            .entry("ttf", "\"\u{f031}\"") // ""
+            .entry("twig", "\"\u{e61c}\"") // ""
+            .entry("txt", "\"\u{f15c}\"") // ""
+            .entry("video", "\"\u{f03d}\"") // ""
+            .entry("vim", "\"\u{e62b}\"") // ""
+            .entry("vue", "\"\u{fd42}\"") // "﵂"
+            .entry("wav", "\"\u{f001}\"") // ""
+            .entry("webm", "\"\u{f03d}\"") // ""
+            .entry("webp", "\"\u{f1c5}\"") // ""
+            .entry("windows", "\"\u{f17a}\"") // ""
+            .entry("woff", "\"\u{f031}\"") // ""
+            .entry("woff2", "\"\u{f031}\"") // ""
+            .entry("xls", "\"\u{f1c3}\"") // ""
+            .entry("xlsx", "\"\u{f1c3}\"") // ""
+            .entry("xml", "\"\u{e619}\"") // ""
+            .entry("xul", "\"\u{e619}\"") // ""
+            .entry("yaml", "\"\u{f481}\"") // ""
+            .entry("yml", "\"\u{f481}\"") // ""
+            .entry("zip", "\"\u{f410}\"") // ""
+            .entry("zsh", "\"\u{f489}\"") // ""
+            .entry("zsh-theme", "\"\u{f489}\"") // ""
+            .entry("zshrc", "\"\u{f489}\"") // ""
+            .build(&mut file)
+            .unwrap();
+        write!(&mut file, ";\n").unwrap();
+    }
+
+    {
+        let path = Path::new(&env::var("OUT_DIR").unwrap()).join("empty_icon_map.rs");
+        let mut file = BufWriter::new(File::create(&path).unwrap());
+
+        write!(&mut file, "static EMPTY_ICON_MAP: phf::Map<&'static str, &'static str> = ").unwrap();
+        let map : phf_codegen::Map<&'static str> = phf_codegen::Map::new();
+        map.build(&mut file).unwrap();
+        write!(&mut file, ";\n").unwrap();
+    }
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -1,10 +1,10 @@
 use crate::meta::{FileType, Name};
-use std::collections::HashMap;
+use phf::map::Map;
 
 pub struct Icons {
     display_icons: bool,
-    icons_by_name: HashMap<&'static str, &'static str>,
-    icons_by_extension: HashMap<&'static str, &'static str>,
+    icons_by_name: &'static Map<&'static str, &'static str>,
+    icons_by_extension: &'static Map<&'static str, &'static str>,
     default_folder_icon: &'static str,
     default_file_icon: &'static str,
 }
@@ -18,6 +18,10 @@ pub enum Theme {
 
 const ICON_SPACE: &str = "  ";
 
+include!(concat!(env!("OUT_DIR"), "/default_icons_by_name.rs"));
+include!(concat!(env!("OUT_DIR"), "/default_icons_by_extension.rs"));
+include!(concat!(env!("OUT_DIR"), "/empty_icon_map.rs"));
+
 // In order to add a new icon, write the unicode value like "\ue5fb" then
 // run the command below in vim:
 //
@@ -25,29 +29,22 @@ const ICON_SPACE: &str = "  ";
 impl Icons {
     pub fn new(theme: Theme) -> Self {
         let display_icons = theme == Theme::Fancy || theme == Theme::Unicode;
-        let (icons_by_name, icons_by_extension, default_file_icon, default_folder_icon) =
-            if theme == Theme::Fancy {
-                (
-                    Self::get_default_icons_by_name(),
-                    Self::get_default_icons_by_extension(),
-                    "\u{f016}", // 
-                    "\u{f115}", // 
-                )
-            } else {
-                (
-                    HashMap::new(),
-                    HashMap::new(),
-                    "\u{1f5cb}", // 🗋
-                    "\u{1f5c1}", // 🗁
-                )
-            };
-
-        Self {
-            display_icons,
-            icons_by_name,
-            icons_by_extension,
-            default_file_icon,
-            default_folder_icon,
+        if theme == Theme::Fancy {
+            Icons {
+                display_icons: display_icons,
+                icons_by_name: &DEFAULT_ICONS_BY_NAME,
+                icons_by_extension: &DEFAULT_ICONS_BY_EXTENSION,
+                default_file_icon: "\u{f016}", // 
+                default_folder_icon: "\u{f115}", // 
+            }
+        } else {
+            Icons {
+                display_icons: display_icons,
+                icons_by_name: &EMPTY_ICON_MAP,
+                icons_by_extension: &EMPTY_ICON_MAP,
+                default_file_icon: "\u{1f5cb}", // 🗋
+                default_folder_icon: "\u{1f5c1}", // 🗁
+            }
         }
     }
 
@@ -87,222 +84,6 @@ impl Icons {
         res
     }
 
-    fn get_default_icons_by_name() -> HashMap<&'static str, &'static str> {
-        let mut m = HashMap::new();
-
-        m.insert(".Trash", "\u{f1f8}"); // ""
-        m.insert(".atom", "\u{e764}"); // ""
-        m.insert(".bashprofile", "\u{e615}"); // ""
-        m.insert(".bashrc", "\u{f489}"); // ""
-        m.insert(".git", "\u{f1d3}"); // ""
-        m.insert(".gitconfig", "\u{f1d3}"); // ""
-        m.insert(".github", "\u{f408}"); // ""
-        m.insert(".gitignore", "\u{f1d3}"); // ""
-        m.insert(".rvm", "\u{e21e}"); // ""
-        m.insert(".vimrc", "\u{e62b}"); // ""
-        m.insert(".vscode", "\u{e70c}"); // ""
-        m.insert(".zshrc", "\u{f489}"); // ""
-        m.insert("bin", "\u{e5fc}"); // ""
-        m.insert("config", "\u{e5fc}"); // ""
-        m.insert("docker-compose.yml", "\u{f308}"); // ""
-        m.insert("dockerfile", "\u{f308}"); // ""
-        m.insert("ds_store", "\u{f179}"); // ""
-        m.insert("gitignore_global", "\u{f1d3}"); // ""
-        m.insert("gradle", "\u{e70e}"); // ""
-        m.insert("gruntfile.coffee", "\u{e611}"); // ""
-        m.insert("gruntfile.js", "\u{e611}"); // ""
-        m.insert("gruntfile.ls", "\u{e611}"); // ""
-        m.insert("gulpfile.coffee", "\u{e610}"); // ""
-        m.insert("gulpfile.js", "\u{e610}"); // ""
-        m.insert("gulpfile.ls", "\u{e610}"); // ""
-        m.insert("hidden", "\u{f023}"); // ""
-        m.insert("include", "\u{e5fc}"); // ""
-        m.insert("lib", "\u{f121}"); // ""
-        m.insert("localized", "\u{f179}"); // ""
-        m.insert("node_modules", "\u{e718}"); // ""
-        m.insert("npmignore", "\u{e71e}"); // ""
-        m.insert("rubydoc", "\u{e73b}"); // ""
-        m.insert("yarn.lock", "\u{e718}"); // ""
-
-        m
-    }
-
-    fn get_default_icons_by_extension() -> HashMap<&'static str, &'static str> {
-        let mut m = HashMap::new();
-
-        m.insert("apk", "\u{e70e}"); // ""
-        m.insert("apk", "\u{e70e}"); // ""
-        m.insert("avi", "\u{f03d}"); // ""
-        m.insert("avro", "\u{e60b}"); // ""
-        m.insert("awk", "\u{f489}"); // ""
-        m.insert("bash", "\u{f489}"); // ""
-        m.insert("bash_history", "\u{f489}"); // ""
-        m.insert("bash_profile", "\u{f489}"); // ""
-        m.insert("bashrc", "\u{f489}"); // ""
-        m.insert("bat", "\u{f17a}"); // ""
-        m.insert("bmp", "\u{f1c5}"); // ""
-        m.insert("c", "\u{e61e}"); // ""
-        m.insert("c++", "\u{e61d}"); // ""
-        m.insert("cc", "\u{e61d}"); // ""
-        m.insert("cfg", "\u{e615}"); // ""
-        m.insert("clj", "\u{e768}"); // ""
-        m.insert("cljs", "\u{e76a}"); // ""
-        m.insert("cls", "\u{e600}"); // ""
-        m.insert("coffee", "\u{f0f4}"); // ""
-        m.insert("conf", "\u{e615}"); // ""
-        m.insert("cp", "\u{e61d}"); // ""
-        m.insert("cpp", "\u{e61d}"); // ""
-        m.insert("csh", "\u{f489}"); // ""
-        m.insert("css", "\u{e749}"); // ""
-        m.insert("csv", "\u{f1c3}"); // ""
-        m.insert("cxx", "\u{e61d}"); // ""
-        m.insert("d", "\u{e7af}"); // ""
-        m.insert("dart", "\u{e798}"); // ""
-        m.insert("db", "\u{f1c0}"); // ""
-        m.insert("diff", "\u{f440}"); // ""
-        m.insert("doc", "\u{f1c2}"); // ""
-        m.insert("docx", "\u{f1c2}"); // ""
-        m.insert("ds_store", "\u{f179}"); // ""
-        m.insert("dump", "\u{f1c0}"); // ""
-        m.insert("ebook", "\u{e28b}"); // ""
-        m.insert("editorconfig", "\u{e615}"); // ""
-        m.insert("ejs", "\u{e618}"); // ""
-        m.insert("env", "\u{f462}"); // ""
-        m.insert("eot", "\u{f031}"); // ""
-        m.insert("epub", "\u{e28a}"); // ""
-        m.insert("erb", "\u{e73b}"); // ""
-        m.insert("erl", "\u{e7b1}"); // ""
-        m.insert("exe", "\u{f17a}"); // ""
-        m.insert("fish", "\u{f489}"); // ""
-        m.insert("flac", "\u{f001}"); // ""
-        m.insert("flv", "\u{f03d}"); // ""
-        m.insert("font", "\u{f031}"); // ""
-        m.insert("gdoc", "\u{f1c2}"); // ""
-        m.insert("gemfile", "\u{e21e}"); // ""
-        m.insert("gemspec", "\u{e21e}"); // ""
-        m.insert("gform", "\u{f298}"); // ""
-        m.insert("gif", "\u{f1c5}"); // ""
-        m.insert("git", "\u{f1d3}"); // ""
-        m.insert("go", "\u{e626}"); // ""
-        m.insert("gradle", "\u{e70e}"); // ""
-        m.insert("gsheet", "\u{f1c3}"); // ""
-        m.insert("gslides", "\u{f1c4}"); // ""
-        m.insert("guardfile", "\u{e21e}"); // ""
-        m.insert("gz", "\u{f410}"); // ""
-        m.insert("h", "\u{f0fd}"); // ""
-        m.insert("hbs", "\u{e60f}"); // ""
-        m.insert("hpp", "\u{f0fd}"); // ""
-        m.insert("hs", "\u{e777}"); // ""
-        m.insert("htm", "\u{f13b}"); // ""
-        m.insert("html", "\u{f13b}"); // ""
-        m.insert("hxx", "\u{f0fd}"); // ""
-        m.insert("ico", "\u{f1c5}"); // ""
-        m.insert("image", "\u{f1c5}"); // ""
-        m.insert("iml", "\u{e7b5}"); // ""
-        m.insert("ini", "\u{f17a}"); // ""
-        m.insert("ipynb", "\u{e606}"); // ""
-        m.insert("jar", "\u{e204}"); // ""
-        m.insert("java", "\u{e204}"); // ""
-        m.insert("jpeg", "\u{f1c5}"); // ""
-        m.insert("jpg", "\u{f1c5}"); // ""
-        m.insert("js", "\u{e74e}"); // ""
-        m.insert("json", "\u{e60b}"); // ""
-        m.insert("jsx", "\u{e7ba}"); // ""
-        m.insert("ksh", "\u{f489}"); // ""
-        m.insert("less", "\u{e758}"); // ""
-        m.insert("lhs", "\u{e777}"); // ""
-        m.insert("license", "\u{f48a}"); // ""
-        m.insert("localized", "\u{f179}"); // ""
-        m.insert("lock", "\u{e21e}"); // ""
-        m.insert("log", "\u{f18d}"); // ""
-        m.insert("lua", "\u{e620}"); // ""
-        m.insert("m4a", "\u{f001}"); // ""
-        m.insert("markdown", "\u{f48a}"); // ""
-        m.insert("md", "\u{f48a}"); // ""
-        m.insert("mkd", "\u{f48a}"); // ""
-        m.insert("mkv", "\u{f03d}"); // ""
-        m.insert("mobi", "\u{e28b}"); // ""
-        m.insert("mov", "\u{f03d}"); // ""
-        m.insert("mp3", "\u{f001}"); // ""
-        m.insert("mp4", "\u{f03d}"); // ""
-        m.insert("mustache", "\u{e60f}"); // ""
-        m.insert("npmignore", "\u{e71e}"); // ""
-        m.insert("ogg", "\u{f001}"); // ""
-        m.insert("ogv", "\u{f03d}"); // ""
-        m.insert("otf", "\u{f031}"); // ""
-        m.insert("pdf", "\u{f1c1}"); // ""
-        m.insert("php", "\u{e73d}"); // ""
-        m.insert("pl", "\u{e769}"); // ""
-        m.insert("png", "\u{f1c5}"); // ""
-        m.insert("ppt", "\u{f1c4}"); // ""
-        m.insert("pptx", "\u{f1c4}"); // ""
-        m.insert("procfile", "\u{e21e}"); // ""
-        m.insert("properties", "\u{e60b}"); // ""
-        m.insert("ps1", "\u{f489}"); // ""
-        m.insert("psd", "\u{e7b8}"); // ""
-        m.insert("pxm", "\u{f1c5}"); // ""
-        m.insert("py", "\u{e606}"); // ""
-        m.insert("pyc", "\u{e606}"); // ""
-        m.insert("r", "\u{f25d}"); // ""
-        m.insert("rakefile", "\u{e21e}"); // ""
-        m.insert("rar", "\u{f410}"); // ""
-        m.insert("rb", "\u{e21e}"); // ""
-        m.insert("rdata", "\u{f25d}"); // ""
-        m.insert("rdb", "\u{e76d}"); // ""
-        m.insert("rdoc", "\u{f48a}"); // ""
-        m.insert("rds", "\u{f25d}"); // ""
-        m.insert("readme", "\u{f48a}"); // ""
-        m.insert("rlib", "\u{e7a8}"); // ""
-        m.insert("rmd", "\u{f48a}"); // ""
-        m.insert("rs", "\u{e7a8}"); // ""
-        m.insert("rspec", "\u{e21e}"); // ""
-        m.insert("rspec_parallel", "\u{e21e}"); // ""
-        m.insert("rspec_status", "\u{e21e}"); // ""
-        m.insert("rss", "\u{f09e}"); // ""
-        m.insert("ru", "\u{e21e}"); // ""
-        m.insert("rubydoc", "\u{e73b}"); // ""
-        m.insert("sass", "\u{e603}"); // ""
-        m.insert("scala", "\u{e737}"); // ""
-        m.insert("scss", "\u{e749}"); // ""
-        m.insert("sh", "\u{f489}"); // ""
-        m.insert("shell", "\u{f489}"); // ""
-        m.insert("slim", "\u{e73b}"); // ""
-        m.insert("sql", "\u{f1c0}"); // ""
-        m.insert("sqlite3", "\u{e7c4}"); // ""
-        m.insert("styl", "\u{e600}"); // ""
-        m.insert("stylus", "\u{e600}"); // ""
-        m.insert("svg", "\u{f1c5}"); // ""
-        m.insert("swift", "\u{e755}"); // ""
-        m.insert("tar", "\u{f410}"); // ""
-        m.insert("tex", "\u{e600}"); // ""
-        m.insert("tiff", "\u{f1c5}"); // ""
-        m.insert("ts", "\u{e628}"); // ""
-        m.insert("tsx", "\u{e7ba}"); // ""
-        m.insert("ttf", "\u{f031}"); // ""
-        m.insert("twig", "\u{e61c}"); // ""
-        m.insert("txt", "\u{f15c}"); // ""
-        m.insert("video", "\u{f03d}"); // ""
-        m.insert("vim", "\u{e62b}"); // ""
-        m.insert("vue", "\u{fd42}"); // "﵂"
-        m.insert("wav", "\u{f001}"); // ""
-        m.insert("webm", "\u{f03d}"); // ""
-        m.insert("webp", "\u{f1c5}"); // ""
-        m.insert("windows", "\u{f17a}"); // ""
-        m.insert("woff", "\u{f031}"); // ""
-        m.insert("woff2", "\u{f031}"); // ""
-        m.insert("xls", "\u{f1c3}"); // ""
-        m.insert("xlsx", "\u{f1c3}"); // ""
-        m.insert("xml", "\u{e619}"); // ""
-        m.insert("xul", "\u{e619}"); // ""
-        m.insert("yaml", "\u{f481}"); // ""
-        m.insert("yml", "\u{f481}"); // ""
-        m.insert("zip", "\u{f410}"); // ""
-        m.insert("zsh", "\u{f489}"); // ""
-        m.insert("zsh-theme", "\u{f489}"); // ""
-        m.insert("zshrc", "\u{f489}"); // ""
-
-        m
-    }
 }
 
 #[cfg(test)]
@@ -403,7 +184,7 @@ mod test {
     fn get_icon_by_name() {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
 
-        for (file_name, file_icon) in &Icons::get_default_icons_by_name() {
+        for (file_name, file_icon) in &DEFAULT_ICONS_BY_NAME {
             let file_path = tmp_dir.path().join(file_name);
             File::create(&file_path).expect("failed to create file");
             let meta = file_path.metadata().expect("failed to get metas");
@@ -421,7 +202,7 @@ mod test {
     fn get_icon_by_extension() {
         let tmp_dir = TempDir::new("test_file_type").expect("failed to create temp dir");
 
-        for (ext, file_icon) in &Icons::get_default_icons_by_extension() {
+        for (ext, file_icon) in &DEFAULT_ICONS_BY_EXTENSION {
             let file_path = tmp_dir.path().join(format!("file.{}", ext));
             File::create(&file_path).expect("failed to create file");
             let meta = file_path.metadata().expect("failed to get metas");


### PR DESCRIPTION
This patch alters the icons code so that the big hashmaps are build at
compiletime using the 'phf' crate.

I did not performance-test this patch, although building these hashmaps
at compiletime should at least theoretically improve execution time.

---

It was fun to write this patch. If you want to apply it, I'd rather speed-test the difference before blindly applying it.

Unfortunately, I do not have the computing power to do meaningful speed tests right now.