### PR TITLE
bugfix: only one value for multi value options in clap

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -26,6 +26,7 @@ pub fn build() -> App<'static, 'static> {
                 .possible_value("never")
                 .default_value("auto")
                 .multiple(true)
+                .number_of_values(1)
                 .help("When to use terminal colours"),
         )
         .arg(
@@ -36,6 +37,7 @@ pub fn build() -> App<'static, 'static> {
                 .possible_value("never")
                 .default_value("auto")
                 .multiple(true)
+                .number_of_values(1)
                 .help("When to print the icons"),
         )
         .arg(
@@ -45,6 +47,7 @@ pub fn build() -> App<'static, 'static> {
                 .possible_value("unicode")
                 .default_value("fancy")
                 .multiple(true)
+                .number_of_values(1)
                 .help("Whether to use fancy or unicode icons"),
         )
         .arg(
@@ -103,6 +106,7 @@ pub fn build() -> App<'static, 'static> {
                 .possible_value("relative")
                 .default_value("date")
                 .multiple(true)
+                .number_of_values(1)
                 .help("How to display date"),
         )
         .arg(
@@ -127,6 +131,7 @@ pub fn build() -> App<'static, 'static> {
                 .possible_value("last")
                 .default_value("none")
                 .multiple(true)
+                .number_of_values(1)
                 .help("Sort the directories then the files"),
         )
         .arg(


### PR DESCRIPTION
before `lsd --icon never ../` would give an error like

![error](https://i.imgur.com/7syR6GE.png)