### PR TITLE
Add --blocks flag as per #96

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -171,8 +171,8 @@ pub fn build() -> App<'static, 'static> {
                 .multiple(true)
                 .number_of_values(1)
                 .require_delimiter(true)
-                .possible_values(&["filetype","permission", "user", "group", "size", "date", "name", "namewithsymlink"])
-                .default_value("filetype,permission,user,group,size,date,namewithsymlink")
+                .possible_values(&["permission", "user", "group", "size", "date", "name", "namewithsymlink"])
+                .default_value("permission,user,group,size,date,namewithsymlink")
                 .help("Specify the blocks that will be displayed and in what order"),
         )
         .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -166,6 +166,23 @@ pub fn build() -> App<'static, 'static> {
                 .help("Sort the directories then the files"),
         )
         .arg(
+            Arg::with_name("blocks")
+                .long("blocks")
+                .multiple(true)
+                .possible_values(&[
+                    "type",
+                    "permission",
+                    "user",
+                    "group",
+                    "size",
+                    "date",
+                    "name",
+                ])
+                .require_delimiter(true)
+                .number_of_values(1)
+                .help("Specify the blocks that will be displayed"),
+        )
+        .arg(
             Arg::with_name("classic")
                 .long("classic")
                 .help("Enable classic mode (no colors or icons)"),

--- a/src/app.rs
+++ b/src/app.rs
@@ -169,18 +169,11 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("blocks")
                 .long("blocks")
                 .multiple(true)
-                .possible_values(&[
-                    "type",
-                    "permission",
-                    "user",
-                    "group",
-                    "size",
-                    "date",
-                    "name",
-                ])
-                .require_delimiter(true)
                 .number_of_values(1)
-                .help("Specify the blocks that will be displayed"),
+                .require_delimiter(true)
+                .possible_values(&["permission", "user", "group", "size", "date", "name"])
+                .default_value("permission,user,group,size,date,name")
+                .help("Specify the blocks that will be displayed and in what order"),
         )
         .arg(
             Arg::with_name("classic")

--- a/src/app.rs
+++ b/src/app.rs
@@ -171,8 +171,8 @@ pub fn build() -> App<'static, 'static> {
                 .multiple(true)
                 .number_of_values(1)
                 .require_delimiter(true)
-                .possible_values(&["permission", "user", "group", "size", "date", "name", "namewithsymlink"])
-                .default_value("permission,user,group,size,date,namewithsymlink")
+                .possible_values(&["permission", "user", "group", "size", "date", "name","namewithoutsymlink" ])
+                .default_value("permission,user,group,size,date,name")
                 .help("Specify the blocks that will be displayed and in what order"),
         )
         .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -171,8 +171,8 @@ pub fn build() -> App<'static, 'static> {
                 .multiple(true)
                 .number_of_values(1)
                 .require_delimiter(true)
-                .possible_values(&["permission", "user", "group", "size", "date", "name"])
-                .default_value("permission,user,group,size,date,name")
+                .possible_values(&["filetype","permission", "user", "group", "size", "date", "name", "namewithsymlink"])
+                .default_value("filetype,permission,user,group,size,date,namewithsymlink")
                 .help("Specify the blocks that will be displayed and in what order"),
         )
         .arg(

--- a/src/app.rs
+++ b/src/app.rs
@@ -171,7 +171,7 @@ pub fn build() -> App<'static, 'static> {
                 .multiple(true)
                 .number_of_values(1)
                 .require_delimiter(true)
-                .possible_values(&["permission", "user", "group", "size", "date", "name","namewithoutsymlink" ])
+                .possible_values(&["permission", "user", "group", "size", "date", "name"])
                 .default_value("permission,user,group,size,date,name")
                 .help("Specify the blocks that will be displayed and in what order"),
         )
@@ -179,5 +179,11 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("classic")
                 .long("classic")
                 .help("Enable classic mode (no colors or icons)"),
+        )
+        .arg(
+            Arg::with_name("no-symlink")
+                .long("no-symlink")
+                .multiple(true)
+                .help("Do not display symlink target"),
         )
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -26,7 +26,7 @@ impl Core {
         #[cfg(target_os = "windows")]
         let console_color_ok = ansi_term::enable_ansi_support().is_ok();
 
-        let mut inner_flags = flags;
+        let mut inner_flags = flags.clone();
 
         let color_theme = match (tty_available && console_color_ok, flags.color) {
             (_, WhenFlag::Never) | (false, WhenFlag::Auto) => color::Theme::NoColor,
@@ -110,7 +110,7 @@ impl Core {
     }
 
     fn sort(&self, metas: &mut Vec<Meta>) {
-        metas.sort_unstable_by(|a, b| sort::by_meta(a, b, self.flags));
+        metas.sort_unstable_by(|a, b| sort::by_meta(a, b, self.flags.clone()));
 
         for meta in metas {
             if let Some(ref mut content) = meta.content {
@@ -122,10 +122,10 @@ impl Core {
     fn display(&self, metas: Vec<Meta>) {
         let output = match self.flags.layout {
             Layout::OneLine { .. } => {
-                display::one_line(metas, self.flags, &self.colors, &self.icons)
+                display::one_line(metas, &self.flags, &self.colors, &self.icons)
             }
-            Layout::Tree { .. } => display::tree(metas, self.flags, &self.colors, &self.icons),
-            Layout::Grid => display::grid(metas, self.flags, &self.colors, &self.icons),
+            Layout::Tree { .. } => display::tree(metas, &self.flags, &self.colors, &self.icons),
+            Layout::Grid => display::grid(metas, &self.flags, &self.colors, &self.icons),
         };
         print!("{}", output);
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -110,7 +110,7 @@ impl Core {
     }
 
     fn sort(&self, metas: &mut Vec<Meta>) {
-        metas.sort_unstable_by(|a, b| sort::by_meta(a, b, self.flags.clone()));
+        metas.sort_unstable_by(|a, b| sort::by_meta(a, b, &self.flags));
 
         for meta in metas {
             if let Some(ref mut content) = meta.content {

--- a/src/display.rs
+++ b/src/display.rs
@@ -58,7 +58,7 @@ fn inner_display_one_line(
             size: detect_size_lengths(&metas, &flags),
             date: detect_date_length(&metas, &flags),
             name: detect_name_length(&metas, &icons),
-            name_with_symlink: detect_name_with_symlink_length(&metas, &icons)
+            name_with_symlink: detect_name_with_symlink_length(&metas, &icons),
         })
     }
 
@@ -283,8 +283,10 @@ fn get_long_output(
     let mut strings: Vec<ANSIString> = Vec::new();
     for block in flags.blocks.iter() {
         match block {
-            Block::FileType => strings.push(meta.file_type.render(colors)),
-            Block::Permission => strings.push(meta.permissions.render(colors)),
+            Block::Permission => {
+                strings.push(meta.file_type.render(colors));
+                strings.push(meta.permissions.render(colors));
+            }
             Block::User => strings.push(meta.owner.render_user(colors, padding_rules.user)),
             Block::Group => strings.push(meta.owner.render_group(colors, padding_rules.group)),
             Block::Size => strings.push(meta.size.render(

--- a/src/display.rs
+++ b/src/display.rs
@@ -18,6 +18,7 @@ struct PaddingRules {
     group: usize,
     size: (usize, usize),
     date: usize,
+    name: usize,
 }
 
 pub fn one_line(metas: Vec<Meta>, flags: &Flags, colors: &Colors, icons: &Icons) -> String {
@@ -55,6 +56,7 @@ fn inner_display_one_line(
             group: detect_group_length(&metas),
             size: detect_size_lengths(&metas, &flags),
             date: detect_date_length(&metas, &flags),
+            name: detect_name_length(&metas, &icons),
         })
     }
 
@@ -262,7 +264,7 @@ fn display_folder_path(meta: &Meta) -> String {
 
 fn get_short_output(meta: &Meta, colors: &Colors, icons: &Icons, flags: &Flags) -> String {
     let strings: &[ANSIString] = &[
-        meta.name.render(colors, icons),
+        meta.name.render(colors, icons, None),
         meta.indicator.render(&flags),
     ];
 
@@ -289,11 +291,11 @@ fn get_long_output(
                 colors,
                 padding_rules.size.0,
                 padding_rules.size.1,
-                &flags
+                &flags,
             )),
             Block::Date => strings.push(meta.date.render(colors, padding_rules.date, &flags)),
             Block::Name => {
-                strings.push(meta.name.render(colors, icons));
+                strings.push(meta.name.render(colors, icons, Some(padding_rules.name)));
                 strings.push(meta.indicator.render(&flags));
                 strings.push(meta.symlink.render(colors));
             }
@@ -388,6 +390,17 @@ fn detect_size_lengths(metas: &[Meta], flags: &Flags) -> (usize, usize) {
     }
 
     (max_value_length, max_unit_size)
+}
+fn detect_name_length(metas: &[Meta], icons: &Icons) -> usize {
+    let mut max_value_length: usize = 0;
+
+    for meta in metas {
+        if meta.name.name_string(&icons).len() > max_value_length {
+            max_value_length = meta.name.name_string(&icons).len();
+        }
+    }
+
+    max_value_length
 }
 
 #[cfg(test)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -319,23 +319,6 @@ fn get_long_output(
         };
         strings.push(ANSIString::from(" ")); // TODO do not add this space to the end
     }
-    // let strings: &[ANSIString] = &[
-    //     meta.file_type.render(colors),
-    //     meta.permissions.render(colors),
-    //     ANSIString::from(" "),
-    //     meta.owner.render_user(colors, padding_rules.user),
-    //     ANSIString::from(" "),
-    //     meta.owner.render_group(colors, padding_rules.group),
-    //     ANSIString::from(" "),
-    //     meta.size
-    //         .render(colors, padding_rules.size.0, padding_rules.size.1),
-    //     ANSIString::from(" "),
-    //     meta.date.render(colors, padding_rules.date, flags),
-    //     ANSIString::from(" "),
-    //     meta.name.render(colors, icons),
-    //     meta.indicator.render(flags),
-    //     meta.symlink.render(colors),
-    // ];
 
     ANSIStrings(&strings).to_string()
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -190,6 +190,8 @@ fn inner_display_tree(
             group: detect_group_length(&metas),
             size: detect_size_lengths(&metas, flags),
             date: detect_date_length(&metas, flags),
+            name: detect_name_length(&metas, &icons),
+            name_with_symlink: detect_name_with_symlink_length(&metas, &icons),
         })
     }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -266,7 +266,7 @@ fn display_folder_path(meta: &Meta) -> String {
 
 fn get_short_output(meta: &Meta, colors: &Colors, icons: &Icons, flags: &Flags) -> String {
     let strings: &[ANSIString] = &[
-        meta.name.render(colors, icons, None),
+        meta.name.render(colors, icons),
         meta.indicator.render(&flags),
     ];
 
@@ -298,28 +298,31 @@ fn get_long_output(
             Block::Date => strings.push(meta.date.render(colors, padding_rules.date, &flags)),
             Block::Name => {
                 if flags.no_symlink {
-                    strings.push(meta.name.render(colors, icons, Some(padding_rules.name)));
+                    strings.push(meta.name.render(colors, icons));
+                    strings
+                        .push(ANSIString::from(" ".to_string().repeat(
+                            padding_rules.name - meta.name.name_string(icons).len(),
+                        )))
                 } else {
                     match meta.symlink.symlink_string() {
-                        Some(_) => {
-                            strings.push(meta.name.render(colors, icons, None));
+                        Some(s) => {
+                            strings.push(meta.name.render(colors, icons));
                             strings.push(meta.indicator.render(&flags));
-                            strings.push(meta.symlink.render(
-                                colors,
-                                Some(
-                                    padding_rules.name_with_symlink
-                                        - meta.name.name_string(icons).len(),
-                                ),
-                            ));
+                            strings.push(meta.symlink.render(colors));
+                            strings.push(ANSIString::from(" ".to_string().repeat(
+                                padding_rules.name_with_symlink
+                                    - meta.name.name_string(icons).len()
+                                    - s.len(),
+                            )))
                         }
                         None => {
-                            strings.push(meta.name.render(
-                                colors,
-                                icons,
-                                Some(padding_rules.name_with_symlink + 3),
-                            ));
+                            strings.push(meta.name.render(colors, icons));
                             strings.push(meta.indicator.render(&flags));
-                            strings.push(meta.symlink.render(colors, None));
+                            strings.push(meta.symlink.render(colors));
+                            strings.push(ANSIString::from(" ".to_string().repeat(
+                                padding_rules.name_with_symlink + 3
+                                    - meta.name.name_string(icons).len(),
+                            )))
                         }
                     }
                 }
@@ -460,7 +463,6 @@ mod tests {
             let output = name.render(
                 &Colors::new(color::Theme::NoColor),
                 &Icons::new(icon::Theme::NoIcon),
-                None,
             );
 
             assert_eq!(get_visible_width(&output), *l);
@@ -492,7 +494,6 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::Fancy),
-                    None,
                 )
                 .to_string();
 
@@ -524,7 +525,6 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoLscolors),
                     &Icons::new(icon::Theme::NoIcon),
-                    None,
                 )
                 .to_string();
 
@@ -560,7 +560,6 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::NoIcon),
-                    None,
                 )
                 .to_string();
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -296,26 +296,34 @@ fn get_long_output(
                 &flags,
             )),
             Block::Date => strings.push(meta.date.render(colors, padding_rules.date, &flags)),
-            Block::Name => strings.push(meta.name.render(colors, icons, Some(padding_rules.name))),
-            Block::NameWithSymlink => match meta.symlink.symlink_string() {
-                Some(_) => {
-                    strings.push(meta.name.render(colors, icons, None));
-                    strings.push(meta.indicator.render(&flags));
-                    strings.push(meta.symlink.render(
-                        colors,
-                        Some(padding_rules.name_with_symlink - meta.name.name_string(icons).len()),
-                    ));
+            Block::Name => {
+                if flags.no_symlink {
+                    strings.push(meta.name.render(colors, icons, Some(padding_rules.name)));
+                } else {
+                    match meta.symlink.symlink_string() {
+                        Some(_) => {
+                            strings.push(meta.name.render(colors, icons, None));
+                            strings.push(meta.indicator.render(&flags));
+                            strings.push(meta.symlink.render(
+                                colors,
+                                Some(
+                                    padding_rules.name_with_symlink
+                                        - meta.name.name_string(icons).len(),
+                                ),
+                            ));
+                        }
+                        None => {
+                            strings.push(meta.name.render(
+                                colors,
+                                icons,
+                                Some(padding_rules.name_with_symlink + 3),
+                            ));
+                            strings.push(meta.indicator.render(&flags));
+                            strings.push(meta.symlink.render(colors, None));
+                        }
+                    }
                 }
-                None => {
-                    strings.push(meta.name.render(
-                        colors,
-                        icons,
-                        Some(padding_rules.name_with_symlink + 3),
-                    ));
-                    strings.push(meta.indicator.render(&flags));
-                    strings.push(meta.symlink.render(colors, None));
-                }
-            },
+            }
         };
         strings.push(ANSIString::from(" ")); // TODO do not add this space to the end
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -452,6 +452,7 @@ mod tests {
             let output = name.render(
                 &Colors::new(color::Theme::NoColor),
                 &Icons::new(icon::Theme::NoIcon),
+                None,
             );
 
             assert_eq!(get_visible_width(&output), *l);
@@ -483,6 +484,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::Fancy),
+                    None,
                 )
                 .to_string();
 
@@ -514,6 +516,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoLscolors),
                     &Icons::new(icon::Theme::NoIcon),
+                    None,
                 )
                 .to_string();
 
@@ -549,6 +552,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::NoIcon),
+                    None,
                 )
                 .to_string();
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -297,11 +297,25 @@ fn get_long_output(
             )),
             Block::Date => strings.push(meta.date.render(colors, padding_rules.date, &flags)),
             Block::Name => strings.push(meta.name.render(colors, icons, Some(padding_rules.name))),
-            Block::NameWithSymlink => {
-                strings.push(meta.name.render(colors, icons, None));
-                strings.push(meta.indicator.render(&flags));
-                strings.push(meta.symlink.render(colors));
-            }
+            Block::NameWithSymlink => match meta.symlink.symlink_string() {
+                Some(_) => {
+                    strings.push(meta.name.render(colors, icons, None));
+                    strings.push(meta.indicator.render(&flags));
+                    strings.push(meta.symlink.render(
+                        colors,
+                        Some(padding_rules.name_with_symlink - meta.name.name_string(icons).len()),
+                    ));
+                }
+                None => {
+                    strings.push(meta.name.render(
+                        colors,
+                        icons,
+                        Some(padding_rules.name_with_symlink + 3),
+                    ));
+                    strings.push(meta.indicator.render(&flags));
+                    strings.push(meta.symlink.render(colors, None));
+                }
+            },
         };
         strings.push(ANSIString::from(" ")); // TODO do not add this space to the end
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -330,8 +330,10 @@ fn get_long_output(
                 }
             }
         };
-        strings.push(ANSIString::from(" ")); // TODO do not add this space to the end
+        strings.push(ANSIString::from(" "));
     }
+
+    strings.pop(); // remove the last space
 
     ANSIStrings(&strings).to_string()
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -174,8 +174,8 @@ impl<'a> From<&'a str> for Block {
             "group" => Block::Group,
             "size" => Block::Size,
             "date" => Block::Date,
-            "name" => Block::Name,
-            "namewithsymlink" => Block::NameWithSymlink,
+            "name" => Block::NameWithSymlink,
+            "namewithoutsymlink" => Block::Name,
             _ => panic!("invalid \"time\" flag: {}", block),
         }
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -156,24 +156,26 @@ impl Default for Flags {
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum Block {
-    // Type,
+    FileType,
     Permission,
     User,
     Group,
     Size,
     Date,
     Name,
+    NameWithSymlink,
 }
 impl<'a> From<&'a str> for Block {
     fn from(block: &'a str) -> Self {
         match block {
-            // "type" => Block::Type,
+            "filetype" => Block::FileType,
             "permission" => Block::Permission,
             "user" => Block::User,
             "group" => Block::Group,
             "size" => Block::Size,
             "date" => Block::Date,
             "name" => Block::Name,
+            "namewithsymlink" => Block::NameWithSymlink,
             _ => panic!("invalid \"time\" flag: {}", block),
         }
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -156,7 +156,7 @@ impl Default for Flags {
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
 pub enum Block {
-    FileType,
+    // FileType,
     Permission,
     User,
     Group,
@@ -168,7 +168,7 @@ pub enum Block {
 impl<'a> From<&'a str> for Block {
     fn from(block: &'a str) -> Self {
         match block {
-            "filetype" => Block::FileType,
+            // "filetype" => Block::FileType,
             "permission" => Block::Permission,
             "user" => Block::User,
             "group" => Block::Group,

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,6 +1,6 @@
 use clap::{ArgMatches, Error, ErrorKind};
 
-#[derive(Clone, Debug, Copy)]
+#[derive(Clone, Debug)]
 pub struct Flags {
     pub display: Display,
     pub layout: Layout,
@@ -15,6 +15,7 @@ pub struct Flags {
     pub icon: WhenFlag,
     pub icon_theme: IconTheme,
     pub recursion_depth: usize,
+    pub blocks: Vec<Block>,
 }
 
 impl Flags {
@@ -26,6 +27,7 @@ impl Flags {
         let size_inputs: Vec<&str> = matches.values_of("size").unwrap().collect();
         let date_inputs: Vec<&str> = matches.values_of("date").unwrap().collect();
         let dir_order_inputs: Vec<&str> = matches.values_of("group-dirs").unwrap().collect();
+        let blocks_inputs: Vec<&str> = matches.values_of("blocks").unwrap().collect();
 
         let display = if matches.is_present("all") {
             Display::DisplayAll
@@ -97,6 +99,7 @@ impl Flags {
             sort_by,
             sort_order,
             size: SizeFlag::from(size_inputs[size_inputs.len() - 1]),
+            blocks: blocks_inputs.into_iter().map(|b| Block::from(b)).collect(),
             // Take only the last value
             date: if classic_mode {
                 DateFlag::Date
@@ -139,6 +142,39 @@ impl Default for Flags {
             color: WhenFlag::Auto,
             icon: WhenFlag::Auto,
             icon_theme: IconTheme::Fancy,
+            blocks: vec![
+                Block::Permission,
+                Block::User,
+                Block::Group,
+                Block::Size,
+                Block::Date,
+                Block::Name,
+            ],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum Block {
+    // Type,
+    Permission,
+    User,
+    Group,
+    Size,
+    Date,
+    Name,
+}
+impl<'a> From<&'a str> for Block {
+    fn from(block: &'a str) -> Self {
+        match block {
+            // "type" => Block::Type,
+            "permission" => Block::Permission,
+            "user" => Block::User,
+            "group" => Block::Group,
+            "size" => Block::Size,
+            "date" => Block::Date,
+            "name" => Block::Name,
+            _ => panic!("invalid \"time\" flag: {}", block),
         }
     }
 }
@@ -189,7 +225,6 @@ pub enum WhenFlag {
     Auto,
     Never,
 }
-
 impl<'a> From<&'a str> for WhenFlag {
     fn from(when: &'a str) -> Self {
         match when {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -16,6 +16,7 @@ pub struct Flags {
     pub icon_theme: IconTheme,
     pub recursion_depth: usize,
     pub blocks: Vec<Block>,
+    pub no_symlink: bool,
 }
 
 impl Flags {
@@ -89,6 +90,7 @@ impl Flags {
             }
             None => usize::max_value(),
         };
+        let no_symlink = matches.is_present("no-symlink");
 
         Ok(Self {
             display,
@@ -122,6 +124,7 @@ impl Flags {
             } else {
                 DirOrderFlag::from(dir_order_inputs[dir_order_inputs.len() - 1])
             },
+            no_symlink,
         })
     }
 }
@@ -150,6 +153,7 @@ impl Default for Flags {
                 Block::Date,
                 Block::Name,
             ],
+            no_symlink: false,
         }
     }
 }
@@ -163,7 +167,6 @@ pub enum Block {
     Size,
     Date,
     Name,
-    NameWithSymlink,
 }
 impl<'a> From<&'a str> for Block {
     fn from(block: &'a str) -> Self {
@@ -174,8 +177,7 @@ impl<'a> From<&'a str> for Block {
             "group" => Block::Group,
             "size" => Block::Size,
             "date" => Block::Date,
-            "name" => Block::NameWithSymlink,
-            "namewithoutsymlink" => Block::Name,
+            "name" => Block::Name,
             _ => panic!("invalid \"time\" flag: {}", block),
         }
     }

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -25,7 +25,7 @@ impl<'a> From<&'a Metadata> for Date {
 }
 
 impl Date {
-    pub fn render(&self, colors: &Colors, date_alignment: usize, flags: Flags) -> ColoredString {
+    pub fn render(&self, colors: &Colors, date_alignment: usize, flags: &Flags) -> ColoredString {
         let mut content = String::with_capacity(date_alignment + 1);
         let now = time::now();
 
@@ -38,7 +38,7 @@ impl Date {
             elem = &Elem::Older;
         }
 
-        let date_string = &self.date_string(flags);
+        let date_string = &self.date_string(&flags);
         content += date_string;
 
         for _ in 0..(date_alignment - date_string.len()) {
@@ -47,7 +47,7 @@ impl Date {
         colors.colorize(content, elem)
     }
 
-    pub fn date_string(&self, flags: Flags) -> String {
+    pub fn date_string(&self, flags: &Flags) -> String {
         match flags.date {
             DateFlag::Date => self.0.ctime().to_string(),
             DateFlag::Relative => format!("{}", HumanTime::from(self.0 - time::now())),

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -119,7 +119,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(40).paint(creation_date.ctime().to_string()),
-            date.render(&colors, creation_date.ctime().to_string().len(), flags)
+            date.render(&colors, creation_date.ctime().to_string().len(), &flags)
         );
 
         fs::remove_file(file_path).unwrap();
@@ -143,7 +143,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(42).paint(creation_date.ctime().to_string()),
-            date.render(&colors, creation_date.ctime().to_string().len(), flags)
+            date.render(&colors, creation_date.ctime().to_string().len(), &flags)
         );
 
         fs::remove_file(file_path).unwrap();
@@ -167,7 +167,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(36).paint(creation_date.ctime().to_string()),
-            date.render(&colors, creation_date.ctime().to_string().len(), flags)
+            date.render(&colors, creation_date.ctime().to_string().len(), &flags)
         );
 
         fs::remove_file(file_path).unwrap();
@@ -193,7 +193,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(36).paint("2 days ago  "),
-            date.render(&colors, 12, flags)
+            date.render(&colors, 12, &flags)
         );
 
         fs::remove_file(file_path).unwrap();
@@ -229,7 +229,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(40).paint("now  "),
-            date.render(&colors, 5, flags)
+            date.render(&colors, 5, &flags)
         );
 
         fs::remove_file(file_path).unwrap();

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -22,7 +22,7 @@ impl From<FileType> for Indicator {
 }
 
 impl Indicator {
-    pub fn render(&self, flags: Flags) -> ColoredString {
+    pub fn render(&self, flags: &Flags) -> ColoredString {
         if flags.display_indicators {
             ANSIString::from(self.0)
         } else {

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -44,7 +44,7 @@ mod test {
 
         let file_type = Indicator::from(FileType::Directory { uid: false });
 
-        assert_eq!("/", file_type.render(flags).to_string().as_str());
+        assert_eq!("/", file_type.render(&flags).to_string().as_str());
     }
 
     #[test]
@@ -57,7 +57,7 @@ mod test {
             exec: true,
         });
 
-        assert_eq!("*", file_type.render(flags).to_string().as_str());
+        assert_eq!("*", file_type.render(&flags).to_string().as_str());
     }
 
     #[test]
@@ -67,7 +67,7 @@ mod test {
 
         let file_type = Indicator::from(FileType::Socket);
 
-        assert_eq!("=", file_type.render(flags).to_string().as_str());
+        assert_eq!("=", file_type.render(&flags).to_string().as_str());
     }
 
     #[test]
@@ -77,7 +77,7 @@ mod test {
 
         let file_type = Indicator::from(FileType::SymLink);
 
-        assert_eq!("@", file_type.render(flags).to_string().as_str());
+        assert_eq!("@", file_type.render(&flags).to_string().as_str());
     }
 
     #[test]
@@ -91,6 +91,6 @@ mod test {
             uid: false,
         });
 
-        assert_eq!("", file_type.render(flags).to_string().as_str());
+        assert_eq!("", file_type.render(&flags).to_string().as_str());
     }
 }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -47,13 +47,8 @@ impl Name {
         content
     }
 
-    pub fn render(&self, colors: &Colors, icons: &Icons, name_alignment: Option<usize>) -> ColoredString {
-        let mut content = self.name_string(&icons);
-        if let Some(na) = name_alignment {
-            for _ in 0..(na - content.len()) {
-                content.push(' ');
-            }
-        }
+    pub fn render(&self, colors: &Colors, icons: &Icons) -> ColoredString {
+        let content = self.name_string(&icons);
 
         let elem = match self.file_type {
             FileType::CharDevice => Elem::CharDevice,
@@ -136,7 +131,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint("  file.txt"),
-            name.render(&colors, &icons, None)
+            name.render(&colors, &icons)
         );
     }
 
@@ -154,7 +149,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(33).paint("  directory"),
-            meta.name.render(&colors, &icons, None)
+            meta.name.render(&colors, &icons)
         );
     }
 
@@ -181,7 +176,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(44).paint("  target.tmp"),
-            name.render(&colors, &icons, None)
+            name.render(&colors, &icons)
         );
     }
 
@@ -207,7 +202,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint("  pipe.tmp"),
-            name.render(&colors, &icons, None)
+            name.render(&colors, &icons)
         );
     }
 
@@ -226,7 +221,7 @@ mod test {
 
         assert_eq!(
             "file.txt",
-            meta.name.render(&colors, &icons, None).to_string().as_str()
+            meta.name.render(&colors, &icons).to_string().as_str()
         );
     }
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -136,7 +136,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint("  file.txt"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, None)
         );
     }
 
@@ -154,7 +154,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(33).paint("  directory"),
-            meta.name.render(&colors, &icons)
+            meta.name.render(&colors, &icons, None)
         );
     }
 
@@ -181,7 +181,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(44).paint("  target.tmp"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, None)
         );
     }
 
@@ -207,7 +207,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint("  pipe.tmp"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, None)
         );
     }
 
@@ -226,7 +226,7 @@ mod test {
 
         assert_eq!(
             "file.txt",
-            meta.name.render(&colors, &icons).to_string().as_str()
+            meta.name.render(&colors, &icons, None).to_string().as_str()
         );
     }
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -38,12 +38,22 @@ impl Name {
         }
     }
 
-    pub fn render(&self, colors: &Colors, icons: &Icons) -> ColoredString {
+    pub fn name_string(&self, icons: &Icons) -> String {
         let icon = icons.get(self);
         let mut content = String::with_capacity(icon.len() + self.name.len() + 3 /* spaces */);
 
         content += icon.as_str();
         content += &self.name;
+        content
+    }
+
+    pub fn render(&self, colors: &Colors, icons: &Icons, name_alignment: Option<usize>) -> ColoredString {
+        let mut content = self.name_string(&icons);
+        if let Some(na) = name_alignment {
+            for _ in 0..(na - content.len()) {
+                content.push(' ');
+            }
+        }
 
         let elem = match self.file_type {
             FileType::CharDevice => Elem::CharDevice,

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -69,12 +69,12 @@ impl Size {
         colors: &Colors,
         value_alignment: usize,
         unit_alignment: usize,
-        flags: Flags,
+        flags: &Flags,
     ) -> ColoredString {
         let mut content = String::with_capacity(value_alignment + unit_alignment + 1);
 
         let value = self.render_value();
-        let unit = self.render_unit(flags);
+        let unit = self.render_unit(&flags);
 
         for _ in 0..(value_alignment - value.len()) {
             content.push(' ');
@@ -84,7 +84,7 @@ impl Size {
         if flags.size != SizeFlag::Short {
             content.push(' ');
         }
-        content += &self.render_unit(flags);
+        content += &self.render_unit(&flags);
 
         for _ in 0..(unit_alignment - unit.len()) {
             content.push(' ');
@@ -128,7 +128,7 @@ impl Size {
         }
     }
 
-    pub fn render_unit(&self, flags: Flags) -> String {
+    pub fn render_unit(&self, flags: &Flags) -> String {
         match flags.size {
             SizeFlag::Default => match self.unit {
                 Unit::None => String::from("-"),

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -162,9 +162,9 @@ mod test {
 
         assert_eq!(size.render_value().as_str(), "42");
 
-        assert_eq!(size.render_unit(flags).as_str(), "B");
+        assert_eq!(size.render_unit(&flags).as_str(), "B");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.render_unit(flags).as_str(), "B");
+        assert_eq!(size.render_unit(&flags).as_str(), "B");
     }
 
     #[test]
@@ -173,9 +173,9 @@ mod test {
         let mut flags = Flags::default();
 
         assert_eq!(size.render_value().as_str(), "42");
-        assert_eq!(size.render_unit(flags).as_str(), "KB");
+        assert_eq!(size.render_unit(&flags).as_str(), "KB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.render_unit(flags).as_str(), "K");
+        assert_eq!(size.render_unit(&flags).as_str(), "K");
     }
 
     #[test]
@@ -184,9 +184,9 @@ mod test {
         let mut flags = Flags::default();
 
         assert_eq!(size.render_value().as_str(), "42");
-        assert_eq!(size.render_unit(flags).as_str(), "MB");
+        assert_eq!(size.render_unit(&flags).as_str(), "MB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.render_unit(flags).as_str(), "M");
+        assert_eq!(size.render_unit(&flags).as_str(), "M");
     }
 
     #[test]
@@ -195,9 +195,9 @@ mod test {
         let mut flags = Flags::default();
 
         assert_eq!(size.render_value().as_str(), "42");
-        assert_eq!(size.render_unit(flags).as_str(), "GB");
+        assert_eq!(size.render_unit(&flags).as_str(), "GB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.render_unit(flags).as_str(), "G");
+        assert_eq!(size.render_unit(&flags).as_str(), "G");
     }
 
     #[test]
@@ -206,9 +206,9 @@ mod test {
         let mut flags = Flags::default();
 
         assert_eq!(size.render_value().as_str(), "42");
-        assert_eq!(size.render_unit(flags).as_str(), "TB");
+        assert_eq!(size.render_unit(&flags).as_str(), "TB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.render_unit(flags).as_str(), "T");
+        assert_eq!(size.render_unit(&flags).as_str(), "T");
     }
 
     #[test]
@@ -217,7 +217,7 @@ mod test {
         let flags = Flags::default();
 
         assert_eq!(size.render_value().as_str(), "42.1");
-        assert_eq!(size.render_unit(flags).as_str(), "KB");
+        assert_eq!(size.render_unit(&flags).as_str(), "KB");
     }
 
     #[test]
@@ -226,6 +226,6 @@ mod test {
         let flags = Flags::default();
 
         assert_eq!(size.render_value().as_str(), "42");
-        assert_eq!(size.render_unit(flags).as_str(), "KB");
+        assert_eq!(size.render_unit(&flags).as_str(), "KB");
     }
 }

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -51,8 +51,14 @@ impl SymLink {
         }
     }
 
-    pub fn render(&self, colors: &Colors) -> ColoredString {
-        if let Some(target_string) = self.symlink_string() {
+    pub fn render(&self, colors: &Colors, symlink_alignment: Option<usize>) -> ColoredString {
+        if let Some(mut target_string) = self.symlink_string() {
+            if let Some(sa) = symlink_alignment {
+                for _ in 0..(sa - target_string.len()) {
+                    target_string.push(' ');
+                }
+            }
+
             let elem = if self.valid {
                 &Elem::SymLink
             } else {

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -51,14 +51,8 @@ impl SymLink {
         }
     }
 
-    pub fn render(&self, colors: &Colors, symlink_alignment: Option<usize>) -> ColoredString {
-        if let Some(mut target_string) = self.symlink_string() {
-            if let Some(sa) = symlink_alignment {
-                for _ in 0..(sa - target_string.len()) {
-                    target_string.push(' ');
-                }
-            }
-
+    pub fn render(&self, colors: &Colors) -> ColoredString {
+        if let Some(target_string) = self.symlink_string() {
             let elem = if self.valid {
                 &Elem::SymLink
             } else {

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -43,8 +43,16 @@ impl<'a> From<&'a Path> for SymLink {
 }
 
 impl SymLink {
-    pub fn render(&self, colors: &Colors) -> ColoredString {
+    pub fn symlink_string(&self) -> Option<String> {
         if let Some(ref target) = self.target {
+            Some(target.to_string())
+        } else {
+            None
+        }
+    }
+
+    pub fn render(&self, colors: &Colors) -> ColoredString {
+        if let Some(target_string) = self.symlink_string() {
             let elem = if self.valid {
                 &Elem::SymLink
             } else {
@@ -53,7 +61,7 @@ impl SymLink {
 
             let strings: &[ColoredString] = &[
                 ColoredString::from(" \u{21d2} "), // ⇒
-                colors.colorize(target.to_string(), elem),
+                colors.colorize(target_string, elem),
             ];
 
             let res = ANSIStrings(strings).to_string();

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -2,12 +2,12 @@ use crate::flags::{DirOrderFlag, Flags, SortFlag, SortOrder};
 use crate::meta::{FileType, Meta};
 use std::cmp::Ordering;
 
-pub fn by_meta(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+pub fn by_meta(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     match flags.sort_by {
         SortFlag::Name => match flags.directory_order {
-            DirOrderFlag::First => by_name_with_dirs_first(a, b, flags),
-            DirOrderFlag::None => by_name(a, b, flags),
-            DirOrderFlag::Last => by_name_with_files_first(a, b, flags),
+            DirOrderFlag::First => by_name_with_dirs_first(a, b, &flags),
+            DirOrderFlag::None => by_name(a, b, &flags),
+            DirOrderFlag::Last => by_name_with_files_first(a, b, &flags),
         },
         SortFlag::Size => match flags.directory_order {
             DirOrderFlag::First => by_size(a, b, flags),
@@ -15,14 +15,14 @@ pub fn by_meta(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
             DirOrderFlag::Last => by_size(a, b, flags),
         },
         SortFlag::Time => match flags.directory_order {
-            DirOrderFlag::First => by_date_with_dirs_first(a, b, flags),
-            DirOrderFlag::None => by_date(a, b, flags),
-            DirOrderFlag::Last => by_date_with_files_first(a, b, flags),
+            DirOrderFlag::First => by_date_with_dirs_first(a, b, &flags),
+            DirOrderFlag::None => by_date(a, b, &flags),
+            DirOrderFlag::Last => by_date_with_files_first(a, b, &flags),
         },
     }
 }
 
-fn by_size(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_size(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
 
     if flags.sort_order == SortOrder::Default {
         b.size.get_bytes().cmp(&a.size.get_bytes())
@@ -33,7 +33,7 @@ fn by_size(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
 
 
 
-fn by_name(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_name(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     if flags.sort_order == SortOrder::Default {
         a.name.cmp(&b.name)
     } else {
@@ -41,25 +41,25 @@ fn by_name(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
     }
 }
 
-fn by_name_with_dirs_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_name_with_dirs_first(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     match (a.file_type, b.file_type) {
-        (FileType::Directory { .. }, FileType::Directory { .. }) => by_name(a, b, flags),
+        (FileType::Directory { .. }, FileType::Directory { .. }) => by_name(a, b, &flags),
         (FileType::Directory { .. }, _) => Ordering::Less,
         (_, FileType::Directory { .. }) => Ordering::Greater,
-        _ => by_name(a, b, flags),
+        _ => by_name(a, b, &flags),
     }
 }
 
-fn by_name_with_files_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_name_with_files_first(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     match (a.file_type, b.file_type) {
-        (FileType::Directory { .. }, FileType::Directory { .. }) => by_name(a, b, flags),
+        (FileType::Directory { .. }, FileType::Directory { .. }) => by_name(a, b, &flags),
         (FileType::Directory { .. }, _) => Ordering::Greater,
         (_, FileType::Directory { .. }) => Ordering::Less,
-        _ => by_name(a, b, flags),
+        _ => by_name(a, b, &flags),
     }
 }
 
-fn by_date(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_date(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     if flags.sort_order == SortOrder::Default {
         b.date.cmp(&a.date).then(a.name.cmp(&b.name))
     } else {
@@ -67,21 +67,21 @@ fn by_date(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
     }
 }
 
-fn by_date_with_dirs_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_date_with_dirs_first(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     match (a.file_type, b.file_type) {
-        (FileType::Directory { .. }, FileType::Directory { .. }) => by_date(a, b, flags),
+        (FileType::Directory { .. }, FileType::Directory { .. }) => by_date(a, b, &flags),
         (FileType::Directory { .. }, _) => Ordering::Less,
         (_, FileType::Directory { .. }) => Ordering::Greater,
-        _ => by_date(a, b, flags),
+        _ => by_date(a, b, &flags),
     }
 }
 
-fn by_date_with_files_first(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
+fn by_date_with_files_first(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
     match (a.file_type, b.file_type) {
-        (FileType::Directory { .. }, FileType::Directory { .. }) => by_date(a, b, flags),
+        (FileType::Directory { .. }, FileType::Directory { .. }) => by_date(a, b, &flags),
         (FileType::Directory { .. }, _) => Ordering::Greater,
         (_, FileType::Directory { .. }) => Ordering::Less,
-        _ => by_date(a, b, flags),
+        _ => by_date(a, b, &flags),
     }
 }
 
@@ -111,11 +111,11 @@ mod tests {
         flags.directory_order = DirOrderFlag::First;
 
         //  Sort with the dirs first
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Greater);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Greater);
 
         //  Sort with the dirs first (the dirs stay first)
         flags.sort_order = SortOrder::Reverse;
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Greater);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Greater);
     }
 
     #[test]
@@ -136,10 +136,10 @@ mod tests {
         flags.directory_order = DirOrderFlag::Last;
 
         // Sort with file first
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Less);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Less);
 
         // Sort with file first reversed (thie files stay first)
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Less);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Less);
     }
 
     #[test]
@@ -160,11 +160,11 @@ mod tests {
         flags.directory_order = DirOrderFlag::None;
 
         // Sort by name unordered
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Less);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Less);
 
         // Sort by name unordered
         flags.sort_order = SortOrder::Reverse;
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Greater);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Greater);
     }
 
     #[test]
@@ -185,11 +185,11 @@ mod tests {
         flags.directory_order = DirOrderFlag::None;
 
         // Sort by name unordered
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Greater);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Greater);
 
         // Sort by name unordered reversed
         flags.sort_order = SortOrder::Reverse;
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Less);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Less);
     }
 
     #[test]
@@ -231,10 +231,10 @@ mod tests {
         flags.sort_by = SortFlag::Time;
 
         // Sort by time
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Less);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Less);
 
         // Sort by time reversed
         flags.sort_order = SortOrder::Reverse;
-        assert_eq!(by_meta(&meta_a, &meta_z, flags), Ordering::Greater);
+        assert_eq!(by_meta(&meta_a, &meta_z, &flags), Ordering::Greater);
     }
 }


### PR DESCRIPTION
Closes #96 

Changes:
- Removed `Clone` derive on `Flags` struct 

TODO:

- [x] fix spacing of name
![](https://i.imgur.com/0oFfZnQ.png)
-  [ ] figure out a way to make second block argument override the the first one
`lsd -l --blocks name --blocks user,date` should be equal to `lsd -l --blocks user,date`. Currently it will result in `lsd -l --blocks name,user,date`. This helps to have a default in the `ls` alias.

Doubts:

- [x] seperately show `symlink` (indicator + symlink)? what to call it?


### Possible future addition

Add alignment direction. `:name` will left align. `name:` will right align. `:name:` will center align.
I took the idea from markdown table formatting.
