### PR TITLE
Make the --tree flag respect the --group-dirs value

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -1,12 +1,8 @@
-use crate::flags::{DirOrderFlag, Flags, Layout, SortFlag, SortOrder};
+use crate::flags::{DirOrderFlag, Flags, SortFlag, SortOrder};
 use crate::meta::{FileType, Meta};
 use std::cmp::Ordering;
 
 pub fn by_meta(a: &Meta, b: &Meta, flags: Flags) -> Ordering {
-    if flags.layout == Layout::Tree {
-        return by_name_with_files_first(a, b, flags);
-    }
-
     match flags.sort_by {
         SortFlag::Name => match flags.directory_order {
             DirOrderFlag::First => by_name_with_dirs_first(a, b, flags),


### PR DESCRIPTION
Fix #158 

The fix is a bit weird though... It seems that this was a special case added on 0fa68098e2af46420a549f4a5d092dc882d1ecc3

I did some small tests and everything appears to be working though. Maybe this was just an oversight?