### PR TITLE
Fix windows color and CLI wildcard issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ time = "0.1.40"
 chrono-humanize = "0.0.11"
 unicode-width = "0.1.5"
 lscolors = "0.5.0"
+wild = "2.0.1"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.9.0"

--- a/src/core.rs
+++ b/src/core.rs
@@ -20,9 +20,15 @@ impl Core {
         // terminal_size allows us to know if the stdout is a tty or not.
         let tty_available = terminal_size().is_some();
 
+        // determine color output availability (and initialize color output (for Windows 10))
+        #[cfg(not(target_os = "windows"))]
+        let console_color_ok = true;
+        #[cfg(target_os = "windows")]
+        let console_color_ok = ansi_term::enable_ansi_support().is_ok();
+
         let mut inner_flags = flags;
 
-        let color_theme = match (tty_available, flags.color) {
+        let color_theme = match (tty_available && console_color_ok, flags.color) {
             (_, WhenFlag::Never) | (false, WhenFlag::Auto) => color::Theme::NoColor,
             _ => color::Theme::Default,
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ extern crate term_grid;
 extern crate terminal_size;
 extern crate time;
 extern crate unicode_width;
+extern crate wild;
 
 #[cfg(unix)]
 extern crate users;
@@ -38,7 +39,7 @@ use crate::flags::Flags;
 use std::path::PathBuf;
 
 fn main() {
-    let matches = app::build().get_matches();
+    let matches = app::build().get_matches_from(wild::args_os());
 
     let inputs = matches
         .values_of("FILE")


### PR DESCRIPTION
These set of commits make minor changes which fix two small Windows issues, color display and *portable* wildcard support.

I hope this is useful and let me know if the PR needs any polishing.