### PR TITLE
Add -d/--directory-only option.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -103,6 +103,15 @@ pub fn build() -> App<'static, 'static> {
                 .help("Stop recursing into directories after reaching specified depth"),
         )
         .arg(
+            Arg::with_name("directory_only")
+                .short("d")
+                .long("directory-only")
+                .conflicts_with("recursive")
+                .conflicts_with("tree")
+                .conflicts_with("depth")
+                .help("Display directories themselves, and not their contents"),
+        )
+        .arg(
             Arg::with_name("size")
                 .long("size")
                 .possible_value("default")

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,12 +103,14 @@ pub fn build() -> App<'static, 'static> {
                 .help("Stop recursing into directories after reaching specified depth"),
         )
         .arg(
-            Arg::with_name("directory_only")
+            Arg::with_name("directory-only")
                 .short("d")
                 .long("directory-only")
+                .conflicts_with("all")
+                .conflicts_with("almost-all")
+                .conflicts_with("depth")
                 .conflicts_with("recursive")
                 .conflicts_with("tree")
-                .conflicts_with("depth")
                 .help("Display directories themselves, and not their contents"),
         )
         .arg(

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,6 @@
 use crate::color::{self, Colors};
 use crate::display;
-use crate::flags::{Flags, IconTheme, Layout, WhenFlag};
+use crate::flags::{Display, Flags, IconTheme, Layout, WhenFlag};
 use crate::icon::{self, Icons};
 use crate::meta::Meta;
 use crate::sort;
@@ -75,15 +75,28 @@ impl Core {
                 }
             };
 
-            match Meta::from_path(&absolute_path) {
-                Ok(meta) => meta_list.push(meta),
-                Err(err) => eprintln!("cannot access '{}': {}", path.display(), err),
+            let meta = match Meta::from_path(&absolute_path) {
+                Ok(meta) => meta,
+                Err(err) => {
+                    eprintln!("cannot access '{}': {}", path.display(), err);
+                    continue;
+                }
             };
 
-            match Meta::from_path_recursive(&absolute_path, depth, self.flags.display) {
-                Ok(Some(content)) => meta_list.extend(content),
-                Ok(None) => (),
-                Err(err) => println!("cannot access '{}': {}", path.display(), err),
+            match self.flags.display {
+                Display::DisplayDirectoryItself => {
+                    meta_list.push(meta);
+                }
+                _ => {
+                    match meta.recurse_into(depth, self.flags.display) {
+                        Ok(Some(content)) => meta_list.extend(content),
+                        Ok(None) => (),
+                        Err(err) => {
+                            eprintln!("cannot access '{}': {}", path.display(), err);
+                            continue;
+                        }
+                    };
+                }
             };
         }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -68,20 +68,22 @@ impl Core {
 
         for path in paths {
             let absolute_path = match fs::canonicalize(&path) {
-                Ok(path) => path,
+                Ok(path) => path.to_path_buf(),
                 Err(err) => {
                     eprintln!("cannot access '{}': {}", path.display(), err);
                     continue;
                 }
             };
 
-            match Meta::from_path_recursive(
-                &fs::canonicalize(&absolute_path.to_path_buf()).unwrap(),
-                depth,
-                self.flags.display,
-            ) {
+            match Meta::from_path(&absolute_path) {
                 Ok(meta) => meta_list.push(meta),
                 Err(err) => eprintln!("cannot access '{}': {}", path.display(), err),
+            };
+
+            match Meta::from_path_recursive(&absolute_path, depth, self.flags.display) {
+                Ok(Some(content)) => meta_list.extend(content),
+                Ok(None) => (),
+                Err(err) => println!("cannot access '{}': {}", path.display(), err),
             };
         }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -60,13 +60,6 @@ fn inner_display_one_line(
 
     // print the files first.
     for meta in &metas {
-        // The first iteration (depth == 0) correspond to the inputs given by
-        // the user. If the user enter a folder name it should not print the
-        // folder meta but its content.
-        if let (0, FileType::Directory { .. }) = (depth, meta.file_type) {
-            continue;
-        }
-
         if let Layout::OneLine { long: true } = flags.layout {
             output += &get_long_output(&meta, &colors, &icons, flags, padding_rules.unwrap());
         } else {
@@ -110,13 +103,6 @@ fn inner_display_grid(
 
     // print the files first.
     for meta in &metas {
-        // The first iteration (depth == 0) correspond to the inputs given by
-        // the user. If the user enter a folder name it should not print the
-        // folder meta but its content.
-        if let (0, FileType::Directory { .. }) = (depth, meta.file_type) {
-            continue;
-        }
-
         let line_output = get_short_output(&meta, &colors, &icons, flags);
         grid.add(Cell {
             width: get_visible_width(&line_output),

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -9,6 +9,7 @@ pub struct Flags {
     pub sort_by: SortFlag,
     pub sort_order: SortOrder,
     pub directory_order: DirOrderFlag,
+    pub directory_display: DirDisplay,
     pub size: SizeFlag,
     pub date: DateFlag,
     pub color: WhenFlag,
@@ -33,6 +34,11 @@ impl Flags {
             Display::DisplayAlmostAll
         } else {
             Display::DisplayOnlyVisible
+        };
+        let dir_display = if matches.is_present("directory-only") {
+            DirDisplay::DirectoryItself
+        } else {
+            DirDisplay::DirectoryContents
         };
 
         let sort_by = if matches.is_present("timesort") {
@@ -105,6 +111,7 @@ impl Flags {
             } else {
                 DirOrderFlag::from(dir_order_inputs[dir_order_inputs.len() - 1])
             },
+            directory_display: dir_display,
         })
     }
 }
@@ -120,6 +127,7 @@ impl Default for Flags {
             sort_by: SortFlag::Name,
             sort_order: SortOrder::Default,
             directory_order: DirOrderFlag::None,
+            directory_display: DirDisplay::DirectoryContents,
             size: SizeFlag::Default,
             date: DateFlag::Date,
             color: WhenFlag::Auto,
@@ -214,6 +222,12 @@ impl<'a> From<&'a str> for DirOrderFlag {
             _ => panic!("invalid \"when\" flag: {}", when),
         }
     }
+}
+
+#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+pub enum DirDisplay {
+    DirectoryContents,
+    DirectoryItself,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -9,7 +9,6 @@ pub struct Flags {
     pub sort_by: SortFlag,
     pub sort_order: SortOrder,
     pub directory_order: DirOrderFlag,
-    pub directory_display: DirDisplay,
     pub size: SizeFlag,
     pub date: DateFlag,
     pub color: WhenFlag,
@@ -32,13 +31,10 @@ impl Flags {
             Display::DisplayAll
         } else if matches.is_present("almost-all") {
             Display::DisplayAlmostAll
+        } else if matches.is_present("directory-only") {
+            Display::DisplayDirectoryItself
         } else {
             Display::DisplayOnlyVisible
-        };
-        let dir_display = if matches.is_present("directory-only") {
-            DirDisplay::DirectoryItself
-        } else {
-            DirDisplay::DirectoryContents
         };
 
         let sort_by = if matches.is_present("timesort") {
@@ -111,7 +107,6 @@ impl Flags {
             } else {
                 DirOrderFlag::from(dir_order_inputs[dir_order_inputs.len() - 1])
             },
-            directory_display: dir_display,
         })
     }
 }
@@ -127,7 +122,6 @@ impl Default for Flags {
             sort_by: SortFlag::Name,
             sort_order: SortOrder::Default,
             directory_order: DirOrderFlag::None,
-            directory_display: DirDisplay::DirectoryContents,
             size: SizeFlag::Default,
             date: DateFlag::Date,
             color: WhenFlag::Auto,
@@ -141,6 +135,7 @@ impl Default for Flags {
 pub enum Display {
     DisplayAll,
     DisplayAlmostAll,
+    DisplayDirectoryItself,
     DisplayOnlyVisible,
 }
 
@@ -222,12 +217,6 @@ impl<'a> From<&'a str> for DirOrderFlag {
             _ => panic!("invalid \"when\" flag: {}", when),
         }
     }
-}
-
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
-pub enum DirDisplay {
-    DirectoryContents,
-    DirectoryItself,
 }
 
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -5,7 +5,7 @@ use std::fs::Metadata;
 use std::time::UNIX_EPOCH;
 use time::{Duration, Timespec};
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Date(time::Tm);
 
 impl<'a> From<&'a Metadata> for Date {

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -3,7 +3,7 @@ use crate::flags::Flags;
 use crate::meta::FileType;
 use ansi_term::ANSIString;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Indicator(&'static str);
 
 impl From<FileType> for Indicator {

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -25,7 +25,7 @@ use std::fs::read_link;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Meta {
     pub name: Name,
     pub path: PathBuf,

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -58,11 +58,13 @@ impl Meta {
             _ => return Ok(None),
         }
 
-        // TODO: Don't read_dir twice; see later.
-        if let Err(err) = self.path.read_dir() {
-            eprintln!("cannot access '{}': {}", self.path.display(), err);
-            return Ok(None);
-        }
+        let entries = match self.path.read_dir() {
+            Ok(entries) => entries,
+            Err(err) => {
+                eprintln!("cannot access '{}': {}", self.path.display(), err);
+                return Ok(None);
+            }
+        };
 
         let mut content: Vec<Meta> = Vec::new();
 
@@ -85,7 +87,7 @@ impl Meta {
             content.push(parent_meta);
         }
 
-        for entry in self.path.read_dir()? {
+        for entry in entries {
             let path = entry?.path();
 
             if let Display::DisplayOnlyVisible = display {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -4,7 +4,7 @@ use crate::meta::filetype::FileType;
 use std::cmp::{Ordering, PartialOrd};
 use std::path::Path;
 
-#[derive(Debug, Eq)]
+#[derive(Clone, Debug, Eq)]
 pub struct Name {
     pub name: String,
     path: String,

--- a/src/meta/owner.rs
+++ b/src/meta/owner.rs
@@ -2,7 +2,7 @@ use crate::color::{ColoredString, Colors, Elem};
 #[cfg(unix)]
 use std::fs::Metadata;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Owner {
     user: String,
     group: String,

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -2,7 +2,7 @@ use crate::color::{ColoredString, Colors, Elem};
 use crate::flags::{Flags, SizeFlag};
 use std::fs::Metadata;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Unit {
     None,
     Byte,
@@ -12,7 +12,7 @@ pub enum Unit {
     Tera,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Size {
     value: u64,
     unit: Unit,

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -3,7 +3,7 @@ use ansi_term::{ANSIString, ANSIStrings};
 use std::fs::read_link;
 use std::path::Path;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SymLink {
     target: Option<String>,
     valid: bool,


### PR DESCRIPTION
Fixes #190, and:
- Moves the decision about which _metas_ to display out of the `display` module.
- Re-uses or clones `Meta` structs when possible instead of using `Meta::from_path` which incurs a system call or two.
- Avoids calling `read_dir()` twice for the same path.
