### PR TITLE
Print errors to stderr

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -70,7 +70,7 @@ impl Core {
             let absolute_path = match fs::canonicalize(&path) {
                 Ok(path) => path,
                 Err(err) => {
-                    println!("couldn't access '{}': {}", path.display(), err);
+                    eprintln!("cannot access '{}': {}", path.display(), err);
                     continue;
                 }
             };
@@ -81,7 +81,7 @@ impl Core {
                 self.flags.display,
             ) {
                 Ok(meta) => meta_list.push(meta),
-                Err(err) => println!("cannot access '{}': {}", path.display(), err),
+                Err(err) => eprintln!("cannot access '{}': {}", path.display(), err),
             };
         }
 

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -57,7 +57,7 @@ impl Meta {
         }
 
         if let Err(err) = meta.path.read_dir() {
-            println!("cannot access '{}': {}", path.display(), err);
+            eprintln!("cannot access '{}': {}", path.display(), err);
             return Ok(meta);
         }
         let mut content = Vec::new();
@@ -99,7 +99,7 @@ impl Meta {
                 match Self::from_path_recursive(&path.to_path_buf(), depth - 1, display) {
                     Ok(res) => res,
                     Err(err) => {
-                        println!("cannot access '{}': {}", path.display(), err);
+                        eprintln!("cannot access '{}': {}", path.display(), err);
                         continue;
                     }
                 };


### PR DESCRIPTION
First of all, thanks for the project, I have been using it for some time now and absolutely love it!

Since the original `ls` sends errors to stderr I thought it might be a good idea to have the same behavior here.