### PR TITLE
Fixes `Cargo.lock` icon

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -123,6 +123,7 @@ impl Icons {
         m.insert("npmignore", "\u{e71e}"); // ""
         m.insert("rubydoc", "\u{e73b}"); // ""
         m.insert("yarn.lock", "\u{e718}"); // ""
+        m.insert("Cargo.lock", "\u{e7a8}"); // ""
 
         m
     }


### PR DESCRIPTION
Cargo.lock currently has no special case so it renders with the default `.lock` extension icon (Ruby).  This PR follows the perceived pattern of the `yarn.lock` and adds a special case for `Cargo.lock`