### PR TITLE
Fix Gentoo installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ sudo dpkg -i lsd_7.2.0_amd64.deb  # adapt version number and architecture
 ```
 
 ### On Gentoo
-
-Package available on [package.gentoo.org](https://packages.gentoo.org/packages/sys-apps/lsd) (maintained by Georgy Yakovlev)
+```sh
+sudo emerge sys-apps/lsd
+```
+(Ebuild maintained by Georgy Yakovlev)
 
 ### From Snap
 


### PR DESCRIPTION
This makes it more in line with the instructions for other distros.