### PR TITLE
Fix listing of user-given arguments.

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -80,7 +80,7 @@ impl Core {
                 }
             };
 
-            let meta = match Meta::from_path(&absolute_path) {
+            let mut meta = match Meta::from_path(&absolute_path) {
                 Ok(meta) => meta,
                 Err(err) => {
                     eprintln!("cannot access '{}': {}", path.display(), err);
@@ -94,8 +94,10 @@ impl Core {
                 }
                 _ => {
                     match meta.recurse_into(depth, self.flags.display) {
-                        Ok(Some(content)) => meta_list.extend(content),
-                        Ok(None) => (),
+                        Ok(content) => {
+                            meta.content = content;
+                            meta_list.push(meta);
+                        }
                         Err(err) => {
                             eprintln!("cannot access '{}': {}", path.display(), err);
                             continue;

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use crate::color::Colors;
-use crate::flags::{Flags, Layout};
+use crate::flags::{Display, Flags, Layout};
 use crate::icon::Icons;
 use crate::meta::{FileType, Meta};
 use ansi_term::{ANSIString, ANSIStrings};
@@ -58,8 +58,18 @@ fn inner_display_one_line(
         })
     }
 
+    // The first iteration (depth == 0) corresponds to the inputs given by the
+    // user. We defer displaying directories given by the user unless we've been
+    // asked to display the directory itself (rather than its contents).
+    let skip_dirs = (depth == 0) && (flags.display != Display::DisplayDirectoryItself);
+
     // print the files first.
     for meta in &metas {
+        // Maybe skip showing the directory meta now; show its contents later.
+        if let (true, FileType::Directory { .. }) = (skip_dirs, meta.file_type) {
+            continue;
+        }
+
         if let Layout::OneLine { long: true } = flags.layout {
             output += &get_long_output(&meta, &colors, &icons, flags, padding_rules.unwrap());
         } else {
@@ -101,8 +111,18 @@ fn inner_display_grid(
         direction: Direction::TopToBottom,
     });
 
+    // The first iteration (depth == 0) corresponds to the inputs given by the
+    // user. We defer displaying directories given by the user unless we've been
+    // asked to display the directory itself (rather than its contents).
+    let skip_dirs = (depth == 0) && (flags.display != Display::DisplayDirectoryItself);
+
     // print the files first.
     for meta in &metas {
+        // Maybe skip showing the directory meta now; show its contents later.
+        if let (true, FileType::Directory { .. }) = (skip_dirs, meta.file_type) {
+            continue;
+        }
+
         let line_output = get_short_output(&meta, &colors, &icons, flags);
         grid.add(Cell {
             width: get_visible_width(&line_output),


### PR DESCRIPTION
Fixes #220.

I misunderstood the purpose of some of the display code and removed it in 96c7a9908103f1d5def1cf1022bd841606acaf8b. I've brought it back here with some adjustments to account for `Display::DisplayDirectoryOnly`.

I'm sorry for that mistake. This PR is a quick fix. I hope I'm not introducing any other bugs. The most useful thing I can do next is introduce more tests to prevent similar regressions in future.