### PR TITLE
Show total size of directories and a new flag for displaying the size (bytes)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -125,6 +125,12 @@ pub fn build() -> App<'static, 'static> {
                 .help("How to display size"),
         )
         .arg(
+            Arg::with_name("total-size")
+                .long("total-size")
+                .multiple(true)
+                .help("Display the total size of directories"),
+        )
+        .arg(
             Arg::with_name("date")
                 .long("date")
                 .possible_value("date")

--- a/src/app.rs
+++ b/src/app.rs
@@ -118,6 +118,7 @@ pub fn build() -> App<'static, 'static> {
                 .long("size")
                 .possible_value("default")
                 .possible_value("short")
+                .possible_value("bytes")
                 .default_value("default")
                 .multiple(true)
                 .number_of_values(1)

--- a/src/core.rs
+++ b/src/core.rs
@@ -105,6 +105,11 @@ impl Core {
                 }
             };
         }
+        if self.flags.total_size {
+            for meta in &mut meta_list.iter_mut() {
+                meta.calculate_total_size();
+            }
+        }
 
         meta_list
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,7 +1,7 @@
 use crate::color::Colors;
 use crate::flags::{Block, Display, Flags, Layout};
 use crate::icon::Icons;
-use crate::meta::{FileType, Meta};
+use crate::meta::{FileType, Meta, Size};
 use ansi_term::{ANSIString, ANSIStrings};
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
 use terminal_size::terminal_size;
@@ -400,12 +400,16 @@ fn detect_size_lengths(metas: &[Meta], flags: &Flags) -> (usize, usize) {
     let mut max_unit_size: usize = 0;
 
     for meta in metas {
-        if meta.size.render_value().len() > max_value_length {
-            max_value_length = meta.size.render_value().len();
+        let unit = meta.size.get_unit(flags);
+        let value_len = meta.size.render_value(&unit).len();
+        let unit_len = Size::render_unit(&unit, &flags).len();
+        
+        if value_len > max_value_length {
+            max_value_length = value_len;
         }
 
-        if meta.size.render_unit(&flags).len() > max_unit_size {
-            max_unit_size = meta.size.render_unit(&flags).len();
+        if unit_len > max_unit_size {
+            max_unit_size = unit_len;
         }
     }
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -17,6 +17,7 @@ pub struct Flags {
     pub recursion_depth: usize,
     pub blocks: Vec<Block>,
     pub no_symlink: bool,
+    pub total_size: bool,
 }
 
 impl Flags {
@@ -91,6 +92,7 @@ impl Flags {
             None => usize::max_value(),
         };
         let no_symlink = matches.is_present("no-symlink");
+        let total_size = matches.is_present("total-size");
 
         Ok(Self {
             display,
@@ -125,6 +127,7 @@ impl Flags {
                 DirOrderFlag::from(dir_order_inputs[dir_order_inputs.len() - 1])
             },
             no_symlink,
+            total_size,
         })
     }
 }
@@ -154,6 +157,7 @@ impl Default for Flags {
                 Block::Name,
             ],
             no_symlink: false,
+            total_size: false,
         }
     }
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -195,6 +195,7 @@ pub enum Display {
 pub enum SizeFlag {
     Default,
     Short,
+    Bytes,
 }
 
 impl<'a> From<&'a str> for SizeFlag {
@@ -202,6 +203,7 @@ impl<'a> From<&'a str> for SizeFlag {
         match size {
             "default" => SizeFlag::Default,
             "short" => SizeFlag::Short,
+            "bytes" => SizeFlag::Bytes,
             _ => panic!("invalid \"size\" flag: {}", size),
         }
     }

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -132,7 +132,7 @@ mod test {
 
     #[test]
     fn render_byte() {
-        let size = Size { bytes: 42 }; // == 42 bytes
+        let size = Size::new(42); // == 42 bytes
         let mut flags = Flags::default();
         let unit = size.get_unit(&flags);
 
@@ -147,7 +147,7 @@ mod test {
 
     #[test]
     fn render_kilobyte() {
-        let size = Size { bytes: 42 * 1024 }; // 42 kilobytes
+        let size = Size::new(42 * 1024); // 42 kilobytes
         let mut flags = Flags::default();
         let unit = size.get_unit(&flags);
 
@@ -159,7 +159,7 @@ mod test {
 
     #[test]
     fn render_megabyte() {
-        let size = Size { bytes: 42 * 1024 * 1024 }; // 42 megabytes
+        let size = Size::new(42 * 1024 * 1024); // 42 megabytes
         let mut flags = Flags::default();
         let unit = size.get_unit(&flags);
 
@@ -171,7 +171,7 @@ mod test {
 
     #[test]
     fn render_gigabyte() {
-        let size = Size { bytes: 42 * 1024 * 1024 * 1024 }; // 42 gigabytes
+        let size = Size::new(42 * 1024 * 1024 * 1024); // 42 gigabytes
         let mut flags = Flags::default();
         let unit = size.get_unit(&flags);
 
@@ -183,7 +183,7 @@ mod test {
 
     #[test]
     fn render_terabyte() {
-        let size = Size { bytes: 42 * 1024 * 1024 * 1024 * 1024 }; // 42 terabytes
+        let size = Size::new(42 * 1024 * 1024 * 1024 * 1024); // 42 terabytes
         let mut flags = Flags::default();
         let unit = size.get_unit(&flags);
 
@@ -195,7 +195,7 @@ mod test {
 
     #[test]
     fn render_with_a_fraction() {
-        let size = Size { bytes: 42 * 1024 + 103 }; // 42.1 kilobytes
+        let size = Size::new(42 * 1024 + 103); // 42.1 kilobytes
         let flags = Flags::default();
         let unit = size.get_unit(&flags);
 
@@ -205,7 +205,7 @@ mod test {
 
     #[test]
     fn render_with_a_truncated_fraction() {
-        let size = Size { bytes: 42 * 1024 + 1 }; // 42.001 kilobytes == 42 kilobytes
+        let size = Size::new(42 * 1024 + 1); // 42.001 kilobytes == 42 kilobytes
         let flags = Flags::default();
         let unit = size.get_unit(&flags);
 

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -25,6 +25,10 @@ impl<'a> From<&'a Metadata> for Size {
 }
 
 impl Size {
+    pub fn new(bytes: u64) -> Self {
+        Self { bytes: bytes }
+    }
+
     pub fn get_bytes(&self) -> u64 {
         self.bytes
     }


### PR DESCRIPTION
This partially implements #180 (the `du`-like feature)
It provides a new `--total-size` flag that shows the total size of directories and its contents (recursively) and a new option `bytes` for `--size` which acts similar to the default `ls` size display.

At first I thought it might be necessary to refactor 'Size' to implement this feature. In hindsight it isn't necessary anymore, but I think it's cleaner (and probably faster) now anyway (especially 'render_value').
Any further suggestions like a short flag for `--total-size`?