### PR TITLE
fix name padding to include indicator's length

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use crate::color::Colors;
-use crate::flags::{Display, Flags, Layout, Block};
+use crate::flags::{Block, Display, Flags, Layout};
 use crate::icon::Icons;
 use crate::meta::{FileType, Meta};
 use ansi_term::{ANSIString, ANSIStrings};
@@ -314,6 +314,7 @@ fn get_long_output(
                             strings.push(ANSIString::from(" ".to_string().repeat(
                                 padding_rules.name_with_symlink
                                     - meta.name.name_string(icons).len()
+                                    - meta.indicator.len()
                                     - s.len(),
                             )))
                         }
@@ -323,7 +324,8 @@ fn get_long_output(
                             strings.push(meta.symlink.render(colors));
                             strings.push(ANSIString::from(" ".to_string().repeat(
                                 padding_rules.name_with_symlink + 3
-                                    - meta.name.name_string(icons).len(),
+                                    - meta.name.name_string(icons).len()
+                                    - meta.indicator.len(),
                             )))
                         }
                     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -314,7 +314,7 @@ fn get_long_output(
                             strings.push(ANSIString::from(" ".to_string().repeat(
                                 padding_rules.name_with_symlink
                                     - meta.name.name_string(icons).len()
-                                    - meta.indicator.len()
+                                    - meta.indicator.len(&flags)
                                     - s.len(),
                             )))
                         }
@@ -325,7 +325,7 @@ fn get_long_output(
                             strings.push(ANSIString::from(" ".to_string().repeat(
                                 padding_rules.name_with_symlink + 3
                                     - meta.name.name_string(icons).len()
-                                    - meta.indicator.len(),
+                                    - meta.indicator.len(&flags),
                             )))
                         }
                     }

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -30,8 +30,12 @@ impl Indicator {
         }
     }
 
-    pub fn len(&self) -> usize {
-        self.0.len()
+    pub fn len(&self, flags: &Flags) -> usize {
+        if flags.display_indicators {
+            self.0.len()
+        } else {
+            0
+        }
     }
 }
 

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -29,6 +29,10 @@ impl Indicator {
             ANSIString::from("")
         }
     }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Before:
<img width="440" alt="Screen Shot 2019-06-17 at 12 11 51" src="https://user-images.githubusercontent.com/2485647/59576062-2a278400-90f9-11e9-8c2f-f22ff5573a38.png">

After:
<img width="442" alt="Screen Shot 2019-06-17 at 12 12 05" src="https://user-images.githubusercontent.com/2485647/59576075-357aaf80-90f9-11e9-8f89-07945e14589e.png">
