### PR TITLE
Take into account the DirOrderFlag when doing size sorting

### DIFF
--- a/src/sort.rs
+++ b/src/sort.rs
@@ -10,9 +10,9 @@ pub fn by_meta(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
             DirOrderFlag::Last => by_name_with_files_first(a, b, &flags),
         },
         SortFlag::Size => match flags.directory_order {
-            DirOrderFlag::First => by_size(a, b, flags),
-            DirOrderFlag::None => by_size(a, b, flags),
-            DirOrderFlag::Last => by_size(a, b, flags),
+            DirOrderFlag::First => by_size_with_dirs_first(a, b, &flags),
+            DirOrderFlag::None => by_size(a, b, &flags),
+            DirOrderFlag::Last => by_size_with_files_first(a, b, &flags),
         },
         SortFlag::Time => match flags.directory_order {
             DirOrderFlag::First => by_date_with_dirs_first(a, b, &flags),
@@ -27,6 +27,24 @@ fn by_size(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
         b.size.get_bytes().cmp(&a.size.get_bytes())
     } else {
         a.size.get_bytes().cmp(&b.size.get_bytes())
+    }
+}
+
+fn by_size_with_dirs_first(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
+    match (a.file_type, b.file_type) {
+        (FileType::Directory { .. }, FileType::Directory { .. }) => by_size(a, b, &flags),
+        (FileType::Directory { .. }, _) => Ordering::Less,
+        (_, FileType::Directory { .. }) => Ordering::Greater,
+        _ => by_size(a, b, &flags),
+    }
+}
+
+fn by_size_with_files_first(a: &Meta, b: &Meta, flags: &Flags) -> Ordering {
+    match (a.file_type, b.file_type) {
+        (FileType::Directory { .. }, FileType::Directory { .. }) => by_size(a, b, &flags),
+        (FileType::Directory { .. }, _) => Ordering::Greater,
+        (_, FileType::Directory { .. }) => Ordering::Less,
+        _ => by_size(a, b, &flags),
     }
 }
 


### PR DESCRIPTION
related to https://github.com/Peltoche/lsd/pull/166

<img width="611" alt="Screen Shot 2019-06-20 at 17 35 02" src="https://user-images.githubusercontent.com/2485647/59833787-c5328f00-9381-11e9-8964-7d61414a838b.png">