### PR TITLE
let lscolors apply default colors if LS_COLORS not defined

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -77,7 +77,7 @@ impl Colors {
         };
         let lscolors = match theme {
             Theme::NoColor => None,
-            Theme::Default => LsColors::from_env(),
+            Theme::Default => Some(LsColors::from_env().unwrap_or_default()),
             Theme::NoLscolors => None,
         };
 


### PR DESCRIPTION
Fixes #90 