### PR TITLE
Support to not display icons in 'short' display format

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -37,6 +37,7 @@ pub fn build() -> App<'static, 'static> {
                 .long("icon")
                 .possible_value("always")
                 .possible_value("auto")
+                .possible_value("long")
                 .possible_value("never")
                 .default_value("auto")
                 .multiple(true)

--- a/src/core.rs
+++ b/src/core.rs
@@ -44,10 +44,10 @@ impl Core {
             _ => color::Theme::Default,
         };
 
-        let icon_theme = match (tty_available, flags.icon, flags.icon_theme) {
-            (_, WhenFlag::Never, _) | (false, WhenFlag::Auto, _) => icon::Theme::NoIcon,
-            (_, _, IconTheme::Fancy) => icon::Theme::Fancy,
-            (_, _, IconTheme::Unicode) => icon::Theme::Unicode,
+        let icon_theme = match (tty_available, flags.icon, flags.long_mode, flags.icon_theme) {
+            (_, WhenFlag::Never, _, _) | (false, WhenFlag::Auto, _ , _) | (_, WhenFlag::Long, false, _) => icon::Theme::NoIcon,
+            (_, _, _, IconTheme::Fancy) => icon::Theme::Fancy,
+            (_, _, _, IconTheme::Unicode) => icon::Theme::Unicode,
         };
 
         if !tty_available {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -4,6 +4,7 @@ use clap::{ArgMatches, Error, ErrorKind};
 pub struct Flags {
     pub display: Display,
     pub layout: Layout,
+    pub long_mode: bool,
     pub display_indicators: bool,
     pub recursive: bool,
     pub sort_by: SortFlag,
@@ -97,6 +98,7 @@ impl Flags {
         Ok(Self {
             display,
             layout,
+            long_mode: matches.is_present("long") || matches.is_present("tree"),
             display_indicators: matches.is_present("indicators"),
             recursive,
             recursion_depth,
@@ -137,6 +139,7 @@ impl Default for Flags {
         Self {
             display: Display::DisplayOnlyVisible,
             layout: Layout::Grid,
+            long_mode: false,
             display_indicators: false,
             recursive: false,
             recursion_depth: usize::max_value(),
@@ -234,6 +237,7 @@ pub enum WhenFlag {
     Always,
     Auto,
     Never,
+    Long,
 }
 impl<'a> From<&'a str> for WhenFlag {
     fn from(when: &'a str) -> Self {
@@ -241,6 +245,7 @@ impl<'a> From<&'a str> for WhenFlag {
             "always" => WhenFlag::Always,
             "auto" => WhenFlag::Auto,
             "never" => WhenFlag::Never,
+            "long" => WhenFlag::Long,
             _ => panic!("invalid \"when\" flag: {}", when),
         }
     }


### PR DESCRIPTION
* Add a new 'long' optional value for the --icon flags. If set
  only 'long' display formats (long or tree) will show icons.

Close #267