### PR TITLE
Create closure to do sorting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
  "terminal_size 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "users 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wild 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -499,10 +499,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "users"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -642,7 +643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
-"checksum users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
+"checksum users 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4227e95324a443c9fcb06e03d4d85e91aabe9a5a02aa818688b6918b6af486"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"

--- a/src/app.rs
+++ b/src/app.rs
@@ -191,8 +191,8 @@ pub fn build() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name("classic")
-                .long("classic")
-                .help("Enable classic mode (no colors or icons)"),
+            .long("classic")
+            .help("Enable classic mode (no colors or icons)"),
         )
         .arg(
             Arg::with_name("no-symlink")

--- a/src/core.rs
+++ b/src/core.rs
@@ -19,6 +19,7 @@ pub struct Core {
     icons: Icons,
     //display: Display,
     colors: Colors,
+    sorter: sort::Sorter,
 }
 
 impl Core {
@@ -58,11 +59,14 @@ impl Core {
             inner_flags.layout = Layout::OneLine;
         };
 
+        let sorter = sort::create_sorter(&flags);
+
         Self {
             flags,
             //display: Display::new(inner_flags),
             colors: Colors::new(color_theme),
             icons: Icons::new(icon_theme),
+            sorter,
         }
     }
 
@@ -118,8 +122,7 @@ impl Core {
     }
 
     fn sort(&self, metas: &mut Vec<Meta>) {
-        let sorter = sort::create_sorter(&self.flags);
-        metas.sort_unstable_by(|a, b| (sorter)(a, b));
+        metas.sort_unstable_by(|a, b| (self.sorter)(a, b));
 
         for meta in metas {
             if let Some(ref mut content) = meta.content {

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,6 +1,6 @@
 use crate::color::{self, Colors};
 use crate::display;
-use crate::flags::{Display, Flags, IconTheme, Layout, WhenFlag};
+use crate::flags::{Display, Flags, IconTheme, Layout, SortOrder, WhenFlag};
 use crate::icon::{self, Icons};
 use crate::meta::Meta;
 use crate::{print_error, print_output, sort};
@@ -19,7 +19,7 @@ pub struct Core {
     icons: Icons,
     //display: Display,
     colors: Colors,
-    sorter: sort::Sorter,
+    sorters: Vec<(SortOrder, sort::SortFn)>,
 }
 
 impl Core {
@@ -59,14 +59,14 @@ impl Core {
             inner_flags.layout = Layout::OneLine;
         };
 
-        let sorter = sort::create_sorter(&flags);
+        let sorters = sort::assemble_sorters(&flags);
 
         Self {
             flags,
             //display: Display::new(inner_flags),
             colors: Colors::new(color_theme),
             icons: Icons::new(icon_theme),
-            sorter,
+            sorters,
         }
     }
 
@@ -122,7 +122,7 @@ impl Core {
     }
 
     fn sort(&self, metas: &mut Vec<Meta>) {
-        metas.sort_unstable_by(|a, b| (self.sorter)(a, b));
+        metas.sort_unstable_by(|a, b| sort::by_meta(&self.sorters, a, b));
 
         for meta in metas {
             if let Some(ref mut content) = meta.content {

--- a/src/core.rs
+++ b/src/core.rs
@@ -118,7 +118,8 @@ impl Core {
     }
 
     fn sort(&self, metas: &mut Vec<Meta>) {
-        metas.sort_unstable_by(|a, b| sort::by_meta(a, b, &self.flags));
+        let sorter = sort::create_sorter(&self.flags);
+        metas.sort_unstable_by(|a, b| (sorter)(a, b));
 
         for meta in metas {
             if let Some(ref mut content) = meta.content {

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -79,6 +79,13 @@ impl FileType {
             FileType::Special
         }
     }
+
+    pub fn is_dirlike(self) -> bool {
+        match self {
+            FileType::Directory { .. } | FileType::SymLink { is_dir: true } => true,
+            _ => false,
+        }
+    }
 }
 
 impl FileType {


### PR DESCRIPTION
Was hacking on #277 and realised that splitting the directories out wasn't necessary so jumped to the sorting with a created closure.

## Future architecture for sorting:
1. Take flags and "compose"(not sure how this works in Rust, so I just went with a loop), sorting functions together to create the sorting function
1. Cache sorting function to reuse for the recursive calls to `Core#sort`

The test pass but I would like to do some performance testing and complete the second step.