### PR TITLE
Scarf install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Status](https://travis-ci.org/Peltoche/lsd.svg?branch=master)](https://travis-ci.org/Peltoche/lsd)
 [![Latest version](https://img.shields.io/crates/v/lsd.svg)](https://crates.io/crates/lsd)
 [![Snap Status](https://build.snapcraft.io/badge/Peltoche/lsd.svg)](https://build.snapcraft.io/user/Peltoche/lsd)
+[![Scarf Version](https://scarf.sh/package/badge/lsd)](https://scarf.sh/package/scarf/lsd)
+
 
 # Table of Contents
 
@@ -74,6 +76,14 @@ via [Homebrew](https://brew.sh/):
 
 ```sh
 brew install lsd
+```
+
+### From Scarf
+
+If you'd like to support lsd, please consider installing with the [Scarf package manager](https://scarf.sh/package/scarf/lsd):
+
+```sh
+scarf install lsd
 ```
 
 ### From Sources


### PR DESCRIPTION
Hi @Peltoche+@meain, this README change adds instructions to install with [Scarf](https://scarf.sh). 

I noticed this repo is using Github Sponsors. Scarf could be another revenue source to support this project, especially when it is used by developers in a commercial setting. It can also provide usage analytics that could be useful to this end. 

I can transfer package ownership to you or add you as a co-maintainer. Happy to help with package maintenance either way. I really like this tool myself so if you decide to collect payments through Scarf I'll be your first customer 😄 