### PR TITLE
Display correct permissions for files with setuid or setgid attributes

### DIFF
--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -77,7 +77,7 @@ impl Permissions {
             // Group permissions
             bit(self.group_read, "r", &Elem::Read),
             bit(self.group_write, "w", &Elem::Write),
-            match (self.group_execute, self.setuid) {
+            match (self.group_execute, self.setgid) {
                 (false, false) => colors.colorize(String::from("-"), &Elem::NoAccess),
                 (true, false) => colors.colorize(String::from("x"), &Elem::Exec),
                 (false, true) => colors.colorize(String::from("S"), &Elem::ExecSticky),


### PR DESCRIPTION
The setuid bit was also checked to render the group permissions.

Before:
```
$ lsd -l --color=never --icon never
.rwSr-Sr-- xduugu xduugu 0 B Thu Nov  7 21:13:39 2019 a
.rw-r--r-- xduugu xduugu 0 B Thu Nov  7 21:13:39 2019 b
.rw-r--r-T xduugu xduugu 0 B Thu Nov  7 21:13:39 2019 c
```

After:
```
$ lsd -l --color=never --icon never
.rwSr--r-- xduugu xduugu 0 B Thu Nov  7 21:13:39 2019 a
.rw-r-Sr-- xduugu xduugu 0 B Thu Nov  7 21:13:39 2019 b
.rw-r--r-T xduugu xduugu 0 B Thu Nov  7 21:13:39 2019 c
```