### PR TITLE
Date formatting feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [build-dependencies]
 clap = "2.33.*"
 version_check = "0.9.*"
+time = "0.1.*"
 
 [dependencies]
 ansi_term = "0.12.*"

--- a/src/app.rs
+++ b/src/app.rs
@@ -208,15 +208,10 @@ fn validate_date_argument(arg: String) -> Result<(), String> {
     use std::error::Error;
     if arg.starts_with('+') {
         validate_time_format(&arg).map_err(|err| err.description().to_string())
-    } else if &arg == "date" {
-        Result::Ok(())
-    } else if &arg == "relative" {
+    } else if &arg == "date" || &arg == "relative" {
         Result::Ok(())
     } else {
-        Result::Err(
-            "possible values: date, relative, +date-time-format"
-            .to_owned()
-        )
+        Result::Err("possible values: date, relative, +date-time-format".to_owned())
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use clap::{App, Arg};
 
+
 pub fn build() -> App<'static, 'static> {
     App::new("lsd")
         .version(crate_version!())
@@ -134,6 +135,7 @@ pub fn build() -> App<'static, 'static> {
         .arg(
             Arg::with_name("date")
                 .long("date")
+                .validator(validate_date_argument)
                 .default_value("date")
                 .multiple(true)
                 .number_of_values(1)
@@ -201,4 +203,17 @@ pub fn build() -> App<'static, 'static> {
                 .default_value("")
                 .help("Do not display files/directories with names matching the glob pattern(s)"),
         )
+}
+
+fn validate_date_argument(arg: String) -> Result<(), String> {
+    use std::error::Error;
+    if arg.starts_with("+") {
+        time::now().strftime(&arg).map(drop).map_err(|err| err.description().to_string())
+    } else if &arg == "date" {
+        Result::Ok(())
+    } else if &arg == "relative" {
+        Result::Ok(())
+    } else {
+        Result::Err("possible values: date, relative".to_owned())
+    }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -134,8 +134,6 @@ pub fn build() -> App<'static, 'static> {
         .arg(
             Arg::with_name("date")
                 .long("date")
-                .possible_value("date")
-                .possible_value("relative")
                 .default_value("date")
                 .multiple(true)
                 .number_of_values(1)

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,7 +138,7 @@ pub fn build() -> App<'static, 'static> {
                 .default_value("date")
                 .multiple(true)
                 .number_of_values(1)
-                .help("How to display date"),
+                .help("How to display date [possible values: date, relative, +date-time-format]"),
         )
         .arg(
             Arg::with_name("timesort")
@@ -213,7 +213,10 @@ fn validate_date_argument(arg: String) -> Result<(), String> {
     } else if &arg == "relative" {
         Result::Ok(())
     } else {
-        Result::Err("possible values: date, relative".to_owned())
+        Result::Err(
+            "possible values: date, relative, +date-time-format"
+            .to_owned()
+        )
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -206,7 +206,7 @@ pub fn build() -> App<'static, 'static> {
 
 fn validate_date_argument(arg: String) -> Result<(), String> {
     use std::error::Error;
-    if arg.starts_with("+") {
+    if arg.starts_with('+') {
         validate_time_format(&arg).map_err(|err| err.description().to_string())
     } else if &arg == "date" {
         Result::Ok(())

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,5 @@
 use clap::{App, Arg};
 
-
 pub fn build() -> App<'static, 'static> {
     App::new("lsd")
         .version(crate_version!())
@@ -208,7 +207,7 @@ pub fn build() -> App<'static, 'static> {
 fn validate_date_argument(arg: String) -> Result<(), String> {
     use std::error::Error;
     if arg.starts_with("+") {
-        time::now().strftime(&arg).map(drop).map_err(|err| err.description().to_string())
+        validate_time_format(&arg).map_err(|err| err.description().to_string())
     } else if &arg == "date" {
         Result::Ok(())
     } else if &arg == "relative" {
@@ -216,4 +215,27 @@ fn validate_date_argument(arg: String) -> Result<(), String> {
     } else {
         Result::Err("possible values: date, relative".to_owned())
     }
+}
+
+fn validate_time_format(formatter: &str) -> Result<(), time::ParseError> {
+    let mut chars = formatter.chars();
+    loop {
+        match chars.next() {
+            Some('%') => match chars.next() {
+                Some('A') | Some('a') | Some('B') | Some('b') | Some('C') | Some('c')
+                | Some('D') | Some('d') | Some('e') | Some('F') | Some('f') | Some('G')
+                | Some('g') | Some('H') | Some('h') | Some('I') | Some('j') | Some('k')
+                | Some('l') | Some('M') | Some('m') | Some('n') | Some('P') | Some('p')
+                | Some('R') | Some('r') | Some('S') | Some('s') | Some('T') | Some('t')
+                | Some('U') | Some('u') | Some('V') | Some('v') | Some('W') | Some('w')
+                | Some('X') | Some('x') | Some('Y') | Some('y') | Some('Z') | Some('z')
+                | Some('+') | Some('%') => (),
+                Some(c) => return Err(time::ParseError::InvalidFormatSpecifier(c)),
+                None => return Err(time::ParseError::MissingFormatConverter),
+            },
+            None => break,
+            _ => continue,
+        }
+    }
+    Ok(())
 }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -260,7 +260,7 @@ impl<'a> From<&'a str> for DateFlag {
         match time {
             "date" => DateFlag::Date,
             "relative" => DateFlag::Relative,
-            time if time.starts_with("+") => DateFlag::Formatted(time[1..].to_owned()),
+            time if time.starts_with('+') => DateFlag::Formatted(time[1..].to_owned()),
             _ => panic!("invalid \"time\" flag: {}", time),
         }
     }

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -248,10 +248,11 @@ impl<'a> From<&'a str> for SizeFlag {
     }
 }
 
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DateFlag {
     Date,
     Relative,
+    Formatted(String),
 }
 
 impl<'a> From<&'a str> for DateFlag {
@@ -259,6 +260,7 @@ impl<'a> From<&'a str> for DateFlag {
         match time {
             "date" => DateFlag::Date,
             "relative" => DateFlag::Relative,
+            time if time.starts_with("+") => DateFlag::Formatted(time[1..].to_owned()),
             _ => panic!("invalid \"time\" flag: {}", time),
         }
     }

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -41,9 +41,10 @@ impl Date {
     }
 
     pub fn date_string(&self, flags: &Flags) -> String {
-        match flags.date {
+        match &flags.date {
             DateFlag::Date => self.0.ctime().to_string(),
             DateFlag::Relative => format!("{}", HumanTime::from(self.0 - time::now())),
+            DateFlag::Formatted(format) => self.0.to_local().strftime(&format).unwrap().to_string(),
         }
     }
 }


### PR DESCRIPTION
$ lsd -l 
drwxr-xr-x dvvv dvvv   4 KB Sun Nov 10 14:13:54 2019   build      
drwxr-xr-x dvvv dvvv  20 KB Sun Nov 10 15:50:42 2019   deps       
drwxr-xr-x dvvv dvvv   4 KB Thu Nov  7 11:58:17 2019   examples   
drwxr-xr-x dvvv dvvv   4 KB Thu Nov  7 11:58:17 2019   incremental
.rwxr-xr-x dvvv dvvv 4.9 MB Sun Nov 10 15:50:42 2019   lsd        
.rw-r--r-- dvvv dvvv 662 B  Thu Nov  7 11:58:25 2019   lsd.d

$ lsd -l --date "+%F %T"
drwxr-xr-x dvvv dvvv   4 KB 2019-11-10 14:13:54   build      
drwxr-xr-x dvvv dvvv  20 KB 2019-11-10 15:50:42   deps       
drwxr-xr-x dvvv dvvv   4 KB 2019-11-07 11:58:17   examples   
drwxr-xr-x dvvv dvvv   4 KB 2019-11-07 11:58:17   incremental
.rwxr-xr-x dvvv dvvv 4.9 MB 2019-11-10 15:50:42   lsd        
.rw-r--r-- dvvv dvvv 662 B  2019-11-07 11:58:25   lsd.d