### PR TITLE
Allow usage of multiple 'depth' arguments

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -104,6 +104,7 @@ pub fn build() -> App<'static, 'static> {
         .arg(
             Arg::with_name("depth")
                 .long("depth")
+                .multiple(true)
                 .takes_value(true)
                 .value_name("num")
                 .help("Stop recursing into directories after reaching specified depth"),

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -69,15 +69,12 @@ impl Flags {
             Layout::Grid
         };
         let recursive = matches.is_present("recursive");
-        let recursion_depth = match matches.values_of("depth") {
-            Some(str)
-                if recursive
-                    || layout
-                        == Layout::Tree {
-                            long: matches.is_present("long"),
-                        } =>
-            {
-                match str.last().unwrap().parse::<usize>() {
+        let recursion_input = matches.values_of("depth").and_then(|values| values.last());
+        let recursion_depth = match recursion_input {
+            Some(str) if recursive || layout == Layout::Tree {
+                long: matches.is_present("long"),
+            } => {
+                match str.parse::<usize>() {
                     Ok(val) => val,
                     Err(_) => {
                         return Err(Error::with_description(

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -69,7 +69,7 @@ impl Flags {
             Layout::Grid
         };
         let recursive = matches.is_present("recursive");
-        let recursion_depth = match matches.value_of("depth") {
+        let recursion_depth = match matches.values_of("depth") {
             Some(str)
                 if recursive
                     || layout
@@ -77,7 +77,7 @@ impl Flags {
                             long: matches.is_present("long"),
                         } =>
             {
-                match str.parse::<usize>() {
+                match str.last().unwrap().parse::<usize>() {
                     Ok(val) => val,
                     Err(_) => {
                         return Err(Error::with_description(
@@ -352,5 +352,27 @@ mod test {
 
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().kind, ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn test_duplicate_depth() {
+        let matches = app::build()
+            .get_matches_from_safe(vec!["lsd",  "--tree", "--depth", "1", "--depth", "2"])
+            .unwrap();
+        let res = Flags::from_matches(&matches);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().recursion_depth, 2);
+    }
+
+    #[test]
+    fn test_missing_depth() {
+        let matches = app::build()
+            .get_matches_from_safe(vec!["lsd",  "--tree"])
+            .unwrap();
+        let res = Flags::from_matches(&matches);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().recursion_depth, usize::max_value());
     }
 }


### PR DESCRIPTION
Fixes behavior mentioned in #298 