### PR TITLE
Fix regression causing size short to have space

### DIFF
--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -141,6 +141,7 @@ impl Size {
 #[cfg(test)]
 mod test {
     use super::Size;
+    use crate::color::{Colors, Theme};
     use crate::flags::{Flags, SizeFlag};
 
     #[test]
@@ -217,5 +218,16 @@ mod test {
 
         assert_eq!(size.value_string(&flags).as_str(), "42");
         assert_eq!(size.unit_string(&flags).as_str(), "KB");
+    }
+
+    #[test]
+    fn render_short_nospaces() {
+        let size = Size::new(42 * 1024); // 42 kilobytes
+        let mut flags = Flags::default();
+        flags.size = SizeFlag::Short;
+        let colors = Colors::new(Theme::NoColor);
+
+        assert_eq!(size.render(&colors, &flags, 2).to_string(), "42K");
+        assert_eq!(size.render(&colors, &flags, 3).to_string(), " 42K");
     }
 }

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -57,14 +57,13 @@ impl Size {
             left_pad.push(' ');
         }
 
-        let strings: &[ColoredString] = &[
-            ColoredString::from(left_pad),
-            val_content,
-            ColoredString::from(" "),
-            unit_content,
-        ];
+        let mut strings: Vec<ColoredString> = vec![ColoredString::from(left_pad), val_content];
+        if flags.size != SizeFlag::Short {
+            strings.push(ColoredString::from(" "));
+        }
+        strings.push(unit_content);
 
-        let res = ANSIStrings(strings).to_string();
+        let res = ANSIStrings(&strings).to_string();
         ColoredString::from(res)
     }
 


### PR DESCRIPTION
Before the display refactor `--size short` did not have a space between the value and the unit.
This changed after the refactor of how display works. This PR changes it back to how it was before.