### PR TITLE
Relative path

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -1,6 +1,7 @@
 use ansi_term::{ANSIString, Colour, Style};
 use lscolors::{Indicator, LsColors};
 use std::collections::HashMap;
+use std::path::Path;
 
 #[allow(dead_code)]
 #[derive(Hash, Debug, Eq, PartialEq, Clone)]
@@ -96,7 +97,7 @@ impl Colors {
     pub fn colorize_using_path<'a>(
         &self,
         input: String,
-        path: &str,
+        path: &Path,
         elem: &Elem,
     ) -> ColoredString<'a> {
         let style_from_path = self.style_from_path(path);
@@ -106,7 +107,7 @@ impl Colors {
         }
     }
 
-    fn style_from_path(&self, path: &str) -> Option<Style> {
+    fn style_from_path(&self, path: &Path) -> Option<Style> {
         match &self.lscolors {
             Some(lscolors) => lscolors
                 .style_for_path(path)

--- a/src/core.rs
+++ b/src/core.rs
@@ -95,7 +95,12 @@ impl Core {
                     meta_list.push(meta);
                 }
                 _ => {
-                    match meta.recurse_into(base_path, depth, self.flags.display, &self.flags.ignore_globs) {
+                    match meta.recurse_into(
+                        base_path,
+                        depth,
+                        self.flags.display,
+                        &self.flags.ignore_globs,
+                    ) {
                         Ok(content) => {
                             meta.content = content;
                             meta_list.push(meta);

--- a/src/core.rs
+++ b/src/core.rs
@@ -95,12 +95,7 @@ impl Core {
                     meta_list.push(meta);
                 }
                 _ => {
-                    match meta.recurse_into(
-                        base_path,
-                        depth,
-                        self.flags.display,
-                        &self.flags.ignore_globs,
-                    ) {
+                    match meta.recurse_into(depth, self.flags.display, &self.flags.ignore_globs) {
                         Ok(content) => {
                             meta.content = content;
                             meta_list.push(meta);

--- a/src/core.rs
+++ b/src/core.rs
@@ -95,7 +95,7 @@ impl Core {
                     meta_list.push(meta);
                 }
                 _ => {
-                    match meta.recurse_into(depth, self.flags.display, &self.flags.ignore_globs) {
+                    match meta.recurse_into(base_path, depth, self.flags.display, &self.flags.ignore_globs) {
                         Ok(content) => {
                             meta.content = content;
                             meta_list.push(meta);

--- a/src/display.rs
+++ b/src/display.rs
@@ -115,12 +115,8 @@ fn inner_display_grid(
                 output += &display_folder_path(&meta);
             }
 
-            let display_option = if should_display_folder_path {
-                DisplayOption::FileName
-            } else {
-                DisplayOption::Relative {
-                    base_path: &meta.path,
-                }
+            let display_option = DisplayOption::Relative {
+                base_path: &meta.path,
             };
 
             output += &inner_display_grid(

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,6 +2,7 @@ use crate::color::{ColoredString, Colors};
 use crate::flags::{Block, Display, Flags, Layout};
 use crate::icon::Icons;
 use crate::meta::{FileType, Meta};
+use crate::meta::name::DisplayOption;
 use ansi_term::{ANSIString, ANSIStrings};
 use std::collections::HashMap;
 use term_grid::{Cell, Direction, Filling, Grid, GridOptions};
@@ -59,8 +60,10 @@ fn inner_display_grid(
         if let (true, FileType::Directory { .. }) = (skip_dirs, meta.file_type) {
             continue;
         }
+        
+        let display_option = DisplayOption::Current;
 
-        let blocks = get_output(&meta, &colors, &icons, &flags, &padding_rules);
+        let blocks = get_output(&meta, &colors, &icons, &flags, display_option, &padding_rules);
 
         for block in blocks {
             let block_str = block.to_string();
@@ -131,7 +134,7 @@ fn inner_display_tree(
     });
 
     for meta in metas.iter() {
-        for block in get_output(&meta, &colors, &icons, &flags, &padding_rules) {
+        for block in get_output(&meta, &colors, &icons, &flags, DisplayOption::FileName, &padding_rules) {
             let block_str = block.to_string();
 
             grid.add(Cell {
@@ -216,6 +219,7 @@ fn get_output<'a>(
     colors: &'a Colors,
     icons: &'a Icons,
     flags: &'a Flags,
+    display_option: DisplayOption,
     padding_rules: &HashMap<Block, usize>,
 ) -> Vec<ANSIString<'a>> {
     let mut strings: Vec<ANSIString> = Vec::new();
@@ -242,13 +246,13 @@ fn get_output<'a>(
             Block::Name => {
                 let s: String = if flags.no_symlink {
                     ANSIStrings(&[
-                        meta.name.render(colors, icons),
+                        meta.name.render(colors, icons, &display_option),
                         meta.indicator.render(&flags),
                     ])
                     .to_string()
                 } else {
                     ANSIStrings(&[
-                        meta.name.render(colors, icons),
+                        meta.name.render(colors, icons, &display_option),
                         meta.indicator.render(&flags),
                         meta.symlink.render(colors),
                     ])

--- a/src/display.rs
+++ b/src/display.rs
@@ -68,7 +68,7 @@ fn inner_display_grid(
     let skip_dirs = (depth == 0) && (flags.display != Display::DisplayDirectoryItself);
 
     // print the files first.
-    for meta in metas.iter() {
+    for meta in metas {
         // Maybe skip showing the directory meta now; show its contents later.
         if let (true, FileType::Directory { .. }) = (skip_dirs, meta.file_type) {
             continue;

--- a/src/display.rs
+++ b/src/display.rs
@@ -20,12 +20,8 @@ pub fn grid(metas: &[Meta], flags: &Flags, colors: &Colors, icons: &Icons) -> St
         None => None,
     };
 
-    let current_dir = std::env::current_dir().unwrap();
-
     inner_display_grid(
-        &DisplayOption::Relative {
-            base_path: &current_dir,
-        },
+        &DisplayOption::None,
         metas,
         &flags,
         colors,

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -91,15 +91,13 @@ impl Icons {
             return res;
         }
 
-        if let Some(icon) = name.file_name()
-            .map(std::ffi::OsStr::to_string_lossy)
-            .and_then(|file_name| self.icons_by_name.get(file_name.as_ref())) {
+        if let Some(icon) = self.icons_by_name.get(name.file_name()) {
             // Use the known names.
             res += icon;
             res += ICON_SPACE;
             res
         } else if let Some(icon) = name.extension()
-            .and_then(|extension| self.icons_by_extension.get(extension)) {
+            .and_then(|extension| self.icons_by_extension.get(extension)){
             // Use the known extensions.
             res += icon;
             res += ICON_SPACE;

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -91,26 +91,25 @@ impl Icons {
             return res;
         }
 
-        // Check the known names.
-        if let Some(icon) = self.icons_by_name.get(name.name().as_str()) {
+        if let Some(icon) = name.file_name()
+            .map(std::ffi::OsStr::to_string_lossy)
+            .and_then(|file_name| self.icons_by_name.get(file_name.as_ref())) {
+            // Use the known names.
             res += icon;
             res += ICON_SPACE;
-            return res;
+            res
+        } else if let Some(icon) = name.extension()
+            .and_then(|extension| self.icons_by_extension.get(extension)) {
+            // Use the known extensions.
+            res += icon;
+            res += ICON_SPACE;
+            res
+        } else {
+            // Use the default icons.
+            res += self.default_file_icon;
+            res += ICON_SPACE;
+            res
         }
-
-        // Check the known extensions.
-        if let Some(extension) = name.extension() {
-            if let Some(icon) = self.icons_by_extension.get(extension.as_str()) {
-                res += icon;
-                res += ICON_SPACE;
-                return res;
-            }
-        }
-
-        // Use the default icons.
-        res += self.default_file_icon;
-        res += ICON_SPACE;
-        res
     }
 
     fn get_default_icons_by_name() -> HashMap<&'static str, &'static str> {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -96,8 +96,10 @@ impl Icons {
             res += icon;
             res += ICON_SPACE;
             res
-        } else if let Some(icon) = name.extension()
-            .and_then(|extension| self.icons_by_extension.get(extension)){
+        } else if let Some(icon) = name
+            .extension()
+            .and_then(|extension| self.icons_by_extension.get(extension))
+        {
             // Use the known extensions.
             res += icon;
             res += ICON_SPACE;

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -56,60 +56,38 @@ impl Icons {
             return String::new();
         }
 
-        let mut res = String::with_capacity(4 + ICON_SPACE.len()); // 4 == max icon size
-
         // Check file types
         let file_type: FileType = name.file_type();
 
-        if let FileType::Directory { .. } = file_type {
-            res += self.default_folder_icon;
-            res += ICON_SPACE;
-            return res;
+        let icon = if let FileType::Directory { .. } = file_type {
+            self.default_folder_icon
         } else if let FileType::SymLink = file_type {
-            res += "\u{e27c}"; // ""
-            res += ICON_SPACE;
-            return res;
+            "\u{e27c}" // ""
         } else if let FileType::Socket = file_type {
-            res += "\u{f6a7}"; // ""
-            res += ICON_SPACE;
-            return res;
+            "\u{f6a7}" // ""
         } else if let FileType::Pipe = file_type {
-            res += "\u{f731}"; // ""
-            res += ICON_SPACE;
-            return res;
+            "\u{f731}" // ""
         } else if let FileType::CharDevice = file_type {
-            res += "\u{e601}"; // ""
-            res += ICON_SPACE;
-            return res;
+            "\u{e601}" // ""
         } else if let FileType::BlockDevice = file_type {
-            res += "\u{fc29}"; // "ﰩ"
-            res += ICON_SPACE;
-            return res;
+            "\u{fc29}" // "ﰩ"
         } else if let FileType::Special = file_type {
-            res += "\u{f2dc}"; // ""
-            res += ICON_SPACE;
-            return res;
-        }
-
-        if let Some(icon) = self.icons_by_name.get(name.file_name()) {
+            "\u{f2dc}" // ""
+        } else if let Some(icon) = self.icons_by_name.get(name.file_name()) {
             // Use the known names.
-            res += icon;
-            res += ICON_SPACE;
-            res
+            icon
         } else if let Some(icon) = name
             .extension()
             .and_then(|extension| self.icons_by_extension.get(extension))
         {
             // Use the known extensions.
-            res += icon;
-            res += ICON_SPACE;
-            res
+            icon
         } else {
             // Use the default icons.
-            res += self.default_file_icon;
-            res += ICON_SPACE;
-            res
-        }
+            self.default_file_icon
+        };
+
+        format!("{}{}", icon, ICON_SPACE)
     }
 
     fn get_default_icons_by_name() -> HashMap<&'static str, &'static str> {

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -24,10 +24,9 @@ pub use crate::flags::Display;
 pub use crate::icon::Icons;
 use crate::print_error;
 
-use std::fs;
 use std::fs::read_link;
 use std::io::{Error, ErrorKind};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use globset::GlobSet;
 
@@ -78,19 +77,11 @@ impl Meta {
 
         if let Display::DisplayAll = display {
             let mut current_meta;
-            let mut parent_meta;
-
-            let absolute_path = fs::canonicalize(&self.path)?;
-            let parent_path = match absolute_path.parent() {
-                None => PathBuf::from("/"),
-                Some(path) => PathBuf::from(path),
-            };
 
             current_meta = self.clone();
             current_meta.name.name = ".".to_owned();
 
-            parent_meta = Self::from_path(&parent_path)?;
-            parent_meta.name.name = "..".to_owned();
+            let parent_meta = Self::from_path(&self.path.join(Component::ParentDir))?;
 
             content.push(current_meta);
             content.push(parent_meta);

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -2,7 +2,7 @@ mod date;
 mod filetype;
 mod indicator;
 mod inode;
-mod name;
+pub mod name;
 mod owner;
 mod permissions;
 mod size;

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -49,7 +49,6 @@ pub struct Meta {
 impl Meta {
     pub fn recurse_into(
         &self,
-        base_path: &Path,
         depth: usize,
         display: Display,
         ignore_globs: &GlobSet,
@@ -88,10 +87,10 @@ impl Meta {
             };
 
             current_meta = self.clone();
-            current_meta.name.display_name = ".".to_owned();
+            current_meta.name.name = ".".to_owned();
 
             parent_meta = Self::from_path(&parent_path)?;
-            parent_meta.name.display_name = "..".to_owned();
+            parent_meta.name.name = "..".to_owned();
 
             content.push(current_meta);
             content.push(parent_meta);
@@ -122,7 +121,7 @@ impl Meta {
                 }
             };
 
-            match entry_meta.recurse_into(base_path, depth - 1, display, ignore_globs) {
+            match entry_meta.recurse_into(depth - 1, display, ignore_globs) {
                 Ok(content) => entry_meta.content = content,
                 Err(err) => {
                     print_error!("lsd: {}: {}\n", path.display(), err);

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -78,8 +78,8 @@ impl Meta {
         let mut content: Vec<Meta> = Vec::new();
 
         if let Display::DisplayAll = display {
-            let current_meta;
-            let parent_meta;
+            let mut current_meta;
+            let mut parent_meta;
 
             let absolute_path = fs::canonicalize(&self.path)?;
             let parent_path = match absolute_path.parent() {
@@ -87,12 +87,11 @@ impl Meta {
                 Some(path) => PathBuf::from(path),
             };
 
-            //replace it by display
             current_meta = self.clone();
-            //current_meta.name.path = PathBuf::from(".");
+            current_meta.name.display_name = ".".to_owned();
 
             parent_meta = Self::from_path(&parent_path)?;
-            //parent_meta.name.name = "..".to_string();
+            parent_meta.name.display_name = "..".to_owned();
 
             content.push(current_meta);
             content.push(parent_meta);

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -45,7 +45,10 @@ impl Name {
     }
 
     pub fn file_name(&self) -> &str {
-        self.path.file_name().and_then(OsStr::to_str).unwrap_or(&self.name)
+        self.path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or(&self.name)
     }
 
     fn relative_path<T: AsRef<Path> + Clone>(&self, base_path: T) -> PathBuf {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -111,7 +111,7 @@ impl Name {
     }
 
     pub fn extension(&self) -> Option<&str> {
-        self.extension.as_deref()
+        self.extension.as_ref().map(|string| string.as_str())
     }
 
     pub fn file_type(&self) -> FileType {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -50,9 +50,6 @@ impl Name {
 
     fn relative_path<T: AsRef<Path> + Clone>(&self, base_path: T) -> PathBuf {
         let base_path = base_path.as_ref();
-        if self.path == base_path {
-            return PathBuf::from(".");
-        }
 
         let shared_components: PathBuf = self
             .path

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -45,7 +45,7 @@ impl Name {
     }
 
     pub fn file_name(&self) -> &str {
-        self.path.file_name().and_then(OsStr::to_str).unwrap()
+        self.path.file_name().and_then(OsStr::to_str).unwrap_or(&self.name)
     }
 
     fn relative_path<T: AsRef<Path> + Clone>(&self, base_path: T) -> PathBuf {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -62,7 +62,7 @@ impl Name {
         };
 
         if target_path == base_path {
-            return PathBuf::from("");
+            return PathBuf::from(".");
         }
 
         let shared_components: PathBuf = target_path

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -111,7 +111,7 @@ impl Name {
     }
 
     pub fn extension(&self) -> Option<&str> {
-        self.extension.as_ref().map(|string| string.as_str())
+        self.extension.as_deref()
     }
 
     pub fn file_type(&self) -> FileType {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -54,7 +54,8 @@ impl Name {
             return PathBuf::from(".");
         }
 
-        let shared_components: PathBuf = self.path
+        let shared_components: PathBuf = self
+            .path
             .components()
             .zip(base_path.components())
             .take_while(|(target_component, base_component)| target_component == base_component)
@@ -88,7 +89,7 @@ impl Name {
                 icons.get(self),
                 self.relative_path(base_path).to_string_lossy()
             ),
-            DisplayOption::None => format!("{}{}", icons.get(self), self.path.to_string_lossy())
+            DisplayOption::None => format!("{}{}", icons.get(self), self.path.to_string_lossy()),
         };
 
         let elem = match self.file_type {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -2,12 +2,13 @@ use crate::color::{ColoredString, Colors, Elem};
 use crate::icon::Icons;
 use crate::meta::filetype::FileType;
 use std::cmp::{Ordering, PartialOrd};
-use std::path::{Path, PathBuf, Component};
 use std::ffi::OsStr;
+use std::path::{Component, Path, PathBuf};
 
+#[derive(Debug)]
 pub enum DisplayOption<'a> {
     FileName,
-    Relative{base_path: &'a Path},
+    Relative { base_path: &'a Path },
 }
 
 #[derive(Clone, Debug, Eq)]
@@ -23,18 +24,43 @@ impl Name {
         self.path.file_name().and_then(OsStr::to_str).unwrap()
     }
 
-    fn relative_path(&self, base_path: &Path) -> std::borrow::Cow<'_, str> {
-        if self.path.starts_with(Component::ParentDir) {
-            self.path.to_string_lossy()
-        } else if self.path.starts_with(base_path) {
-            let relative_path = self.path.strip_prefix(base_path).unwrap().to_string_lossy();
-            if relative_path == "" { std::borrow::Cow::Borrowed(".")
-            } else {
-                relative_path
-            }
+    fn relative_path<T: AsRef<Path> + Clone>(&self, base_path: T) -> PathBuf {
+        use std::borrow::Cow;
+        let target_path = if self.path.is_absolute() {
+            Cow::Borrowed(&self.path)
         } else {
-            std::borrow::Cow::Borrowed(&self.display_name)
+            Cow::Owned(self.path.canonicalize().unwrap())
+        };
+
+        let base_path = if base_path.as_ref().is_absolute() {
+            Cow::Borrowed(base_path.as_ref())
+        } else {
+            Cow::Owned(base_path.as_ref().canonicalize().unwrap())
+        };
+
+        if target_path == base_path {
+            return PathBuf::from("");
         }
+
+        let shared_components: PathBuf = target_path
+            .components()
+            .zip(base_path.components())
+            .take_while(|(target_component, base_component)| target_component == base_component)
+            .map(|tuple| tuple.0)
+            .collect();
+
+        base_path
+            .strip_prefix(&shared_components)
+            .unwrap()
+            .components()
+            .map(|_| Component::ParentDir)
+            .chain(
+                target_path
+                    .strip_prefix(&shared_components)
+                    .unwrap()
+                    .components(),
+            )
+            .collect()
     }
 
     pub fn new(path: &Path, file_type: FileType) -> Self {
@@ -50,15 +76,28 @@ impl Name {
         Self {
             path: PathBuf::from(path),
             extension,
-            display_name: path.file_name().and_then(OsStr::to_str).unwrap_or("?").to_owned(),
+            display_name: path
+                .file_name()
+                .and_then(OsStr::to_str)
+                .unwrap_or("?")
+                .to_owned(),
             file_type,
         }
     }
 
-    pub fn render(&self, colors: &Colors, icons: &Icons, display_option: &DisplayOption) -> ColoredString {
+    pub fn render(
+        &self,
+        colors: &Colors,
+        icons: &Icons,
+        display_option: &DisplayOption,
+    ) -> ColoredString {
         let content = match display_option {
             DisplayOption::FileName => format!("{}{}", icons.get(self), self.file_name()),
-            DisplayOption::Relative{base_path} => format!("{}{}", icons.get(self), self.relative_path(base_path)),
+            DisplayOption::Relative { base_path } => format!(
+                "{}{}",
+                icons.get(self),
+                self.relative_path(base_path).to_string_lossy()
+            ),
         };
 
         let elem = match self.file_type {
@@ -86,24 +125,31 @@ impl Name {
 
 impl Ord for Name {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.display_name.cmp(&other.display_name)
+        self.display_name
+            .to_lowercase()
+            .cmp(&other.display_name.to_lowercase())
     }
 }
 
 impl PartialOrd for Name {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.display_name.partial_cmp(&other.display_name)
+        self.display_name
+            .to_lowercase()
+            .partial_cmp(&other.display_name.to_lowercase())
     }
 }
 
 impl PartialEq for Name {
     fn eq(&self, other: &Self) -> bool {
-        self.path.eq(&other.path)
+        self.display_name
+            .to_lowercase()
+            .eq(&other.display_name.to_lowercase())
     }
 }
 
 #[cfg(test)]
 mod test {
+    use super::DisplayOption;
     use super::Name;
     use crate::color::{self, Colors};
     use crate::icon::{self, Icons};
@@ -116,7 +162,7 @@ mod test {
     use std::fs::{self, File};
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     #[cfg(unix)]
     use std::process::Command;
     use tempfile::tempdir;
@@ -138,7 +184,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint(" file.txt"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, &DisplayOption::FileName)
         );
     }
 
@@ -156,7 +202,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(33).paint(" directory"),
-            meta.name.render(&colors, &icons)
+            meta.name.render(&colors, &icons, &DisplayOption::FileName)
         );
     }
 
@@ -179,11 +225,11 @@ mod test {
 
         let colors = Colors::new(color::Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&tmp_dir.into_path(), &symlink_path, file_type);
+        let name = Name::new(&symlink_path, file_type);
 
         assert_eq!(
             Colour::Fixed(44).paint(" target.tmp"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, &DisplayOption::FileName)
         );
     }
 
@@ -205,11 +251,11 @@ mod test {
 
         let colors = Colors::new(color::Theme::NoLscolors);
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
-        let name = Name::new(&tmp_dir.into_path(), &pipe_path, file_type);
+        let name = Name::new(&pipe_path, file_type);
 
         assert_eq!(
             Colour::Fixed(184).paint(" pipe.tmp"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, &DisplayOption::FileName)
         );
     }
 
@@ -227,7 +273,10 @@ mod test {
 
         assert_eq!(
             "file.txt",
-            meta.name.render(&colors, &icons).to_string().as_str()
+            meta.name
+                .render(&colors, &icons, &DisplayOption::FileName)
+                .to_string()
+                .as_str()
         );
     }
 
@@ -263,7 +312,7 @@ mod test {
 
     #[test]
     fn test_order_impl_is_case_insensitive() {
-        let path_1 = Path::new("AAAA");
+        let path_1 = Path::new("/AAAA");
         let name_1 = Name::new(
             &path_1,
             FileType::File {
@@ -272,7 +321,7 @@ mod test {
             },
         );
 
-        let path_2 = Path::new("aaaa");
+        let path_2 = Path::new("/aaaa");
         let name_2 = Name::new(
             &path_2,
             FileType::File {
@@ -286,7 +335,7 @@ mod test {
 
     #[test]
     fn test_partial_order_impl() {
-        let path_a = Path::new("aaaa");
+        let path_a = Path::new("/aaaa");
         let name_a = Name::new(
             &path_a,
             FileType::File {
@@ -295,7 +344,7 @@ mod test {
             },
         );
 
-        let path_z = Path::new("zzzz");
+        let path_z = Path::new("/zzzz");
         let name_z = Name::new(
             &path_z,
             FileType::File {
@@ -374,5 +423,53 @@ mod test {
         );
 
         assert_eq!(true, name_1 == name_2);
+    }
+
+    #[test]
+    fn test_parent_relative_path() {
+        let name = Name::new(
+            Path::new("/home/parent1/child"),
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
+        let base_path = Path::new("/home/parent2");
+
+        assert_eq!(
+            PathBuf::from("../parent1/child"),
+            name.relative_path(base_path),
+        )
+    }
+
+    #[test]
+    fn test_current_relative_path() {
+        let name = Name::new(
+            Path::new("/home/parent1/child"),
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
+        let base_path = PathBuf::from("/home/parent1");
+
+        assert_eq!(PathBuf::from("child"), name.relative_path(base_path),)
+    }
+
+    #[test]
+    fn test_grand_parent_relative_path() {
+        let name = Name::new(
+            Path::new("/home/grand-parent1/parent1/child"),
+            FileType::File {
+                uid: false,
+                exec: false,
+            },
+        );
+        let base_path = PathBuf::from("/home/grand-parent2/parent1");
+
+        assert_eq!(
+            PathBuf::from("../../grand-parent1/parent1/child"),
+            name.relative_path(base_path),
+        )
     }
 }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -51,6 +51,10 @@ impl Name {
     fn relative_path<T: AsRef<Path> + Clone>(&self, base_path: T) -> PathBuf {
         let base_path = base_path.as_ref();
 
+        if self.path == base_path {
+            return PathBuf::from(AsRef::<Path>::as_ref(&Component::CurDir));
+        }
+
         let shared_components: PathBuf = self
             .path
             .components()

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -1,7 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
-use std::path::{Path};
+use std::path::Path;
 use std::ptr::null_mut;
 
 use winapi::ctypes::c_void;

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -13,7 +13,7 @@ use super::{Owner, Permissions};
 
 const BUF_SIZE: u32 = 256;
 
-pub fn get_file_data(path: &PathBuf) -> Result<(Owner, Permissions), io::Error> {
+pub fn get_file_data(path: &Path) -> Result<(Owner, Permissions), io::Error> {
     // Overall design:
     // This function allocates some data with GetNamedSecurityInfoW,
     // manipulates it only through WinAPI calls (treating the pointers as

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -1,7 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::ptr::null_mut;
 
 use winapi::ctypes::c_void;

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -1,7 +1,7 @@
 use std::ffi::{OsStr, OsString};
 use std::io;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
-use std::path::{Path, PathBuf};
+use std::path::{Path};
 use std::ptr::null_mut;
 
 use winapi::ctypes::c_void;


### PR DESCRIPTION
This pull request contains following changes

1. meta::Name includes PathBuf instead of String

2. Name::render function accepts DisplayOption enum value
    DisplayOption::FileName: draw file name(using when drawing tree)
    DisplayOption::Relative{ base_path }: draw relative path to base_path
    DisplayOption::None: draw path it self

3. the file path passed directly has None DisplayOption. so it can draw file paths like ls
    $ lsd ../Cargo.*
     ../Cargo.lock  ../Cargo.toml
    
    $ lsd meta/.rs
     meta/date.rs  meta/inode.rs  meta/owner.rs  meta/symlink.rs
     meta/filetype.rs  meta/mod.rs  meta/permissions.rs  meta/windows_utils.rs
     meta/indicator.rs  meta/name.rs  meta/size.rs
    
    $ lsd /home/dvvv/src/lsd/src/.rs
     /home/dvvv/src/lsd/src/app.rs  /home/dvvv/src/lsd/src/flags.rs
     /home/dvvv/src/lsd/src/color.rs  /home/dvvv/src/lsd/src/icon.rs
     /home/dvvv/src/lsd/src/core.rs  /home/dvvv/src/lsd/src/main.rs
     /home/dvvv/src/lsd/src/display.rs  /home/dvvv/src/lsd/src/sort.rs
    
4. also, recursive directory listing has Relative DisplayOption, so it looks like ls and previous lsd
    $ lsd src/*
     src/app.rs   src/color.rs   src/core.rs   src/display.rs   src/flags.rs   src/icon.rs   src/main.rs   src/sort.rs

    src/meta:
     date.rs       indicator.rs   mod.rs    owner.rs         size.rs      windows_utils.rs
     filetype.rs   inode.rs       name.rs   permissions.rs   symlink.rs

i don't think this pull request looks rusty. The Name structure must always have a PathBuf: This is a duplicate of the Meta structure.
I've tried changing it to a Path reference that refers to Meta's PathBuf, but that's not possible because move occurs when the Meta structure is created(as far as I know) .
I've tried changing the Name structure to a Path structure, but that doesn't fit the module named Meta.
I would like to hear you guys opinion.