### PR TITLE
Improve Go icon readability

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -219,7 +219,7 @@ impl Icons {
         m.insert("gform", "\u{f298}"); // ""
         m.insert("gif", "\u{f1c5}"); // ""
         m.insert("git", "\u{f1d3}"); // ""
-        m.insert("go", "\u{e626}"); // ""
+        m.insert("go", "\u{e627}"); // ""
         m.insert("gradle", "\u{e70e}"); // ""
         m.insert("gsheet", "\u{f1c3}"); // ""
         m.insert("gslides", "\u{f1c4}"); // ""


### PR DESCRIPTION
Use the filled icon instead of the outlined version

![image](https://user-images.githubusercontent.com/15048443/75883873-08576400-5e24-11ea-9f71-06fb000e8c5e.png)

it's a bit creepier but definitely looks better