### PR TITLE
delete fs canonicalize for showing broken softlink without error

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn main() {
         }
     }
 
-    let var = std::env::var_os("SHELL_COMPLETIONS_DIR").or(std::env::var_os("OUT_DIR"));
+    let var = std::env::var_os("SHELL_COMPLETIONS_DIR").or_else(|| std::env::var_os("OUT_DIR"));
     let outdir = match var {
         None => return,
         Some(outdir) => outdir,

--- a/src/app.rs
+++ b/src/app.rs
@@ -220,9 +220,8 @@ pub fn build() -> App<'static, 'static> {
 }
 
 fn validate_date_argument(arg: String) -> Result<(), String> {
-    use std::error::Error;
     if arg.starts_with('+') {
-        validate_time_format(&arg).map_err(|err| err.description().to_string())
+        validate_time_format(&arg).map_err(|err| err.to_string())
     } else if &arg == "date" || &arg == "relative" {
         Result::Ok(())
     } else {

--- a/src/core.rs
+++ b/src/core.rs
@@ -85,7 +85,7 @@ impl Core {
             let mut meta = match Meta::from_path(&path) {
                 Ok(meta) => meta,
                 Err(err) => {
-                    print_error!("cannot access '{}': {}", path.display(), err);
+                    print_error!("lsd: {}: {}\n", path.display(), err);
                     continue;
                 }
             };
@@ -101,7 +101,7 @@ impl Core {
                             meta_list.push(meta);
                         }
                         Err(err) => {
-                            print_error!("cannot access '{}': {}", path.display(), err);
+                            print_error!("lsd: {}: {}\n", path.display(), err);
                             continue;
                         }
                     };

--- a/src/core.rs
+++ b/src/core.rs
@@ -4,7 +4,6 @@ use crate::flags::{Display, Flags, IconTheme, Layout, WhenFlag};
 use crate::icon::{self, Icons};
 use crate::meta::Meta;
 use crate::{print_error, print_output, sort};
-use std::fs;
 use std::path::PathBuf;
 
 #[cfg(not(target_os = "windows"))]
@@ -83,11 +82,6 @@ impl Core {
         };
 
         for path in paths {
-            if let Err(err) = fs::canonicalize(&path) {
-                print_error!("cannot access '{}': {}", path.display(), err);
-                continue;
-            }
-
             let mut meta = match Meta::from_path(&path) {
                 Ok(meta) => meta,
                 Err(err) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,10 @@ macro_rules! print_output {
 fn main() {
     let matches = app::build().get_matches_from(wild::args_os());
 
+    // input translate glob FILE without single quote into real names
+    // for example:
+    // * to all files matched
+    // '*' remain as '*'
     let inputs = matches
         .values_of("FILE")
         .expect("failed to retrieve cli value")

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -69,7 +69,7 @@ impl Meta {
         let entries = match self.path.read_dir() {
             Ok(entries) => entries,
             Err(err) => {
-                print_error!("cannot access '{}': {}", self.path.display(), err);
+                print_error!("lsd: {}: {}\n", self.path.display(), err);
                 return Ok(None);
             }
         };
@@ -116,7 +116,7 @@ impl Meta {
             let mut entry_meta = match Self::from_path(&path) {
                 Ok(res) => res,
                 Err(err) => {
-                    print_error!("cannot access '{}': {}", path.display(), err);
+                    print_error!("lsd: {}: {}\n", path.display(), err);
                     continue;
                 }
             };
@@ -124,7 +124,7 @@ impl Meta {
             match entry_meta.recurse_into(depth - 1, display, ignore_globs) {
                 Ok(content) => entry_meta.content = content,
                 Err(err) => {
-                    print_error!("cannot access '{}': {}", path.display(), err);
+                    print_error!("lsd: {}: {}\n", path.display(), err);
                     continue;
                 }
             };
@@ -162,7 +162,7 @@ impl Meta {
         let metadata = match metadata {
             Ok(meta) => meta,
             Err(err) => {
-                print_error!("cannot access '{}': {}", path.display(), err);
+                print_error!("lsd: {}: {}\n", path.display(), err);
                 return 0;
             }
         };
@@ -175,7 +175,7 @@ impl Meta {
             let entries = match path.read_dir() {
                 Ok(entries) => entries,
                 Err(err) => {
-                    print_error!("cannot access '{}': {}", path.display(), err);
+                    print_error!("lsd: {}: {}\n", path.display(), err);
                     return size;
                 }
             };
@@ -183,7 +183,7 @@ impl Meta {
                 let path = match entry {
                     Ok(entry) => entry.path(),
                     Err(err) => {
-                        print_error!("cannot access '{}': {}", path.display(), err);
+                        print_error!("lsd: {}: {}\n", path.display(), err);
                         continue;
                     }
                 };


### PR DESCRIPTION
fix https://github.com/Peltoche/lsd/issues/72

I have checked:
1.  it could report file not existed for not existed files without the `canonicalize`
2. deleting `canonicalize` not broken any tests

And if we add the `canonicalize`, https://github.com/Peltoche/lsd/issues/72 happened