### PR TITLE
Bump up ci/cd rust version to 1.34

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,7 +6,7 @@ env:
   PROJECT_NAME: lsd
   PROJECT_DESC: "An ls command with a lot of pretty colors."
   PROJECT_AUTH: "Peltoche <peltoche@halium.fr>"
-  RUST_MIN_SRV: "1.31.0"
+  RUST_MIN_SRV: "1.34.0"
 
 on: [push, pull_request]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,16 @@ matrix:
 
     # Minimum Rust supported channel.
     - os: linux
-      rust: 1.33.0
+      rust: 1.34.0
       env: TARGET=x86_64-unknown-linux-gnu
     - os: linux
-      rust: 1.33.0
+      rust: 1.34.0
       env: TARGET=i686-unknown-linux-gnu
     - os: osx
-      rust: 1.33.0
+      rust: 1.34.0
       env: TARGET=x86_64-apple-darwin
     - os: linux
-      rust: 1.33.0
+      rust: 1.34.0
       env:
         - TARGET=arm-unknown-linux-gnueabihf
         - CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc-4.8


### PR DESCRIPTION
The minimum rust version of lscolors has been bumped up to 1.34. lsd needs to be updated to 1.34 in order to make the lscolors dependency a problem.
https://github.com/sharkdp/lscolors/commit/936e518d6c3a26a1ddc812d8d40e542b916888b1