### PR TITLE
Hyperlink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,11 +282,17 @@ dependencies = [
  "terminal_size 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wild 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "maybe-uninit"
@@ -309,6 +325,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ppv-lite86"
@@ -416,6 +437,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,9 +519,35 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "smallvec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "users"
@@ -608,17 +660,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum globset 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
 "checksum globwalk 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d9db17aec586697a93219b19726b5b68307eba92898c34b170857343fe67c99d"
 "checksum hermit-abi 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "725cf19794cf90aa94e65050cb4191ff5d8fa87a498383774c47b332e3af952e"
+"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ddf60d063dbe6b75388eec66cfc07781167ae3d34a09e0c433e6c5de0511f7fb"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.68 (registry+https://github.com/rust-lang/crates.io-index)" = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lscolors 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f77452267149eac960ded529fe5f5460ddf792845a1d71b5d0cfcee5642e47e"
+"checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum normalize-line-endings 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 "checksum num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
 "checksum num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+"checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum predicates 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
 "checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
@@ -632,6 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex-syntax 0.6.17 (registry+https://github.com/rust-lang/crates.io-index)" = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum same-file 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+"checksum smallvec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term_grid 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "230d3e804faaed5a39b08319efb797783df2fd9671b39b7596490cb486d702cf"
@@ -641,7 +697,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+"checksum unicode-normalization 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+"checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 "checksum users 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c72f4267aea0c3ec6d07eaabea6ead7c5ddacfafc5e22bcf8d186706851fb4cf"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ unicode-width = "0.1.*"
 lscolors = "0.7"
 wild = "2.0.*"
 globset = "0.4.*"
+url = "2.1.*"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.9.*"

--- a/src/app.rs
+++ b/src/app.rs
@@ -217,6 +217,17 @@ pub fn build() -> App<'static, 'static> {
                 .multiple(true)
                 .help("Display the index number of each file"),
         )
+        .arg(
+            Arg::with_name("hyperlink")
+                .long("hyperlink")
+                .possible_value("always")
+                .possible_value("auto")
+                .possible_value("never")
+                .default_value("auto")
+                .multiple(true)
+                .number_of_values(1)
+                .help("Attach hyperlink to filenames")
+        )
 }
 
 fn validate_date_argument(arg: String) -> Result<(), String> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -226,7 +226,7 @@ pub fn build() -> App<'static, 'static> {
                 .default_value("auto")
                 .multiple(true)
                 .number_of_values(1)
-                .help("Attach hyperlink to filenames")
+                .help("Attach hyperlink to filenames"),
         )
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,5 +1,5 @@
 use crate::color::{ColoredString, Colors};
-use crate::flags::{Block, Display, Flags, Layout};
+use crate::flags::{Block, Display, Flags, Layout, WhenFlag};
 use crate::icon::Icons;
 use crate::meta::{FileType, Meta};
 use ansi_term::{ANSIString, ANSIStrings};
@@ -219,6 +219,7 @@ fn get_output<'a>(
     padding_rules: &HashMap<Block, usize>,
 ) -> Vec<ANSIString<'a>> {
     let mut strings: Vec<ANSIString> = Vec::new();
+    let hyperlink = flags.hyperlink == WhenFlag::Always;
     for block in flags.blocks.iter() {
         match block {
             Block::INode => strings.push(meta.inode.render(colors)),
@@ -242,13 +243,13 @@ fn get_output<'a>(
             Block::Name => {
                 let s: String = if flags.no_symlink {
                     ANSIStrings(&[
-                        meta.name.render(colors, icons),
+                        meta.name.render(colors, icons, &hyperlink),
                         meta.indicator.render(&flags),
                     ])
                     .to_string()
                 } else {
                     ANSIStrings(&[
-                        meta.name.render(colors, icons),
+                        meta.name.render(colors, icons, &hyperlink),
                         meta.indicator.render(&flags),
                         meta.symlink.render(colors),
                     ])
@@ -337,6 +338,7 @@ mod tests {
             let output = name.render(
                 &Colors::new(color::Theme::NoColor),
                 &Icons::new(icon::Theme::NoIcon),
+                &false,
             );
 
             assert_eq!(get_visible_width(&output), *l);
@@ -368,6 +370,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::Fancy),
+                    &false,
                 )
                 .to_string();
 
@@ -399,6 +402,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoLscolors),
                     &Icons::new(icon::Theme::NoIcon),
+                    &false,
                 )
                 .to_string();
 
@@ -434,6 +438,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::NoIcon),
+                    &false,
                 )
                 .to_string();
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -243,13 +243,13 @@ fn get_output<'a>(
             Block::Name => {
                 let s: String = if flags.no_symlink {
                     ANSIStrings(&[
-                        meta.name.render(colors, icons, &hyperlink),
+                        meta.name.render(colors, icons, hyperlink),
                         meta.indicator.render(&flags),
                     ])
                     .to_string()
                 } else {
                     ANSIStrings(&[
-                        meta.name.render(colors, icons, &hyperlink),
+                        meta.name.render(colors, icons, hyperlink),
                         meta.indicator.render(&flags),
                         meta.symlink.render(colors),
                     ])
@@ -338,7 +338,7 @@ mod tests {
             let output = name.render(
                 &Colors::new(color::Theme::NoColor),
                 &Icons::new(icon::Theme::NoIcon),
-                &false,
+                false,
             );
 
             assert_eq!(get_visible_width(&output), *l);
@@ -370,7 +370,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::Fancy),
-                    &false,
+                    false,
                 )
                 .to_string();
 
@@ -402,7 +402,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoLscolors),
                     &Icons::new(icon::Theme::NoIcon),
-                    &false,
+                    false,
                 )
                 .to_string();
 
@@ -438,7 +438,7 @@ mod tests {
                 .render(
                     &Colors::new(color::Theme::NoColor),
                     &Icons::new(icon::Theme::NoIcon),
-                    &false,
+                    false,
                 )
                 .to_string();
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -21,6 +21,7 @@ pub struct Flags {
     pub no_symlink: bool,
     pub total_size: bool,
     pub ignore_globs: GlobSet,
+    pub hyperlink: WhenFlag,
 }
 
 impl Flags {
@@ -33,6 +34,7 @@ impl Flags {
         let date_inputs: Vec<&str> = matches.values_of("date").unwrap().collect();
         let dir_order_inputs: Vec<&str> = matches.values_of("group-dirs").unwrap().collect();
         let ignore_globs_inputs: Vec<&str> = matches.values_of("ignore-glob").unwrap().collect();
+        let hyperlink_inputs: Vec<&str> = matches.values_of("hyperlink").unwrap().collect();
         // inode set layout to oneline and blocks to inode,name
         let inode = matches.is_present("inode");
         let blocks_inputs: Vec<&str> = if let Some(blocks) = matches.values_of("blocks") {
@@ -178,6 +180,11 @@ impl Flags {
             no_symlink: matches.is_present("no-symlink"),
             total_size: matches.is_present("total-size"),
             inode,
+            hyperlink: if classic_mode {
+                WhenFlag::Never
+            } else {
+                WhenFlag::from(hyperlink_inputs[hyperlink_inputs.len() - 1])
+            },
         })
     }
 }
@@ -203,6 +210,7 @@ impl Default for Flags {
             total_size: false,
             ignore_globs: GlobSet::empty(),
             inode: false,
+            hyperlink: WhenFlag::Auto,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ extern crate terminal_size;
 extern crate time;
 extern crate unicode_width;
 extern crate wild;
+extern crate url;
 
 #[cfg(unix)]
 extern crate users;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ extern crate term_grid;
 extern crate terminal_size;
 extern crate time;
 extern crate unicode_width;
-extern crate wild;
 extern crate url;
+extern crate wild;
 
 #[cfg(unix)]
 extern crate users;

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -123,6 +123,7 @@ mod test {
     use crate::meta::Meta;
     #[cfg(unix)]
     use crate::meta::Permissions;
+    #[cfg(unix)]
     use crate::url::Url;
     use ansi_term::Colour;
     use std::cmp::Ordering;

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -243,6 +243,27 @@ mod test {
     }
 
     #[test]
+    #[cfg(unix)]
+    fn test_print_hyperlink() {
+        let tmp_dir = tempdir().expect("failed to create temp dir");
+        let icons = Icons::new(icon::Theme::Fancy);
+
+        // Create the file;
+        let file_path = tmp_dir.path().join("file.txt");
+        File::create(&file_path).expect("failed to create file");
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let colors = Colors::new(color::Theme::NoLscolors);
+        let file_type = FileType::new(&meta, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+
+        assert_eq!(
+            Colour::Fixed(184).paint(" file.txt"),
+            name.render(&colors, &icons, &true)
+        );
+    }
+
+    #[test]
     fn test_extensions_with_valid_file() {
         let path = Path::new("some-file.txt");
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -45,7 +45,8 @@ impl Name {
 
         content += icon.as_str();
         if *hyperlink {
-            let url = Url::from_file_path(&self.path).expect("absolute path");
+            let real_path = std::fs::canonicalize(&self.path).expect("canonicalize");
+            let url = Url::from_file_path(&real_path).expect("absolute path");
 
             // ansi_term does not yet support hyperlink, as such, we must
             // implemented ourselves
@@ -258,7 +259,8 @@ mod test {
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&file_path, file_type);
 
-        let expected_url = Url::from_file_path(file_path).expect("absolute path");
+        let real_path = std::fs::canonicalize(&file_path).expect("canonicalize");
+        let expected_url = Url::from_file_path(&real_path).expect("absolute path");
         let expected_text = format!(" \x1B;;{}\x1B\x5C{}\x1B;;\x1B\x5C", expected_url, "file.txt");
 
         assert_eq!(

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -1,6 +1,7 @@
 use crate::color::{ColoredString, Colors, Elem};
 use crate::icon::Icons;
 use crate::meta::filetype::FileType;
+use crate::url::Url;
 use std::cmp::{Ordering, PartialOrd};
 use std::path::Path;
 
@@ -43,11 +44,24 @@ impl Name {
         let mut content = String::with_capacity(icon.len() + self.name.len() + 3 /* spaces */);
 
         content += icon.as_str();
-        content += if *hyperlink {
-            &self.name // <- TODO: Modify this line to render hyperlink
+        if *hyperlink {
+            let url = Url::from_file_path(&self.path).expect("absolute path");
+
+            // ansi_term does not yet support hyperlink, as such, we must
+            // implemented ourselves
+            // issue: https://github.com/ogham/rust-ansi-term/issues/60
+
+            // activate hyperlink mode
+            content += "\x1B;;";
+            content += url.as_str();
+            content += "\x1B\x5C";
+            content += &self.name;
+
+            // deactivate hyperlink mode
+            content += "\x1B;;\x1B\x5C";
         } else {
-            &self.name
-        };
+            content += &self.name;
+        }
         content
     }
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -38,17 +38,21 @@ impl Name {
         }
     }
 
-    pub fn name_string(&self, icons: &Icons) -> String {
+    pub fn name_string(&self, icons: &Icons, hyperlink: &bool) -> String {
         let icon = icons.get(self);
         let mut content = String::with_capacity(icon.len() + self.name.len() + 3 /* spaces */);
 
         content += icon.as_str();
-        content += &self.name;
+        content += if *hyperlink {
+            &self.name // <- TODO: Modify this line to render hyperlink
+        } else {
+            &self.name
+        };
         content
     }
 
-    pub fn render(&self, colors: &Colors, icons: &Icons) -> ColoredString {
-        let content = self.name_string(&icons);
+    pub fn render(&self, colors: &Colors, icons: &Icons, hyperlink: &bool) -> ColoredString {
+        let content = self.name_string(&icons, &hyperlink);
 
         let elem = match self.file_type {
             FileType::CharDevice => Elem::CharDevice,
@@ -131,7 +135,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint(" file.txt"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, &false)
         );
     }
 
@@ -140,7 +144,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let icons = Icons::new(icon::Theme::Fancy);
 
-        // Chreate the directory
+        // Create the directory
         let dir_path = tmp_dir.path().join("directory");
         fs::create_dir(&dir_path).expect("failed to create the dir");
         let meta = Meta::from_path(&dir_path).unwrap();
@@ -149,7 +153,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(33).paint(" directory"),
-            meta.name.render(&colors, &icons)
+            meta.name.render(&colors, &icons, &false)
         );
     }
 
@@ -176,7 +180,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(44).paint(" target.tmp"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, &false)
         );
     }
 
@@ -202,7 +206,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint(" pipe.tmp"),
-            name.render(&colors, &icons)
+            name.render(&colors, &icons, &false)
         );
     }
 
@@ -220,7 +224,7 @@ mod test {
 
         assert_eq!(
             "file.txt",
-            meta.name.render(&colors, &icons).to_string().as_str()
+            meta.name.render(&colors, &icons, &false).to_string().as_str()
         );
     }
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -53,13 +53,13 @@ impl Name {
             // issue: https://github.com/ogham/rust-ansi-term/issues/60
 
             // activate hyperlink mode
-            content += "\x1B;;";
+            content += "\x1B]8;;";
             content += url.as_str();
             content += "\x1B\x5C";
             content += &self.name;
 
             // deactivate hyperlink mode
-            content += "\x1B;;\x1B\x5C";
+            content += "\x1B]8;;\x1B\x5C";
         } else {
             content += &self.name;
         }
@@ -261,7 +261,7 @@ mod test {
 
         let real_path = std::fs::canonicalize(&file_path).expect("canonicalize");
         let expected_url = Url::from_file_path(&real_path).expect("absolute path");
-        let expected_text = format!(" \x1B;;{}\x1B\x5C{}\x1B;;\x1B\x5C", expected_url, "file.txt");
+        let expected_text = format!(" \x1B]8;;{}\x1B\x5C{}\x1B]8;;\x1B\x5C", expected_url, "file.txt");
 
         assert_eq!(
             Colour::Fixed(184).paint(expected_text),

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -39,12 +39,12 @@ impl Name {
         }
     }
 
-    pub fn name_string(&self, icons: &Icons, hyperlink: &bool) -> String {
+    pub fn name_string(&self, icons: &Icons, hyperlink: bool) -> String {
         let icon = icons.get(self);
         let mut content = String::with_capacity(icon.len() + self.name.len() + 3 /* spaces */);
 
         content += icon.as_str();
-        if *hyperlink {
+        if hyperlink {
             let real_path = std::fs::canonicalize(&self.path).expect("canonicalize");
             let url = Url::from_file_path(&real_path).expect("absolute path");
 
@@ -66,8 +66,8 @@ impl Name {
         content
     }
 
-    pub fn render(&self, colors: &Colors, icons: &Icons, hyperlink: &bool) -> ColoredString {
-        let content = self.name_string(&icons, &hyperlink);
+    pub fn render(&self, colors: &Colors, icons: &Icons, hyperlink: bool) -> ColoredString {
+        let content = self.name_string(&icons, hyperlink);
 
         let elem = match self.file_type {
             FileType::CharDevice => Elem::CharDevice,
@@ -151,7 +151,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint(" file.txt"),
-            name.render(&colors, &icons, &false)
+            name.render(&colors, &icons, false)
         );
     }
 
@@ -169,7 +169,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(33).paint(" directory"),
-            meta.name.render(&colors, &icons, &false)
+            meta.name.render(&colors, &icons, false)
         );
     }
 
@@ -196,7 +196,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(44).paint(" target.tmp"),
-            name.render(&colors, &icons, &false)
+            name.render(&colors, &icons, false)
         );
     }
 
@@ -222,7 +222,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint(" pipe.tmp"),
-            name.render(&colors, &icons, &false)
+            name.render(&colors, &icons, false)
         );
     }
 
@@ -241,7 +241,7 @@ mod test {
         assert_eq!(
             "file.txt",
             meta.name
-                .render(&colors, &icons, &false)
+                .render(&colors, &icons, false)
                 .to_string()
                 .as_str()
         );
@@ -271,7 +271,7 @@ mod test {
 
         assert_eq!(
             Colour::Fixed(184).paint(expected_text),
-            name.render(&colors, &icons, &true)
+            name.render(&colors, &icons, true)
         );
     }
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -121,9 +121,9 @@ mod test {
     use crate::icon::{self, Icons};
     use crate::meta::FileType;
     use crate::meta::Meta;
-    use crate::url::Url;
     #[cfg(unix)]
     use crate::meta::Permissions;
+    use crate::url::Url;
     use ansi_term::Colour;
     use std::cmp::Ordering;
     use std::fs::{self, File};
@@ -240,7 +240,10 @@ mod test {
 
         assert_eq!(
             "file.txt",
-            meta.name.render(&colors, &icons, &false).to_string().as_str()
+            meta.name
+                .render(&colors, &icons, &false)
+                .to_string()
+                .as_str()
         );
     }
 
@@ -261,7 +264,10 @@ mod test {
 
         let real_path = std::fs::canonicalize(&file_path).expect("canonicalize");
         let expected_url = Url::from_file_path(&real_path).expect("absolute path");
-        let expected_text = format!(" \x1B]8;;{}\x1B\x5C{}\x1B]8;;\x1B\x5C", expected_url, "file.txt");
+        let expected_text = format!(
+            " \x1B]8;;{}\x1B\x5C{}\x1B]8;;\x1B\x5C",
+            expected_url, "file.txt"
+        );
 
         assert_eq!(
             Colour::Fixed(184).paint(expected_text),

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -120,6 +120,7 @@ mod test {
     use crate::icon::{self, Icons};
     use crate::meta::FileType;
     use crate::meta::Meta;
+    use crate::url::Url;
     #[cfg(unix)]
     use crate::meta::Permissions;
     use ansi_term::Colour;
@@ -257,8 +258,11 @@ mod test {
         let file_type = FileType::new(&meta, &Permissions::from(&meta));
         let name = Name::new(&file_path, file_type);
 
+        let expected_url = Url::from_file_path(file_path).expect("absolute path");
+        let expected_text = format!(" \x1B;;{}\x1B\x5C{}\x1B;;\x1B\x5C", expected_url, "file.txt");
+
         assert_eq!(
-            Colour::Fixed(184).paint(" file.txt"),
+            Colour::Fixed(184).paint(expected_text),
             name.render(&colors, &icons, &true)
         );
     }


### PR DESCRIPTION
Fix https://github.com/Peltoche/lsd/issues/192

## Preview

![preview: `lsd --hyperlink=always -1`](https://user-images.githubusercontent.com/11488886/79633212-4fa87280-818e-11ea-9748-526dbe1248d5.png)

## Remaining Issues

It works well with `-1` flag, but it prints a [broken list](https://user-images.githubusercontent.com/11488886/79633337-f725a500-818e-11ea-923b-ef747b5b2fcf.png) without it. I can guess this is due to width of filenames not being calculated correctly: It did not strip away ANSI symbols first. I will not try fixing it as reading the source code alone had sucked the energy out of me.
