### PR TITLE
Using rust version on style job

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install `rust` toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: ${{ env.RUST_MIN_SRV }}
         override: true
         profile: minimal # minimal component installation (ie, no documentation)
         components: rustfmt, clippy

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,7 +6,7 @@ env:
   PROJECT_NAME: lsd
   PROJECT_DESC: "An ls command with a lot of pretty colors."
   PROJECT_AUTH: "Peltoche <peltoche@halium.fr>"
-  RUST_MIN_SRV: "1.34.0"
+  RUST_MIN_SRV: "1.43.0"
 
 on: [push, pull_request]
 

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,7 +6,7 @@ env:
   PROJECT_NAME: lsd
   PROJECT_DESC: "An ls command with a lot of pretty colors."
   PROJECT_AUTH: "Peltoche <peltoche@halium.fr>"
-  RUST_MIN_SRV: "1.43.0"
+  RUST_MIN_SRV: "1.43.1"
 
 on: [push, pull_request]
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -1,5 +1,6 @@
 use clap::{ArgMatches, Error, ErrorKind};
 use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::iter::Iterator;
 
 #[derive(Clone, Debug)]
 pub struct Flags {
@@ -78,7 +79,7 @@ impl Flags {
         };
 
         let recursive = matches.is_present("recursive");
-        let recursion_input = matches.values_of("depth").and_then(|values| values.last());
+        let recursion_input = matches.values_of("depth").and_then(Iterator::last);
         let recursion_depth = match recursion_input {
             Some(str) if recursive || layout == Layout::Tree => match str.parse::<usize>() {
                 Ok(val) => val,


### PR DESCRIPTION
clippy corrects to use the new rust std API as the rust version goes up, so we need to apply a minimal rust version to the style job as well.