### PR TITLE
Add case-insensitive matching of known filenames and extensions

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -82,13 +82,13 @@ impl Icons {
             .icons_by_name
             .get(String::from(name.file_name()).to_lowercase().as_str())
         {
-            // Use the known names.
+            // Use the known lower-case names.
             icon
         } else if let Some(icon) = self
             .icons_by_name
             .get(String::from(name.file_name()).to_uppercase().as_str())
         {
-            // Use the known names.
+            // Use the known upper-case names.
             icon
         } else if let Some(icon) = name
             .extension()
@@ -100,13 +100,13 @@ impl Icons {
             self.icons_by_extension
                 .get(String::from(extension).to_lowercase().as_str())
         }) {
-            // Use the known extensions.
+            // Use the known lower-case extensions.
             icon
         } else if let Some(icon) = name.extension().and_then(|extension| {
             self.icons_by_extension
                 .get(String::from(extension).to_uppercase().as_str())
         }) {
-            // Use the known extensions.
+            // Use the known upper-case extensions.
             icon
         } else {
             // Use the default icons.

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -77,13 +77,13 @@ impl Icons {
             "\u{f2dc}" // ""
         } else if let Some(icon) = self
             .icons_by_name
-            .get(String::from(name.file_name()).to_lowercase().as_str())
+            .get(name.file_name().to_lowercase().as_str())
         {
             // Use the known names.
             icon
         } else if let Some(icon) = name.extension().and_then(|extension| {
             self.icons_by_extension
-                .get(String::from(extension).to_lowercase().as_str())
+                .get(extension.to_lowercase().as_str())
         }) {
             // Use the known extensions.
             icon

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -78,10 +78,16 @@ impl Icons {
         } else if let Some(icon) = self.icons_by_name.get(name.file_name()) {
             // Use the known names.
             icon
-        } else if let Some(icon) = self.icons_by_name.get(String::from(name.file_name()).to_lowercase().as_str()) {
+        } else if let Some(icon) = self
+            .icons_by_name
+            .get(String::from(name.file_name()).to_lowercase().as_str())
+        {
             // Use the known names.
             icon
-        } else if let Some(icon) = self.icons_by_name.get(String::from(name.file_name()).to_uppercase().as_str()) {
+        } else if let Some(icon) = self
+            .icons_by_name
+            .get(String::from(name.file_name()).to_uppercase().as_str())
+        {
             // Use the known names.
             icon
         } else if let Some(icon) = name
@@ -90,16 +96,16 @@ impl Icons {
         {
             // Use the known extensions.
             icon
-        } else if let Some(icon) = name
-            .extension()
-            .and_then(|extension| self.icons_by_extension.get(String::from(extension).to_lowercase().as_str()))
-        {
+        } else if let Some(icon) = name.extension().and_then(|extension| {
+            self.icons_by_extension
+                .get(String::from(extension).to_lowercase().as_str())
+        }) {
             // Use the known extensions.
             icon
-        } else if let Some(icon) = name
-            .extension()
-            .and_then(|extension| self.icons_by_extension.get(String::from(extension).to_uppercase().as_str()))
-        {
+        } else if let Some(icon) = name.extension().and_then(|extension| {
+            self.icons_by_extension
+                .get(String::from(extension).to_uppercase().as_str())
+        }) {
             // Use the known extensions.
             icon
         } else {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -78,9 +78,27 @@ impl Icons {
         } else if let Some(icon) = self.icons_by_name.get(name.file_name()) {
             // Use the known names.
             icon
+        } else if let Some(icon) = self.icons_by_name.get(String::from(name.file_name()).to_lowercase().as_str()) {
+            // Use the known names.
+            icon
+        } else if let Some(icon) = self.icons_by_name.get(String::from(name.file_name()).to_uppercase().as_str()) {
+            // Use the known names.
+            icon
         } else if let Some(icon) = name
             .extension()
             .and_then(|extension| self.icons_by_extension.get(extension))
+        {
+            // Use the known extensions.
+            icon
+        } else if let Some(icon) = name
+            .extension()
+            .and_then(|extension| self.icons_by_extension.get(String::from(extension).to_lowercase().as_str()))
+        {
+            // Use the known extensions.
+            icon
+        } else if let Some(icon) = name
+            .extension()
+            .and_then(|extension| self.icons_by_extension.get(String::from(extension).to_uppercase().as_str()))
         {
             // Use the known extensions.
             icon

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -75,38 +75,17 @@ impl Icons {
             "\u{fc29}" // "ﰩ"
         } else if let FileType::Special = file_type {
             "\u{f2dc}" // ""
-        } else if let Some(icon) = self.icons_by_name.get(name.file_name()) {
-            // Use the known names.
-            icon
         } else if let Some(icon) = self
             .icons_by_name
             .get(String::from(name.file_name()).to_lowercase().as_str())
         {
-            // Use the known lower-case names.
-            icon
-        } else if let Some(icon) = self
-            .icons_by_name
-            .get(String::from(name.file_name()).to_uppercase().as_str())
-        {
-            // Use the known upper-case names.
-            icon
-        } else if let Some(icon) = name
-            .extension()
-            .and_then(|extension| self.icons_by_extension.get(extension))
-        {
-            // Use the known extensions.
+            // Use the known names.
             icon
         } else if let Some(icon) = name.extension().and_then(|extension| {
             self.icons_by_extension
                 .get(String::from(extension).to_lowercase().as_str())
         }) {
-            // Use the known lower-case extensions.
-            icon
-        } else if let Some(icon) = name.extension().and_then(|extension| {
-            self.icons_by_extension
-                .get(String::from(extension).to_uppercase().as_str())
-        }) {
-            // Use the known upper-case extensions.
+            // Use the known extensions.
             icon
         } else {
             // Use the default icons.
@@ -119,7 +98,9 @@ impl Icons {
     fn get_default_icons_by_name() -> HashMap<&'static str, &'static str> {
         let mut m = HashMap::new();
 
-        m.insert(".Trash", "\u{f1f8}"); // ""
+        // Note: filenames must be lower-case
+
+        m.insert(".trash", "\u{f1f8}"); // ""
         m.insert(".atom", "\u{e764}"); // ""
         m.insert(".bashprofile", "\u{e615}"); // ""
         m.insert(".bashrc", "\u{f489}"); // ""
@@ -159,6 +140,8 @@ impl Icons {
 
     fn get_default_icons_by_extension() -> HashMap<&'static str, &'static str> {
         let mut m = HashMap::new();
+
+        // Note: extensions must be lower-case
 
         m.insert("7z", "\u{f410}"); // ""
         m.insert("apk", "\u{e70e}"); // ""

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -404,3 +404,67 @@ fn cmd() -> Command {
 fn tempdir() -> assert_fs::TempDir {
     assert_fs::TempDir::new().unwrap()
 }
+
+#[cfg(unix)]
+#[test]
+fn test_lower_case_name_icon_match() {
+    let dir = tempdir();
+    dir.child(".trash").touch().unwrap();
+    let test_file = dir.path().join(".trash");
+
+    cmd()
+        .arg("--icon")
+        .arg("always")
+        .arg("--ignore-config")
+        .arg(test_file)
+        .assert()
+        .stdout(predicate::str::contains("\u{f1f8}"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_upper_case_name_icon_match() {
+    let dir = tempdir();
+    dir.child(".TRASH").touch().unwrap();
+    let test_file = dir.path().join(".TRASH");
+
+    cmd()
+        .arg("--icon")
+        .arg("always")
+        .arg("--ignore-config")
+        .arg(test_file)
+        .assert()
+        .stdout(predicate::str::contains("\u{f1f8}"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_lower_case_ext_icon_match() {
+    let dir = tempdir();
+    dir.child("test.7z").touch().unwrap();
+    let test_file = dir.path().join("test.7z");
+
+    cmd()
+        .arg("--icon")
+        .arg("always")
+        .arg("--ignore-config")
+        .arg(test_file)
+        .assert()
+        .stdout(predicate::str::contains("\u{f410}"));
+}
+
+#[cfg(unix)]
+#[test]
+fn test_upper_case_ext_icon_match() {
+    let dir = tempdir();
+    dir.child("test.7Z").touch().unwrap();
+    let test_file = dir.path().join("test.7Z");
+
+    cmd()
+        .arg("--icon")
+        .arg("always")
+        .arg("--ignore-config")
+        .arg(test_file)
+        .assert()
+        .stdout(predicate::str::contains("\u{f410}"));
+}


### PR DESCRIPTION
Although this achieves what I set out to do, I fully expect that there's a more idiomatic way of doing it, so I'm expecting changes to be requested

The main reason for this change is that I had a dockerfile that had a capital 'd' and therefore it didn't match anything in the known filename hash set. I figured that the same logic should apply to extensions, too

Feel free to reject this, too, as I know it's an edge case and some would argue that a dockerfile with a capital 'd' doesn't deserve to have a nice icon haha