### PR TITLE
Escape special chars in filename like `\t` and `\n`

### DIFF
--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -521,4 +521,37 @@ mod test {
             name.relative_path(base_path),
         )
     }
+
+    #[test]
+    fn test_special_chars_in_filename() {
+        let tmp_dir = tempdir().expect("failed to create temp dir");
+        let icons = Icons::new(icon::Theme::Fancy);
+
+        // Create the file;
+        let file_path = tmp_dir.path().join("file\ttab.txt");
+        File::create(&file_path).expect("failed to create file");
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let colors = Colors::new(color::Theme::NoLscolors);
+        let file_type = FileType::new(&meta, None, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+
+        assert_eq!(
+            Colour::Fixed(184).paint(" file\\ttab.txt"),
+            name.render(&colors, &icons, &DisplayOption::FileName)
+        );
+
+        let file_path = tmp_dir.path().join("file\ntab.txt");
+        File::create(&file_path).expect("failed to create file");
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let colors = Colors::new(color::Theme::NoLscolors);
+        let file_type = FileType::new(&meta, None, &Permissions::from(&meta));
+        let name = Name::new(&file_path, file_type);
+
+        assert_eq!(
+            Colour::Fixed(184).paint(" file\\ntab.txt"),
+            name.render(&colors, &icons, &DisplayOption::FileName)
+        );
+    }
 }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -523,6 +523,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_special_chars_in_filename() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let icons = Icons::new(icon::Theme::Fancy);
@@ -541,7 +542,7 @@ mod test {
             name.render(&colors, &icons, &DisplayOption::FileName)
         );
 
-        let file_path = tmp_dir.path().join("file\ntab.txt");
+        let file_path = tmp_dir.path().join("file\nnewline.txt");
         File::create(&file_path).expect("failed to create file");
         let meta = file_path.metadata().expect("failed to get metas");
 
@@ -550,7 +551,7 @@ mod test {
         let name = Name::new(&file_path, file_type);
 
         assert_eq!(
-            Colour::Fixed(184).paint(" file\\ntab.txt"),
+            Colour::Fixed(184).paint(" file\\nnewline.txt"),
             name.render(&colors, &icons, &DisplayOption::FileName)
         );
     }


### PR DESCRIPTION
- Basic fix for https://github.com/Peltoche/lsd/issues/335
- Might also fix this https://github.com/Peltoche/lsd/issues/325

Before it would put a tab instead of `\t` in the filename. Same for `\n`.