### PR TITLE
Add installation instructions for Windows via Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ environment.systemPackages = with pkgs; [
 pkg install lsd
 ```
 
+### On Windows
+Install with [Scoop](https://scoop.sh):
+```powershell
+scoop install lsd
+```
+
 ### From Sources
 
 With Rust's package manager cargo, you can install lsd via:


### PR DESCRIPTION
I think it'd be helpful for Windows folks to know that lsd is available on scoop as well.