### PR TITLE
Improve help for "--ignore-glob" argument

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -208,7 +208,7 @@ pub fn build() -> App<'static, 'static> {
                 .number_of_values(1)
                 .value_name("pattern")
                 .default_value("")
-                .help("Do not display files/directories with names matching the glob pattern(s)"),
+                .help("Do not display files/directories with names matching the glob pattern(s). More than one be specified by repeating the argument"),
         )
         .arg(
             Arg::with_name("inode")

--- a/src/app.rs
+++ b/src/app.rs
@@ -208,7 +208,7 @@ pub fn build() -> App<'static, 'static> {
                 .number_of_values(1)
                 .value_name("pattern")
                 .default_value("")
-                .help("Do not display files/directories with names matching the glob pattern(s). More than one be specified by repeating the argument"),
+                .help("Do not display files/directories with names matching the glob pattern(s). More than one can be specified by repeating the argument"),
         )
         .arg(
             Arg::with_name("inode")


### PR DESCRIPTION
It is not quite clear if and how you can specify more than on glob to ignore. The addition to the help text should clear that up.
