### PR TITLE
Show contents for symlink folders instead of folder

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -95,12 +95,7 @@ impl Core {
                     meta_list.push(meta);
                 }
                 _ => {
-                    match meta.recurse_into(
-                        depth,
-                        self.flags.display,
-                        &self.flags.ignore_globs,
-                        self.flags.dereference,
-                    ) {
+                    match meta.recurse_into(depth, &self.flags) {
                         Ok(content) => {
                             meta.content = content;
                             meta_list.push(meta);

--- a/src/display.rs
+++ b/src/display.rs
@@ -68,7 +68,8 @@ fn inner_display_grid(
         // Maybe skip showing the directory meta now; show its contents later.
         if skip_dirs
             && (matches!(meta.file_type, FileType::Directory{..})
-                || matches!(meta.file_type, FileType::SymLink { is_dir: true }))
+                || (matches!(meta.file_type, FileType::SymLink { is_dir: true })
+                    && flags.layout != Layout::OneLine))
         {
             continue;
         }
@@ -109,7 +110,7 @@ fn inner_display_grid(
         output += &grid.fit_into_columns(flags.blocks.len()).to_string();
     }
 
-    let should_display_folder_path = should_display_folder_path(depth, &metas);
+    let should_display_folder_path = should_display_folder_path(depth, &metas, &flags);
 
     // print the folder content
     for meta in metas {
@@ -218,7 +219,7 @@ fn inner_display_tree(
     output
 }
 
-fn should_display_folder_path(depth: usize, metas: &[Meta]) -> bool {
+fn should_display_folder_path(depth: usize, metas: &[Meta], flags: &Flags) -> bool {
     if depth > 0 {
         true
     } else {
@@ -226,7 +227,8 @@ fn should_display_folder_path(depth: usize, metas: &[Meta]) -> bool {
             .iter()
             .filter(|x| {
                 matches!(x.file_type, FileType::Directory { .. })
-                    || matches!(x.file_type, FileType::SymLink { is_dir: true })
+                    || (matches!(x.file_type, FileType::SymLink { is_dir: true })
+                        && flags.layout != Layout::OneLine)
             })
             .count();
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -66,7 +66,10 @@ fn inner_display_grid(
     // print the files first.
     for meta in metas {
         // Maybe skip showing the directory meta now; show its contents later.
-        if let (true, FileType::Directory { .. }) = (skip_dirs, meta.file_type) {
+        if skip_dirs
+            && (matches!(meta.file_type, FileType::Directory{..})
+                || matches!(meta.file_type, FileType::SymLink { is_dir: true }))
+        {
             continue;
         }
 
@@ -221,7 +224,10 @@ fn should_display_folder_path(depth: usize, metas: &[Meta]) -> bool {
     } else {
         let folder_number = metas
             .iter()
-            .filter(|x| matches!(x.file_type, FileType::Directory { .. }))
+            .filter(|x| {
+                matches!(x.file_type, FileType::Directory { .. })
+                    || matches!(x.file_type, FileType::SymLink { is_dir: true })
+            })
             .count();
 
         folder_number > 1 || folder_number < metas.len()

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -63,6 +63,7 @@ impl Meta {
 
         match self.file_type {
             FileType::Directory { .. } => (),
+            FileType::SymLink { is_dir: true } => (),
             _ => return Ok(None),
         }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -204,6 +204,21 @@ fn test_dereference_link_right_type_and_no_link() {
         .stdout(predicate::str::contains(link_icon).not());
 }
 
+#[cfg(unix)]
+#[test]
+fn test_show_folder_content_of_symlink() {
+    let dir = tempdir();
+    dir.child("target").child("inside").touch().unwrap();
+    let link = dir.path().join("link");
+    fs::symlink("target", &link).unwrap();
+
+    cmd()
+        .arg(link)
+        .assert()
+        .stdout(predicate::str::starts_with("link").not())
+        .stdout(predicate::str::starts_with("inside"));
+}
+
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }


### PR DESCRIPTION
fix #345

---

For some reason in gnu ls with `-l`, the previous behavior was correct.

```
= gls -l templ
lrwxr-xr-x 1 meain wheel 4 Aug 22 00:26 templ -> temp

= gls -l templ/
total 0
-rw-r--r-- 1 meain wheel 0 Aug 22 00:26 one
-rw-r--r-- 1 meain wheel 0 Aug 22 00:26 two

= gls templ
one  two

= gls templ/
one  two
```