### PR TITLE
Use last sort flag for sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Added
 - Add support for `--extensionsort` `-X` from [aldhsu](https://github.com/aldhsu)
+### Changed
+- Use last sort flag for sort field from [meain](https://github.com/meain)
 
 ## [0.18.0] - 2020-08-29
 ### Added

--- a/src/app.rs
+++ b/src/app.rs
@@ -144,6 +144,8 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("timesort")
                 .short("t")
                 .long("timesort")
+                .overrides_with("sizesort")
+                .overrides_with("extensionsort")
                 .multiple(true)
                 .help("Sort by time modified"),
         )
@@ -151,6 +153,8 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("sizesort")
                 .short("S")
                 .long("sizesort")
+                .overrides_with("timesort")
+                .overrides_with("extensionsort")
                 .multiple(true)
                 .help("Sort by size"),
         )
@@ -158,6 +162,8 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("extensionsort")
                 .short("X")
                 .long("extensionsort")
+                .overrides_with("sizesort")
+                .overrides_with("timesort")
                 .multiple(true)
                 .help("Sort by file extension"),
         )

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -361,6 +361,7 @@ pub enum Layout {
 #[cfg(test)]
 mod test {
     use super::Flags;
+    use super::SortFlag;
     use crate::app;
     use clap::ErrorKind;
 
@@ -406,5 +407,32 @@ mod test {
 
         assert!(res.is_ok());
         assert_eq!(res.unwrap().recursion_depth, usize::max_value());
+    }
+
+    #[test]
+    fn test_multi_sort_use_last() {
+        let matches = app::build()
+            .get_matches_from_safe(vec!["lsd", "-t", "-S"])
+            .unwrap();
+        let res = Flags::from_matches(&matches);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().sort_by, SortFlag::Size);
+
+        let matches = app::build()
+            .get_matches_from_safe(vec!["lsd", "-S", "-t"])
+            .unwrap();
+        let res = Flags::from_matches(&matches);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().sort_by, SortFlag::Time);
+
+        let matches = app::build()
+            .get_matches_from_safe(vec!["lsd", "-t", "-S", "-X"])
+            .unwrap();
+        let res = Flags::from_matches(&matches);
+
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap().sort_by, SortFlag::Extension);
     }
 }


### PR DESCRIPTION
Previously the order was predefined in the binary based on all the ones
that we had. Now we can use the last sort arg passed as the index to
sort.