### PR TITLE
Add a minimal emoji theme

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -48,10 +48,11 @@ pub fn build() -> App<'static, 'static> {
                 .long("icon-theme")
                 .possible_value("fancy")
                 .possible_value("unicode")
+                .possible_value("emoji")
                 .default_value("fancy")
                 .multiple(true)
                 .number_of_values(1)
-                .help("Whether to use fancy or unicode icons"),
+                .help("Which icon theme to use"),
         )
         .arg(
             Arg::with_name("indicators")

--- a/src/core.rs
+++ b/src/core.rs
@@ -49,6 +49,7 @@ impl Core {
             (_, WhenFlag::Never, _) | (false, WhenFlag::Auto, _) => icon::Theme::NoIcon,
             (_, _, IconTheme::Fancy) => icon::Theme::Fancy,
             (_, _, IconTheme::Unicode) => icon::Theme::Unicode,
+            (_, _, IconTheme::Emoji) => icon::Theme::Emoji,
         };
 
         if !tty_available {

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -342,6 +342,7 @@ impl<'a> From<&'a str> for DirOrderFlag {
 pub enum IconTheme {
     Unicode,
     Fancy,
+    Emoji,
 }
 
 impl<'a> From<&'a str> for IconTheme {
@@ -349,6 +350,7 @@ impl<'a> From<&'a str> for IconTheme {
         match theme {
             "fancy" => IconTheme::Fancy,
             "unicode" => IconTheme::Unicode,
+            "emoji" => IconTheme::Emoji,
             _ => panic!("invalid \"icon-theme\" flag: {}", theme),
         }
     }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -14,6 +14,7 @@ pub enum Theme {
     NoIcon,
     Fancy,
     Unicode,
+    Emoji,
 }
 
 const ICON_SPACE: &str = " ";
@@ -24,22 +25,27 @@ const ICON_SPACE: &str = " ";
 // s#\\u[0-9a-f]*#\=eval('"'.submatch(0).'"')#
 impl Icons {
     pub fn new(theme: Theme) -> Self {
-        let display_icons = theme == Theme::Fancy || theme == Theme::Unicode;
+        let display_icons = theme != Theme::NoIcon;
         let (icons_by_name, icons_by_extension, default_file_icon, default_folder_icon) =
-            if theme == Theme::Fancy {
-                (
+            match theme {
+                Theme::Emoji => (
+                    HashMap::new(),
+                    HashMap::new(),
+                    "\u{1f4c3}", // 📃
+                    "\u{1f4c2}", // 📂
+                ),
+                Theme::Fancy => (
                     Self::get_default_icons_by_name(),
                     Self::get_default_icons_by_extension(),
                     "\u{f016}", // 
                     "\u{f115}", // 
-                )
-            } else {
-                (
+                ),
+                _ => (
                     HashMap::new(),
                     HashMap::new(),
                     "\u{1f5cb}", // 🗋
                     "\u{1f5c1}", // 🗁
-                )
+                ),
             };
 
         Self {


### PR DESCRIPTION
Add a minimal emoji-based theme. Many terminal implementations support color emojis out of the box nowadays. This, for example, is on a Gnome Terminal on Fedora 32, with no configuration whatsoever:

![Screenshot from 2020-09-25 15-30-23](https://user-images.githubusercontent.com/110678/94317718-185f9e00-ff44-11ea-84a3-40abe33794a5.png)
