### PR TITLE
skip extension if no ext found

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -77,7 +77,7 @@ jobs:
       shell: bash
       run: |
         case ${{ matrix.job.target }} in
-          arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf python3 ;;
+          arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
         esac
     - name: Initialize workflow variables
       id: vars

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -77,7 +77,7 @@ jobs:
       shell: bash
       run: |
         case ${{ matrix.job.target }} in
-          arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf python3 ;;
         esac
     - name: Initialize workflow variables
       id: vars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add support for using a config file [kmoschcau](https://github.com/kmoschcau)
 - Add support for `--extensionsort` `-X` from [aldhsu](https://github.com/aldhsu)
+- Add support for `--versionsort` `-v` from [zwpaper](https://github.com/zwpaper)
 ### Changed
 - Use last sort flag for sort field from [meain](https://github.com/meain)
+### Fixed
+- Fix group name show in gid from [zwpaper](https://github.com/zwpaper)
+- Fix panic caused by invalid UTF-8 chars in extension from [zwpaper](https://github.com/zwpaper) and [0jdxt](https://github.com/0jdxt)
 
 ## [0.18.0] - 2020-08-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 This project is heavily inspired by the super [colorls](https://github.com/athityakumar/colorls)
 project but with some little differences.  For example it is written in rust and not in ruby which makes it much faster.
 
+`lsd` will try to display the UTF-8 chars in file name, A `U+FFFD REPLACEMENT CHARACTER`(�) is used to replace the invalid UTF-8 code.
+
 ## Screenshot
 
 ![image](https://raw.githubusercontent.com/Peltoche/lsd/assets/screen_lsd.png)

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 This project is heavily inspired by the super [colorls](https://github.com/athityakumar/colorls)
 project but with some little differences.  For example it is written in rust and not in ruby which makes it much faster.
 
-`lsd` will try to display the UTF-8 chars in file name, A `U+FFFD REPLACEMENT CHARACTER`(�) is used to replace the invalid UTF-8 code.
-
 ## Screenshot
 
 ![image](https://raw.githubusercontent.com/Peltoche/lsd/assets/screen_lsd.png)
@@ -141,7 +139,7 @@ On non-Windows systems `lsd` follows the
 [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
 convention for the location of the configuration file. The configuration dir
 `lsd` uses is itself named `lsd`. In that directory it looks first for a file
-called `config.yaml` and if it can't find one, a file named `config.yml`.  
+called `config.yaml` and if it can't find one, a file named `config.yml`.
 For most people it should be enough to put their config file at
 `~/.config/lsd/config.yaml`.
 
@@ -309,7 +307,9 @@ For now, the default colors are:
 ||![#d75f87](https://placehold.it/17/d75f87/000000?text=+) No Access|![#00d7d7](https://placehold.it/17/00d7d7/000000?text=+) Pipe/Symlink/Blockdevice/Socket/Special|||
 |||![#d78700](https://placehold.it/17/d78700/000000?text=+) CharDevice|||
 
+### UTF-8 Chars
 
+`lsd` will try to display the UTF-8 chars in file name, A `U+FFFD REPLACEMENT CHARACTER`(�) is used to represent the invalid UTF-8 chars.
 
 ## Contributors
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -27,12 +27,9 @@ impl Name {
             None => path.to_string_lossy().to_string(),
         };
 
-        let mut extension = None;
-        if let Some(res) = path.extension() {
-            if let Some(res) = res.to_str() {
-                extension = Some(res.to_string());
-            }
-        }
+        let extension = path
+            .extension()
+            .map(|ext| ext.to_string_lossy().to_string());
 
         Self {
             name,

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -29,11 +29,9 @@ impl Name {
 
         let mut extension = None;
         if let Some(res) = path.extension() {
-            extension = Some(
-                res.to_str()
-                    .expect("failed to encode file name")
-                    .to_string(),
-            );
+            if let Some(res) = res.to_str() {
+                extension = Some(res.to_string());
+            }
         }
 
         Self {
@@ -91,7 +89,6 @@ impl Name {
             for c in string.chars() {
                 // The `escape_default` method on `char` is *almost* what we want here, but
                 // it still escapes non-ASCII UTF-8 characters, which are still printable.
-
                 if c >= 0x20 as char && c != 0x7f as char {
                     chars.push(c);
                 } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -362,6 +362,42 @@ fn test_version_sort_overwrite_by_sizesort() {
         .stdout(predicate::str::is_match("11\n2\n$").unwrap());
 }
 
+#[test]
+#[cfg(target_os = "linux")]
+fn test_bad_utf_8_extension() {
+    let tmp = tempdir();
+    Command::new("python3")
+        .arg("-c")
+        .arg(format!(
+            r#"import pathlib; pathlib.Path('{}/bad.extension\udca7\udcfd').touch()"#,
+            tmp.path().to_str().unwrap()
+        ))
+        .output()
+        .expect("failed to create file");
+    cmd()
+        .arg(tmp.path())
+        .assert()
+        .stdout(predicate::str::is_match("bad.extension\u{fffd}\u{fffd}\n$").unwrap());
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_bad_utf_8_name() {
+    let tmp = tempdir();
+    Command::new("python3")
+        .arg("-c")
+        .arg(format!(
+            r#"import pathlib; pathlib.Path('{}/bad-name\udca7\udcfd.ext').touch()"#,
+            tmp.path().to_str().unwrap()
+        ))
+        .output()
+        .expect("failed to create file");
+    cmd()
+        .arg(tmp.path())
+        .assert()
+        .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
+}
+
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }


### PR DESCRIPTION
fix https://github.com/Peltoche/lsd/issues/387

I also found the output is a little bit different like ls, as `lsd` will display the UTF-8 in file names, It seems like work as expect IMO. If necessary we can discuss this in a new issue. @meain 

ls:
```
[root@b78708e2fc75 tmp]# \ls
'5a35.ico'$'\247\375''='$'\356\324\373\206\362\300''^m'$'\330'
```

lsd:

```
[root@b78708e2fc75 tmp]# lsd
 5a35.ico��=������^m�
```

FYI:
the utf8 code in the filename is reserved for utf-16(https://en.wikipedia.org/wiki/UTF-16#U+D800_to_U+DFFF), and rust will check this by default.

Following the rust way, we display the reserved chars as �