### PR TITLE
Add --auto-all which shows dotfiles based on count

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,17 @@ pub fn build() -> App<'static, 'static> {
                 .help("Do not list implied . and .."),
         )
         .arg(
+            Arg::with_name("auto-all")
+                .overrides_with("almost-all")
+                .overrides_with("all")
+                .conflicts_with("tree")
+                .long("auto-all")
+                .takes_value(true)
+                .value_name("threshold")
+                .validator(|s| s.parse::<u32>().map_err(|_| "auto-all threshold must be non-negative".to_owned()).map(|_| ()))
+                .help("Show dotfiles (excluding . and ..) if the number of dotfiles is fewer than specified number"),
+        )
+        .arg(
             Arg::with_name("color")
                 .long("color")
                 .possible_value("always")

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -13,6 +13,7 @@ use yaml_rust::Yaml;
 pub enum Display {
     All,
     AlmostAll,
+    AutoAll(u32),
     DirectoryItself,
     DisplayOnlyVisible,
 }
@@ -44,6 +45,15 @@ impl Configurable<Self> for Display {
             Some(Self::All)
         } else if matches.is_present("almost-all") {
             Some(Self::AlmostAll)
+        } else if matches.is_present("auto-all") {
+            // the value is pre-validated
+            Some(Self::AutoAll(
+                matches
+                    .value_of("auto-all")
+                    .unwrap()
+                    .parse::<u32>()
+                    .unwrap(),
+            ))
         } else if matches.is_present("directory-only") {
             Some(Self::DirectoryItself)
         } else {

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -121,16 +121,19 @@ impl Meta {
 
             if let Display::AutoAll(threshold) = flags.display {
                 if name.to_string_lossy().starts_with('.') {
-                    if dotfiles_count < threshold {
-                        dotfiles_count += 1;
+                    use std::cmp::Ordering::*;
+                    match dotfiles_count.cmp(&threshold) {
+                        Less => {
+                            dotfiles_count += 1;
 
-                        // save to temporary content, will be pushed to head later
-                        dotfiles_content.push(entry_meta);
-                    } else if dotfiles_count == threshold {
-                        // only clean up once
-                        dotfiles_content.clear();
-                    } else {
-                        continue;
+                            // save to temporary content, will be pushed to head later
+                            dotfiles_content.push(entry_meta);
+                        }
+                        Equal => {
+                            // only clean up once
+                            dotfiles_content.clear();
+                        }
+                        _ => continue,
                     }
 
                     // conflict with --tree, so safely skip recurse_into

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -98,6 +98,34 @@ fn test_list_all_populated_directory() {
 }
 
 #[test]
+fn test_list_autoall_showing_dotfiles() {
+    let dir = tempdir();
+    dir.child(".one").touch().unwrap();
+    dir.child(".two").touch().unwrap();
+    cmd()
+        .arg("--ignore-config")
+        .arg("--auto-all")
+        .arg("2")
+        .arg(dir.path())
+        .assert()
+        .stdout(predicate::str::is_match(".one\n.two\n$").unwrap());
+}
+
+#[test]
+fn test_list_autoall_hiding_dotfiles() {
+    let dir = tempdir();
+    dir.child(".one").touch().unwrap();
+    dir.child(".two").touch().unwrap();
+    cmd()
+        .arg("--ignore-config")
+        .arg("--auto-all")
+        .arg("1")
+        .arg(dir.path())
+        .assert()
+        .stdout(predicate::eq(""));
+}
+
+#[test]
 fn test_list_inode_populated_directory() {
     let dir = tempdir();
     dir.child("one").touch().unwrap();


### PR DESCRIPTION
This originates from some frustration dealing with Terraform during my day job. So Terraform requires running `init` first and it will download a bunch of things into the `.terraform` directory, and I often find I want to quickly know whether such folder exist before running other commands to avoid hitting errors only due to not running `init` - this is further complicated because we have a lot of Terraform projects and I also clean up some of those from my disk from time to time, so it's hard to know by heart which of those I've already `init`ed.

I've always relied on a custom alias `ll` which over the years switched from vanilla `ls` to `lsd` so I've always had to do `ll` once before I remember I need `ll -a` to see "all the things". After a couple times in a short period of time I wondered if this could be improved, so this is an idea that I think can greatly help the situation.

With these changes `lsd --auto-all 5` would behave like this:

In a folder with fewer than 5 dotfiles, it shows all of them:

```
<$> ll
drwxr-xr-x 160 B  aquarhead 2020-09-25 15:09 .terraform/
.rw-r--r-- 1.0 KB aquarhead 2020-09-30 15:09 main.tf
.rw-r--r-- 373 B  aquarhead 2020-09-25 15:09 output.tf
```

Or for `lsd` repo itself (exactly 5)

```
<$> ll
drwxr-xr-x 416 B  aquarhead 2020-10-02 19:10 .git/
drwxr-xr-x 160 B  aquarhead 2020-10-02 15:10 .github/
drwxr-xr-x 160 B  aquarhead 2020-10-02 15:10 ci/
drwxr-xr-x 416 B  aquarhead 2020-10-02 15:10 src/
drwxr-xr-x 192 B  aquarhead 2020-10-02 19:10 target/
drwxr-xr-x  96 B  aquarhead 2020-10-02 15:10 tests/
.rw-r--r--  26 B  aquarhead 2020-10-02 15:10 .gitignore
.rw-r--r-- 352 B  aquarhead 2020-10-02 15:10 .release.toml
.rw-r--r-- 3.7 KB aquarhead 2020-10-02 15:10 .travis.yml
.rw-r--r-- 1.3 KB aquarhead 2020-10-02 15:10 build.rs
.rw-r--r--  18 KB aquarhead 2020-10-02 15:10 Cargo.lock
.rw-r--r-- 1.1 KB aquarhead 2020-10-02 15:10 Cargo.toml
.rw-r--r--  11 KB aquarhead 2020-10-02 15:10 CHANGELOG.md
.rw-r--r--  25 B  aquarhead 2020-10-02 15:10 CODEOWNERS
.rw-r--r--  11 KB aquarhead 2020-10-02 15:10 LICENSE
.rw-r--r-- 9.6 KB aquarhead 2020-10-02 15:10 README.md
```

While for a folder with more than 5 dotfiles, it shows none of them:

```
<$> ll -a ~ | rg "^." | wc -l
     165

<$> ll ~
drwx------  96 B  aquarhead 2019-02-12 11:02 Applications/
drwxr-xr-x 288 B  aquarhead 2020-09-22 09:09 bin/
drwxr-xr-x 192 B  aquarhead 2018-03-05 23:03 Design/
drwx------ 480 B  aquarhead 2020-09-18 19:09 Desktop/
drwx------ 352 B  aquarhead 2020-07-20 15:07 Documents/
drwx------ 1.1 KB aquarhead 2020-10-02 10:10 Downloads/
...
```

(My full `ll` alias is: `lsd -lF --auto-all 5 --ignore-config --icon never --group-dirs first --date +%Y-%m-%d\ %H:%m --blocks permission,size,user,date,name`)

Alternatives:
- show _up to_ X number of dotfiles: inspired by a wrong implementation for my original idea, it can be helpful to know there're some dotfiles at least, but at the same time it's hard to see which dotfiles would show and which would not, and might not play well with sorting

Question:
- I didn't look into how to add it to the yaml config - personally I don't like it read config files, and I'm delighted to see the `ignore-config` flag - is it something critical for a new flag? (Is it supported by `clap` so trivial to add?)

Aside: I've actually used `exa` for a while now and this PR was originally targeted at it, I only discovered it's not maintained for almost a year now and it's not formatted at all so it's really hard to contribute, so I took another look at `lsd` and made some quick adjustments to the flags and it works just fine, thanks for creating the tool and making it easy (and possible) to contribute ❤️ 