### PR TITLE
Refactor: Convert dirorder flag to sort flag.

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -59,7 +59,7 @@ impl Core {
             inner_flags.layout = Layout::OneLine;
         };
 
-        let sorters = sort::assemble_sorters(&flags);
+        let sorters = sort::assemble_sorters(&flags.sorters);
 
         Self {
             flags,


### PR DESCRIPTION
This refactor will make it easier to add multisorting eg. something like `--sort=-directory,name,extension,-size`.
This refactor removes special case dirorder flags and combines sort order and sort field into one property.

