### PR TITLE
Fix date test bug on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix group name show in gid from [zwpaper](https://github.com/zwpaper)
 - Fix panic caused by invalid UTF-8 chars in extension from [zwpaper](https://github.com/zwpaper) and [0jdxt](https://github.com/0jdxt)
-- Fix localisation issues in running tests from [0jdxt](https://github.com/0jdxt)
 
 ## [0.18.0] - 2020-08-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix group name show in gid from [zwpaper](https://github.com/zwpaper)
 - Fix panic caused by invalid UTF-8 chars in extension from [zwpaper](https://github.com/zwpaper) and [0jdxt](https://github.com/0jdxt)
+- Fix localisation issues in running tests from [0jdxt](https://github.com/0jdxt)
 
 ## [0.18.0] - 2020-08-29
 ### Added

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -87,11 +87,11 @@ mod test {
 
         Command::new("powershell")
             .arg("-Command")
-            .arg("$(Get-Item")
-            .arg(path)
-            .arg(").lastwritetime=$(Get-Date \"")
-            .arg(date.strftime("%m/%d/%Y %H:%M:%S").unwrap().to_string())
-            .arg("\")")
+            .arg(format!(
+                r#"$(Get-Item {}).lastwritetime=$(Get-Date "{}")"#,
+                path.display(),
+                date.rfc3339()
+            ))
             .status()
     }
 
@@ -174,7 +174,7 @@ mod test {
 
         let creation_date = time::now() - time::Duration::days(2);
 
-        let success = cross_platform_touch(&file_path, &creation_date.to_local())
+        let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
         assert!(success, "failed to exec touch");
@@ -199,18 +199,7 @@ mod test {
         file_path.push("test_with_relative_date_now.tmp");
 
         let creation_date = time::now();
-
-        let success = Command::new("touch")
-            .arg("-t")
-            .arg(
-                creation_date
-                    .to_local()
-                    .strftime("%Y%m%d%H%M.%S")
-                    .unwrap()
-                    .to_string(),
-            )
-            .arg(&file_path)
-            .status()
+        let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
         assert_eq!(true, success, "failed to exec touch");

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -211,7 +211,7 @@ mod tests {
             .arg("-Command")
             .arg("$(Get-Item")
             .arg(&path_z)
-            .arg(").lastwritetime=$(Get-Date \"11/16/1985\")")
+            .arg(").lastwritetime=$(Get-Date \"1985-11-16\")")
             .status()
             .unwrap()
             .success();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -363,7 +363,7 @@ fn test_version_sort_overwrite_by_sizesort() {
 }
 
 #[cfg(test)]
-#[cfg(not(target_os = "mac"))]
+#[cfg(target_os = "linux")]
 fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
     let mut fname = format!("{}/{}", tmp.display(), pre).into_bytes();
     fname.reserve(2 + suf.len());
@@ -374,12 +374,11 @@ fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
 }
 
 #[test]
-#[cfg(not(target_os = "mac"))]
+#[cfg(target_os = "linux")]
 fn test_bad_utf_8_extension() {
     use std::fs::File;
     let tmp = tempdir();
     let fname = bad_utf8(tmp.path(), "bad.extension", "");
-    File::create(fname).expect("failed to create file");
 
     cmd()
         .arg(tmp.path())
@@ -388,25 +387,17 @@ fn test_bad_utf_8_extension() {
 }
 
 #[test]
-#[cfg(not(target_os = "mac"))]
+#[cfg(target_os = "linux")]
 fn test_bad_utf_8_name() {
     use std::fs::File;
     let tmp = tempdir();
     let fname = bad_utf8(tmp.path(), "bad-name", ".ext");
     File::create(fname).expect("failed to create file");
 
-    #[cfg(target_os = "linux")]
-    let match_str = "bad-name\u{fffd}\u{fffd}.ext\n$";
-
-    // when the invalid utf8 filename is read on windows,
-    // some bytes are eaten up
-    #[cfg(target_os = "windows")]
-    let match_str = "bad-name\u{fffd}\u{fffd}xt\n$";
-
     cmd()
         .arg(tmp.path())
         .assert()
-        .stdout(predicate::str::is_match(match_str).unwrap());
+        .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
 }
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -359,7 +359,6 @@ fn test_version_sort_overwrite_by_sizesort() {
         .stdout(predicate::str::is_match("11\n2\n$").unwrap());
 }
 
-#[cfg(test)]
 #[cfg(target_os = "linux")]
 fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
     let mut fname = format!("{}/{}", tmp.display(), pre).into_bytes();
@@ -398,12 +397,10 @@ fn test_bad_utf_8_name() {
         .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
 }
 
-#[cfg(test)]
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }
 
-#[cfg(test)]
 fn tempdir() -> assert_fs::TempDir {
     assert_fs::TempDir::new().unwrap()
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -362,8 +362,8 @@ fn test_version_sort_overwrite_by_sizesort() {
         .stdout(predicate::str::is_match("11\n2\n$").unwrap());
 }
 
-#[cfg(not(os = "darwin"))]
 #[cfg(test)]
+#[cfg(not(target_os = "mac"))]
 fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
     let mut fname = format!("{}/{}", tmp.display(), pre).into_bytes();
     fname.reserve(2 + suf.len());
@@ -373,8 +373,8 @@ fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
     unsafe { String::from_utf8_unchecked(fname) }
 }
 
-#[cfg(not(os = "darwin"))]
 #[test]
+#[cfg(not(target_os = "mac"))]
 fn test_bad_utf_8_extension() {
     use std::fs::File;
     let tmp = tempdir();
@@ -387,8 +387,8 @@ fn test_bad_utf_8_extension() {
         .stdout(predicate::str::is_match("bad.extension\u{fffd}\u{fffd}\n$").unwrap());
 }
 
-#[cfg(not(os = "darwin"))]
 #[test]
+#[cfg(not(target_os = "mac"))]
 fn test_bad_utf_8_name() {
     use std::fs::File;
     let tmp = tempdir();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -379,6 +379,7 @@ fn test_bad_utf_8_extension() {
     use std::fs::File;
     let tmp = tempdir();
     let fname = bad_utf8(tmp.path(), "bad.extension", "");
+    File::create(fname).expect("failed to create file");
 
     cmd()
         .arg(tmp.path())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -401,28 +401,12 @@ fn test_bad_utf_8_name() {
         .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
 }
 
-#[test]
-fn test_tree_d() {
-    let tmp = tempdir();
-    tmp.child("one").touch().unwrap();
-    tmp.child("two").touch().unwrap();
-    tmp.child("one.d").create_dir_all().unwrap();
-    tmp.child("one.d/one").touch().unwrap();
-    tmp.child("one.d/one.d").create_dir_all().unwrap();
-    tmp.child("two.d").create_dir_all().unwrap();
-
-    cmd()
-        .arg(tmp.path())
-        .arg("--tree")
-        .arg("-d")
-        .assert()
-        .stdout(predicate::str::is_match("├── one.d\n│  └── one.d\n└── two.d\n$").unwrap());
-}
-
+#[cfg(test)]
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }
 
+#[cfg(test)]
 fn tempdir() -> assert_fs::TempDir {
     assert_fs::TempDir::new().unwrap()
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -362,8 +362,8 @@ fn test_version_sort_overwrite_by_sizesort() {
         .stdout(predicate::str::is_match("11\n2\n$").unwrap());
 }
 
+#[cfg(not(os = "darwin"))]
 #[cfg(test)]
-#[cfg(target_os = "linux")]
 fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
     let mut fname = format!("{}/{}", tmp.display(), pre).into_bytes();
     fname.reserve(2 + suf.len());
@@ -373,8 +373,8 @@ fn bad_utf8(tmp: &std::path::Path, pre: &str, suf: &str) -> String {
     unsafe { String::from_utf8_unchecked(fname) }
 }
 
+#[cfg(not(os = "darwin"))]
 #[test]
-#[cfg(target_os = "linux")]
 fn test_bad_utf_8_extension() {
     use std::fs::File;
     let tmp = tempdir();
@@ -387,8 +387,8 @@ fn test_bad_utf_8_extension() {
         .stdout(predicate::str::is_match("bad.extension\u{fffd}\u{fffd}\n$").unwrap());
 }
 
+#[cfg(not(os = "darwin"))]
 #[test]
-#[cfg(target_os = "linux")]
 fn test_bad_utf_8_name() {
     use std::fs::File;
     let tmp = tempdir();
@@ -399,6 +399,24 @@ fn test_bad_utf_8_name() {
         .arg(tmp.path())
         .assert()
         .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
+}
+
+#[test]
+fn test_tree_d() {
+    let tmp = tempdir();
+    tmp.child("one").touch().unwrap();
+    tmp.child("two").touch().unwrap();
+    tmp.child("one.d").create_dir_all().unwrap();
+    tmp.child("one.d/one").touch().unwrap();
+    tmp.child("one.d/one.d").create_dir_all().unwrap();
+    tmp.child("two.d").create_dir_all().unwrap();
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--tree")
+        .arg("-d")
+        .assert()
+        .stdout(predicate::str::is_match("├── one.d\n│  └── one.d\n└── two.d\n$").unwrap());
 }
 
 fn cmd() -> Command {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -401,24 +401,6 @@ fn test_bad_utf_8_name() {
         .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
 }
 
-#[test]
-fn test_tree_d() {
-    let tmp = tempdir();
-    tmp.child("one").touch().unwrap();
-    tmp.child("two").touch().unwrap();
-    tmp.child("one.d").create_dir_all().unwrap();
-    tmp.child("one.d/one").touch().unwrap();
-    tmp.child("one.d/one.d").create_dir_all().unwrap();
-    tmp.child("two.d").create_dir_all().unwrap();
-
-    cmd()
-        .arg(tmp.path())
-        .arg("--tree")
-        .arg("-d")
-        .assert()
-        .stdout(predicate::str::is_match("├── one.d\n│  └── one.d\n└── two.d\n$").unwrap());
-}
-
 #[cfg(test)]
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -401,6 +401,24 @@ fn test_bad_utf_8_name() {
         .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
 }
 
+#[test]
+fn test_tree_d() {
+    let tmp = tempdir();
+    tmp.child("one").touch().unwrap();
+    tmp.child("two").touch().unwrap();
+    tmp.child("one.d").create_dir_all().unwrap();
+    tmp.child("one.d/one").touch().unwrap();
+    tmp.child("one.d/one.d").create_dir_all().unwrap();
+    tmp.child("two.d").create_dir_all().unwrap();
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--tree")
+        .arg("-d")
+        .assert()
+        .stdout(predicate::str::is_match("├── one.d\n│  └── one.d\n└── two.d\n$").unwrap());
+}
+
 #[cfg(test)]
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -395,10 +395,18 @@ fn test_bad_utf_8_name() {
     let fname = bad_utf8(tmp.path(), "bad-name", ".ext");
     File::create(fname).expect("failed to create file");
 
+    #[cfg(target_os = "linux")]
+    let match_str = "bad-name\u{fffd}\u{fffd}.ext\n$";
+
+    // when the invalid utf8 filename is read on windows,
+    // some bytes are eaten up
+    #[cfg(target_os = "windows")]
+    let match_str = "bad-name\u{fffd}\u{fffd}xt\n$";
+
     cmd()
         .arg(tmp.path())
         .assert()
-        .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
+        .stdout(predicate::str::is_match(match_str).unwrap());
 }
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,10 +103,10 @@ fn test_list_inode_populated_directory() {
     dir.child("one").touch().unwrap();
     dir.child("two").touch().unwrap();
 
-    #[cfg(unix)]
-    let matched = "\\d+ one\n\\d+ two\n$";
     #[cfg(windows)]
     let matched = "- one\n\\- two\n$";
+    #[cfg(unix)]
+    let matched = "\\d+ one\n\\d+ two\n$";
 
     cmd()
         .arg("--inode")
@@ -128,9 +128,6 @@ fn test_list_block_inode_populated_directory_without_long() {
     dir.child("one").touch().unwrap();
     dir.child("two").touch().unwrap();
 
-    #[cfg(unix)]
-    let matched = "one\ntwo\n$";
-    #[cfg(windows)]
     let matched = "one\ntwo\n$";
 
     cmd()
@@ -148,10 +145,10 @@ fn test_list_block_inode_populated_directory_with_long() {
     dir.child("one").touch().unwrap();
     dir.child("two").touch().unwrap();
 
-    #[cfg(unix)]
-    let matched = "\\d+ one\n\\d+ two\n$";
     #[cfg(windows)]
     let matched = "- one\n\\- two\n$";
+    #[cfg(unix)]
+    let matched = "\\d+ one\n\\d+ two\n$";
 
     cmd()
         .arg("--long")


### PR DESCRIPTION
had a localisation issue with creating dates for testing since they are created in powershell using "MM/DD/YYYY" format and my machine is localised to "DD/MM/YYY" so keeping them ISO8601 will solve this i.e. "YYYY-MM-DD"