### PR TITLE
using serde yaml to parse config file with type check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "dtoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
 name = "float-cmp"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +351,8 @@ dependencies = [
  "libc",
  "lscolors",
  "predicates",
+ "serde",
+ "serde_yaml",
  "tempfile",
  "term_grid",
  "terminal_size",
@@ -422,6 +430,24 @@ checksum = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 dependencies = [
  "predicates-core",
  "treeline",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -531,10 +557,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "syn"
+version = "1.0.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "tempfile"
@@ -620,6 +689,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "users"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ wild = "2.0.*"
 globset = "0.4.*"
 xdg = "2.1.*"
 yaml-rust = "0.4.*"
+serde = { version = "1.0", features = ["derive"] }
+serde_yaml = "0.8"
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11.*"

--- a/README.md
+++ b/README.md
@@ -134,8 +134,7 @@ The [release page](https://github.com/Peltoche/lsd/releases) includes precompile
 ## Configuration
 
 `lsd` can be configured with a configuration file to set the default options.
-Right now this only supports setting options that can be passed via the command
-line options as well.
+Check [Config file content](#config-file-content) for details.
 
 ### Config file location
 
@@ -145,19 +144,20 @@ On non-Windows systems `lsd` follows the
 [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
 convention for the location of the configuration file. The configuration dir
 `lsd` uses is itself named `lsd`. In that directory it looks first for a file
-called `config.yaml` and if it can't find one, a file named `config.yml`.
+called `config.yaml`.
 For most people it should be enough to put their config file at
 `~/.config/lsd/config.yaml`.
 
 #### Windows
 
-On Windows systems `lsd` only looks for the two files in one location:
+On Windows systems `lsd` only looks for the `config.yaml` files in one location:
 `%APPDATA%\lsd\`
 
 ### Config file content
 
 This is an example config file with the default values and some additional
 remarks.
+
 ```yaml
 # == Classic ==
 # This is a shorthand to override some of the options to be backwards compatible

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -97,7 +97,7 @@ impl Config {
             Err(e) => {
                 match e.kind() {
                     std::io::ErrorKind::NotFound => {}
-                    _ => print_error!("bad config file: {}, {}\n", &file, e),
+                    _ => print_error!("Can not open config file {}: {}.", &file, e),
                 };
                 None
             }
@@ -109,7 +109,7 @@ impl Config {
         match serde_yaml::from_str::<Self>(yaml) {
             Ok(c) => Some(c),
             Err(e) => {
-                print_error!("configuration file format error, {}\n\n", e);
+                print_error!("Configuration file format error, {}.", e);
                 None
             }
         }
@@ -126,7 +126,7 @@ impl Config {
                     return Some(p);
                 }
             }
-            Err(e) => print_error!("can not open config file: {}", e),
+            Err(e) => print_error!("Can not open config file: {}.", e),
         }
         None
     }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,6 +1,7 @@
-use crate::print_error;
 ///! This module provides methods to handle the program's config files and operations related to
 ///! this.
+use crate::print_error;
+
 use std::path::PathBuf;
 
 use serde::Deserialize;

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,14 +1,13 @@
-use serde::Deserialize;
-use serde_yaml::Sequence;
-use std::error::Error;
+use crate::print_error;
 ///! This module provides methods to handle the program's config files and operations related to
 ///! this.
-use std::fs;
-use std::io::BufReader;
 use std::path::PathBuf;
-use xdg::BaseDirectories;
 
-use crate::print_error;
+use serde::Deserialize;
+use serde_yaml::Sequence;
+
+use std::fs;
+use xdg::BaseDirectories;
 
 const CONF_DIR: &str = "lsd";
 const CONF_FILE_NAME: &str = "config";
@@ -33,7 +32,7 @@ pub struct Config {
     pub sorting: Option<Sorting>,
     pub no_symlink: Option<bool>,
     pub total_size: Option<bool>,
-    pub styling: Option<Styling>,
+    pub symlink_arrow: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -43,32 +42,44 @@ pub struct Color {
 
 #[derive(Debug, Deserialize)]
 pub struct Icons {
-    pub when: String, // enum?
-    pub theme: String,
+    pub when: Option<String>, // enum?
+    pub theme: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Recursion {
-    pub enabled: bool,
-    pub depth: i32,
+    pub enabled: Option<bool>,
+    pub depth: Option<usize>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Sorting {
-    pub column: String, // enum?
-    pub reverse: bool,
-    pub dir_grouping: String, // enum?
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Styling {
-    pub symlink_arrow: bool,
+    pub column: Option<String>, // enum?
+    pub reverse: Option<bool>,
+    pub dir_grouping: Option<String>, // enum?
 }
 
 impl Config {
-    /// This constructs a Config struct without a file [String] and without a [Yaml].
+    /// This constructs a Config struct with all None
     pub fn with_none() -> Self {
-        Self::default()
+        Self {
+            classic: None,
+            blocks: None,
+            color: None,
+            date: None,
+            dereference: None,
+            display: None,
+            icons: None,
+            ignore_globs: None,
+            indicators: None,
+            layout: None,
+            recursion: None,
+            size: None,
+            sorting: None,
+            no_symlink: None,
+            total_size: None,
+            symlink_arrow: None,
+        }
     }
 
     /// This constructs a Config struct with a passed file [String] and without a [Yaml].
@@ -124,24 +135,120 @@ impl Default for Config {
         if let Some(c) = Self::with_file(Self::config_file_path().to_string_lossy().to_string()) {
             c
         } else {
-            Config {
-                classic: Some(false),
-                blocks: None,
-                color: None,
-                date: None,
-                dereference: None,
-                display: None,
-                icons: None,
-                ignore_globs: None,
-                indicators: None,
-                layout: None,
-                recursion: None,
-                size: None,
-                sorting: None,
-                no_symlink: None,
-                total_size: None,
-                styling: None,
-            }
+            Self::with_yaml(
+                r#"---
+# == Classic ==
+# This is a shorthand to override some of the options to be backwards compatible
+# with `ls`. It affects the "color"->"when", "sorting"->"dir-grouping", "date"
+# and "icons"->"when" options.
+# Possible values: false, true
+classic: false
+
+# == Blocks ==
+# This specifies the columns and their order when using the long and the tree
+# layout.
+# Possible values: permission, user, group, size, size_value, date, name, inode
+blocks:
+  - permission
+  - user
+  - group
+  - size
+  - date
+  - name
+
+# == Color ==
+# This has various color options. (Will be expanded in the future.)
+color:
+  # When to colorize the output.
+  # When "classic" is set, this is set to "never".
+  # Possible values: never, auto, always
+  when: auto
+
+# == Date ==
+# This specifies the date format for the date column. The freeform format
+# accepts an strftime like string.
+# When "classic" is set, this is set to "date".
+# Possible values: date, relative, +<date_format>
+date: date
+
+# == Dereference ==
+# Whether to dereference symbolic links.
+# Possible values: false, true
+dereference: false
+
+# == Display ==
+# What items to display. Do not specify this for the default behavior.
+# Possible values: all, almost-all, directory-only
+# display: all
+
+# == Icons ==
+icons:
+  # When to use icons.
+  # When "classic" is set, this is set to "never".
+  # Possible values: always, auto, never
+  when: auto
+  # Which icon theme to use.
+  # Possible values: fancy, unicode
+  theme: fancy
+
+# == Ignore Globs ==
+# A list of globs to ignore when listing.
+# ignore-globs:
+#   - .git
+
+# == Indicators ==
+# Whether to add indicator characters to certain listed files.
+# Possible values: false, true
+indicators: false
+
+# == Layout ==
+# Which layout to use. "oneline" might be a bit confusing here and should be
+# called "one-per-line". It might be changed in the future.
+# Possible values: grid, tree, oneline
+layout: grid
+
+# == Recursion ==
+recursion:
+  # Whether to enable recursion.
+  # Possible values: false, true
+  enabled: false
+  # How deep the recursion should go. This has to be a positive integer. Leave
+  # it unspecified for (virtually) infinite.
+  # depth: 3
+
+# == Size ==
+# Specifies the format of the size column.
+# Possible values: default, short, bytes
+size: default
+
+# == Sorting ==
+sorting:
+  # Specify what to sort by.
+  # Possible values: extension, name, time, size, version
+  column: name
+  # Whether to reverse the sorting.
+  # Possible values: false, true
+  reverse: false
+  # Whether to group directories together and where.
+  # When "classic" is set, this is set to "none".
+  # Possible values: first, last, none
+  dir-grouping: none
+
+# == No Symlink ==
+# Whether to omit showing symlink targets
+# Possible values: false, true
+no-symlink: false
+
+# == Total size ==
+# Whether to display the total size of directories.
+# Possible values: false, true
+total-size: false
+
+# == Symlink arrow ==
+# Specifies how the symlink arrow display, chars in both ascii and utf8
+symlink-arrow: ⇒"#,
+            )
+            .unwrap()
         }
     }
 }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -267,7 +267,7 @@ mod tests {
     fn test_read_config_bad_bool() {
         let c = Config::with_yaml("classic: notbool");
         println!("{:?}", c);
-        assert!(c.is_some())
+        assert!(c.is_none())
     }
 
     #[test]

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -51,10 +51,10 @@ impl Config {
 
     /// This tries to read a configuration file like in the XDG_BASE_DIRS specification and returns
     /// the contents of the YAML config file.
-    pub fn read_config() -> Self {
+    pub fn read_config(name: &str) -> Self {
         let config_file_long_path;
         let config_file_short_path;
-        match Self::config_file_paths() {
+        match Self::config_file_paths(name) {
             Some((long, short)) => {
                 config_file_long_path = long;
                 config_file_short_path = short;
@@ -102,7 +102,7 @@ impl Config {
     /// This provides two paths for a configuration file (the first with the long yaml extension,
     /// the second with the short yml extension), according to the XDG_BASE_DIRS specification.
     #[cfg(not(windows))]
-    pub fn config_file_paths() -> Option<(PathBuf, PathBuf)> {
+    pub fn config_file_paths(name: &str) -> Option<(PathBuf, PathBuf)> {
         let base_dirs;
         match BaseDirectories::with_prefix(CONF_DIR) {
             Ok(result) => base_dirs = result,
@@ -110,13 +110,13 @@ impl Config {
         }
 
         let config_file_long_path;
-        match base_dirs.place_config_file([CONF_FILE_NAME, YAML_LONG_EXT].join(".")) {
+        match base_dirs.place_config_file([name, YAML_LONG_EXT].join(".")) {
             Ok(result) => config_file_long_path = result,
             _ => return None,
         }
 
         let config_file_short_path;
-        match base_dirs.place_config_file([CONF_FILE_NAME, YAML_SHORT_EXT].join(".")) {
+        match base_dirs.place_config_file([name, YAML_SHORT_EXT].join(".")) {
             Ok(result) => config_file_short_path = result,
             _ => return None,
         }
@@ -127,7 +127,7 @@ impl Config {
     /// This provides two paths for a configuration file (the first with the long yaml extension,
     /// the second with the short yml extension) inside the %APPDATA% directory.
     #[cfg(windows)]
-    pub fn config_file_paths() -> Option<(PathBuf, PathBuf)> {
+    pub fn config_file_paths(name: &str) -> Option<(PathBuf, PathBuf)> {
         let mut config_file_long_path;
         match dirs::config_dir() {
             Some(path) => config_file_long_path = path,
@@ -137,8 +137,8 @@ impl Config {
         config_file_long_path.push(CONF_DIR);
         let mut config_file_short_path = config_file_long_path.clone();
 
-        config_file_long_path.push([CONF_FILE_NAME, YAML_LONG_EXT].join("."));
-        config_file_short_path.push([CONF_FILE_NAME, YAML_SHORT_EXT].join("."));
+        config_file_long_path.push([name, YAML_LONG_EXT].join("."));
+        config_file_short_path.push([name, YAML_SHORT_EXT].join("."));
 
         Some((config_file_long_path, config_file_short_path))
     }
@@ -171,5 +171,11 @@ impl Config {
             "The {} config value has to be a {}.",
             name, type_name
         ));
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::read_config(CONF_FILE_NAME)
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -95,7 +95,7 @@ impl Core {
             };
 
             let recurse =
-                self.flags.layout == Layout::Tree || self.flags.display != Display::DirectoryItself;
+                self.flags.layout == Layout::Tree || self.flags.display != Display::DirectoryOnly;
             if recurse {
                 match meta.recurse_into(depth, &self.flags) {
                     Ok(content) => {

--- a/src/core.rs
+++ b/src/core.rs
@@ -89,7 +89,7 @@ impl Core {
             let mut meta = match Meta::from_path(&path, self.flags.dereference.0) {
                 Ok(meta) => meta,
                 Err(err) => {
-                    print_error!("lsd: {}: {}\n", path.display(), err);
+                    print_error!("{}: {}.", path.display(), err);
                     continue;
                 }
             };

--- a/src/display.rs
+++ b/src/display.rs
@@ -61,7 +61,7 @@ fn inner_display_grid(
     // The first iteration (depth == 0) corresponds to the inputs given by the
     // user. We defer displaying directories given by the user unless we've been
     // asked to display the directory itself (rather than its contents).
-    let skip_dirs = (depth == 0) && (flags.display != Display::DirectoryItself);
+    let skip_dirs = (depth == 0) && (flags.display != Display::DirectoryOnly);
 
     // print the files first.
     for meta in metas {

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -97,16 +97,16 @@ impl Blocks {
 
     /// Get a potential `Blocks` struct from a [Config].
     ///
-    /// of its [String](Yaml::String) values is returned in a `Blocks` in a [Some]. Otherwise it
+    /// of its [String]values is returned in a `Blocks` in a [Some]. Otherwise it
     /// returns [None].
     /// Config make sure blocks are Strings, we can unwrap here without panic
     fn from_config(config: &Config) -> Option<Self> {
         if let Some(c) = &config.blocks {
             let mut blocks: Vec<Block> = vec![];
             for b in c.iter() {
-                match Block::try_from(b.as_str().unwrap()) {
+                match Block::try_from(b.as_str()) {
                     Ok(block) => blocks.push(block),
-                    Err(err) => print_error!("bad blocks: {}", err),
+                    Err(err) => print_error!("{}.", err),
                 }
             }
             if blocks.is_empty() {

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -24,11 +24,6 @@ impl Blocks {
     /// `Blocks` does not contain a [Block] of variant [INode](Block::INode) yet, one is prepended
     /// to the returned value.
     ///
-    /// # Note
-    ///
-    /// The configuration file's Yaml is read in any case, to be able to check for errors and print
-    /// out warnings.
-    ///
     /// # Errors
     ///
     /// This errors if any of the [ArgMatches] parameter arguments causes [Block]'s implementation
@@ -118,26 +113,6 @@ impl Blocks {
             None
         }
     }
-
-    /// Get a [Blocks] from a [Yaml] array. The [Config] is used to log warnings about wrong values
-    /// in a Yaml.
-    // fn from_yaml_array(values: &[Yaml], config: &Config) -> Option<Self> {
-    //     let mut blocks: Vec<Block> = vec![];
-    //     for array_el in values.iter() {
-    //         match array_el {
-    //             Yaml::String(value) => match Block::try_from(value.as_str()) {
-    //                 Ok(block) => blocks.push(block),
-    //                 Err(err) => config.print_warning(&err),
-    //             },
-    //             _ => config.print_warning("The blocks config values have to be strings."),
-    //         }
-    //     }
-    //     if blocks.is_empty() {
-    //         None
-    //     } else {
-    //         Some(Self(blocks))
-    //     }
-    // }
 
     /// This returns a Blocks struct for the long format.
     ///

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -92,9 +92,9 @@ impl Blocks {
 
     /// Get a potential `Blocks` struct from a [Config].
     ///
-    /// of its [String]values is returned in a `Blocks` in a [Some]. Otherwise it
-    /// returns [None].
-    /// Config make sure blocks are Strings, we can unwrap here without panic
+    /// If the [Config] contains an array of blocks values,
+    /// its [String] values is returned as `Blocks` in a [Some].
+    /// Otherwise it returns [None].
     fn from_config(config: &Config) -> Option<Self> {
         if let Some(c) = &config.blocks {
             let mut blocks: Vec<Block> = vec![];
@@ -444,7 +444,7 @@ mod test_blocks {
     #[test]
     fn test_from_config_invalid_is_ignored() {
         let mut c = Config::with_none();
-        c.blocks = Some(vec!["permission".into(), "for".into(), "date".into()].into());
+        c.blocks = Some(vec!["permission".into(), "foo".into(), "date".into()].into());
         let blocks = Blocks(vec![Block::Permission, Block::Date]);
         assert_eq!(Some(blocks), Blocks::from_config(&c));
     }

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -36,8 +36,7 @@ pub enum ColorOption {
 }
 
 impl ColorOption {
-    /// Get a Color value from a [Yaml] string. The [Config] is used to log warnings about wrong
-    /// values in a Yaml.
+    /// Get a Color value from a [String].
     fn from_str(value: &str) -> Option<Self> {
         match value {
             "always" => Some(Self::Always),
@@ -45,7 +44,7 @@ impl ColorOption {
             "never" => Some(Self::Never),
             _ => {
                 print_error!(
-                    "color/when could only be one of auto, always and never, got {}",
+                    "Config color.when could only be one of auto, always and never, got {}.",
                     &value
                 );
                 None
@@ -67,7 +66,7 @@ impl Configurable<Self> for ColorOption {
             if let Some(color) = matches.value_of("color") {
                 Self::from_str(&color)
             } else {
-                print_error!("bad color, should never happen");
+                print_error!("Bad color args. This should not be reachable!");
                 None
             }
         } else {

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -66,8 +66,7 @@ impl Configurable<Self> for ColorOption {
             if let Some(color) = matches.value_of("color") {
                 Self::from_str(&color)
             } else {
-                print_error!("Bad color args. This should not be reachable!");
-                None
+                panic!("Bad color args. This should not be reachable!");
             }
         } else {
             None
@@ -87,7 +86,6 @@ impl Configurable<Self> for ColorOption {
         if let Some(color) = &config.color {
             Some(color.when)
         } else {
-            // TODO: maybe return default value?
             None
         }
     }
@@ -192,7 +190,7 @@ mod test_color_option {
     fn test_from_config_classic_mode() {
         let mut c = Config::with_none();
         c.color = Some(config_file::Color {
-            when: ColorOption::Never,
+            when: ColorOption::Always,
         });
         c.classic = Some(true);
         assert_eq!(Some(ColorOption::Never), ColorOption::from_config(&c));

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -4,9 +4,9 @@
 use super::Configurable;
 
 use crate::config_file::Config;
+use crate::print_error;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// A collection of flags on how to use colors.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -42,7 +42,7 @@ impl ColorOption {
             "auto" => Some(Self::Auto),
             "never" => Some(Self::Never),
             _ => {
-                config.print_invalid_value_warning("color->when", &value);
+                print_error!("color->when: {}", &value);
                 None
             }
         }
@@ -78,22 +78,11 @@ impl Configurable<Self> for ColorOption {
     /// "when" and it is one of "always", "auto" or "never", this returns its corresponding variant
     /// in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            if let Yaml::Boolean(true) = &yaml["classic"] {
-                Some(Self::Never)
-            } else {
-                match &yaml["color"]["when"] {
-                    Yaml::BadValue => None,
-                    Yaml::String(value) => Self::from_yaml_string(&value, &config),
-                    _ => {
-                        config.print_wrong_type_warning("color->when", "string");
-                        None
-                    }
-                }
-            }
-        } else {
-            None
+        if let Some(_c) = &config.color {
+            // TODO(zhangwei)
+            return None
         }
+        None
     }
 }
 
@@ -170,7 +159,7 @@ mod test_color_option {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, ColorOption::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, ColorOption::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -179,7 +168,7 @@ mod test_color_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(ColorOption::Always),
-            ColorOption::from_config(&Config::with_yaml(yaml))
+            ColorOption::from_config(&Config::with_none())
         );
     }
 
@@ -189,7 +178,7 @@ mod test_color_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(ColorOption::Auto),
-            ColorOption::from_config(&Config::with_yaml(yaml))
+            ColorOption::from_config(&Config::with_none())
         );
     }
 
@@ -199,7 +188,7 @@ mod test_color_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(ColorOption::Never),
-            ColorOption::from_config(&Config::with_yaml(yaml))
+            ColorOption::from_config(&Config::with_none())
         );
     }
 
@@ -209,7 +198,7 @@ mod test_color_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(ColorOption::Never),
-            ColorOption::from_config(&Config::with_yaml(yaml))
+            ColorOption::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Color]. To set it up from [ArgMatches], a [Yaml] and its [Default]
+//! This module defines the [Color]. To set it up from [ArgMatches], a [Config] and its [Default]
 //! value, use its [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;
@@ -104,10 +104,8 @@ mod test_color_option {
     use super::ColorOption;
 
     use crate::app;
-    use crate::config_file::Config;
+    use crate::config_file::{self, Config};
     use crate::flags::Configurable;
-
-    use yaml_rust::YamlLoader;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -162,49 +160,40 @@ mod test_color_option {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, ColorOption::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_always() {
-        let yaml_string = "color:\n  when: always";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(ColorOption::Always),
-            ColorOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.color = Some(config_file::Color {
+            when: "always".into(),
+        });
+
+        assert_eq!(Some(ColorOption::Always), ColorOption::from_config(&c));
     }
 
     #[test]
     fn test_from_config_auto() {
-        let yaml_string = "color:\n  when: auto";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(ColorOption::Auto),
-            ColorOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.color = Some(config_file::Color {
+            when: "auto".into(),
+        });
+        assert_eq!(Some(ColorOption::Auto), ColorOption::from_config(&c));
     }
 
     #[test]
     fn test_from_config_never() {
-        let yaml_string = "color:\n  when: never";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(ColorOption::Never),
-            ColorOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.color = Some(config_file::Color {
+            when: "never".into(),
+        });
+        assert_eq!(Some(ColorOption::Never), ColorOption::from_config(&c));
     }
 
     #[test]
     fn test_from_config_classic_mode() {
-        let yaml_string = "classic: true\ncolor:\n  when: always";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(ColorOption::Never),
-            ColorOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.color = Some(config_file::Color {
+            when: "always".into(),
+        });
+        c.classic = Some(true);
+        assert_eq!(Some(ColorOption::Never), ColorOption::from_config(&c));
     }
 }

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -7,6 +7,7 @@ use crate::config_file::Config;
 use crate::print_error;
 
 use clap::ArgMatches;
+use serde::Deserialize;
 
 /// A collection of flags on how to use colors.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -26,7 +27,8 @@ impl Color {
 }
 
 /// The flag showing when to use colors in the output.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum ColorOption {
     Always,
     Auto,
@@ -84,7 +86,7 @@ impl Configurable<Self> for ColorOption {
         }
 
         if let Some(color) = &config.color {
-            Self::from_str(&color.when)
+            Some(color.when)
         } else {
             // TODO: maybe return default value?
             None
@@ -163,7 +165,7 @@ mod test_color_option {
     fn test_from_config_always() {
         let mut c = Config::with_none();
         c.color = Some(config_file::Color {
-            when: "always".into(),
+            when: ColorOption::Always,
         });
 
         assert_eq!(Some(ColorOption::Always), ColorOption::from_config(&c));
@@ -173,7 +175,7 @@ mod test_color_option {
     fn test_from_config_auto() {
         let mut c = Config::with_none();
         c.color = Some(config_file::Color {
-            when: "auto".into(),
+            when: ColorOption::Auto,
         });
         assert_eq!(Some(ColorOption::Auto), ColorOption::from_config(&c));
     }
@@ -182,7 +184,7 @@ mod test_color_option {
     fn test_from_config_never() {
         let mut c = Config::with_none();
         c.color = Some(config_file::Color {
-            when: "never".into(),
+            when: ColorOption::Never,
         });
         assert_eq!(Some(ColorOption::Never), ColorOption::from_config(&c));
     }
@@ -191,7 +193,7 @@ mod test_color_option {
     fn test_from_config_classic_mode() {
         let mut c = Config::with_none();
         c.color = Some(config_file::Color {
-            when: "always".into(),
+            when: ColorOption::Never,
         });
         c.classic = Some(true);
         assert_eq!(Some(ColorOption::Never), ColorOption::from_config(&c));

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -69,7 +69,7 @@ impl Configurable<Self> for DateFlag {
     /// Get a potential `DateFlag` variant from a [Config].
     ///
     /// If the `Config::classic` is `true` then this returns the Some(DateFlag::Date),
-    /// Otherwise if the Config::date` has value and is one of "date" or "relative",
+    /// Otherwise if the `Config::date` has value and is one of "date" or "relative",
     /// this returns its corresponding variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -18,9 +18,8 @@ pub enum DateFlag {
 }
 
 impl DateFlag {
-    /// Get a value from a date format string. The [Config] is used to log warnings about wrong
-    /// values in a Yaml.
-    fn from_format_string(value: &str, config: &Config) -> Option<Self> {
+    /// Get a value from a date format string
+    fn from_format_string(value: &str) -> Option<Self> {
         match app::validate_time_format(&value) {
             Ok(()) => Some(Self::Formatted(value[1..].to_string())),
             _ => {
@@ -30,13 +29,12 @@ impl DateFlag {
         }
     }
 
-    /// Get a value from a [Yaml] string. The [Config] is used to log warnings about wrong values
-    /// in a Yaml.
-    fn from_yaml_string(value: &str, config: &Config) -> Option<Self> {
+    /// Get a value from a str.
+    fn from_str(value: &str) -> Option<Self> {
         match value {
             "date" => Some(Self::Date),
             "relative" => Some(Self::Relative),
-            _ if value.starts_with('+') => Self::from_format_string(&value, &config),
+            _ if value.starts_with('+') => Self::from_format_string(&value),
             _ => {
                 print_error!("Not a valid date value: {}", value);
                 None
@@ -70,14 +68,20 @@ impl Configurable<Self> for DateFlag {
 
     /// Get a potential `DateFlag` variant from a [Config].
     ///
-    /// If the Config's [Yaml] contains a [Boolean](Yaml::Boolean) value pointed to by "classic"
-    /// and its value is `true`, then this returns the [DateFlag::Date] variant in a [Some].
-    /// Otherwise if the Yaml contains a [String](Yaml::String) value pointed to by "date" and it
-    /// is one of "date" or "relative", this returns its corresponding variant in a [Some].
+    /// If the `Config::classic` is `true` then this returns the Some(DateFlag::Date),
+    /// Otherwise if the Config::date` has value and is one of "date" or "relative",
+    /// this returns its corresponding variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(true) = &config.classic {
+            return Some(Self::Date);
+        }
+
+        if let Some(date) = &config.date {
+            Self::from_str(&date)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -100,8 +100,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -157,56 +155,42 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, DateFlag::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_date() {
-        let yaml_string = "date: date";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DateFlag::Date),
-            DateFlag::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.date = Some("date".into());
+
+        assert_eq!(Some(DateFlag::Date), DateFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_relative() {
-        let yaml_string = "date: relative";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DateFlag::Relative),
-            DateFlag::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.date = Some("relative".into());
+        assert_eq!(Some(DateFlag::Relative), DateFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_format() {
-        let yaml_string = "date: +%F";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
+        let mut c = Config::with_none();
+        c.date = Some("+%F".into());
         assert_eq!(
             Some(DateFlag::Formatted("%F".to_string())),
-            DateFlag::from_config(&Config::with_none())
+            DateFlag::from_config(&c)
         );
     }
 
     #[test]
     fn test_from_config_format_invalid() {
-        let yaml_string = "date: +%J";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, DateFlag::from_config(&Config::with_none()));
+        let mut c = Config::with_none();
+        c.date = Some("+%J".into());
+        assert_eq!(None, DateFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_classic_mode() {
-        let yaml_string = "classic: true\ndate: relative";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DateFlag::Date),
-            DateFlag::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.date = Some("relative".into());
+        c.classic = Some(true);
+        assert_eq!(Some(DateFlag::Date), DateFlag::from_config(&c));
     }
 }

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -1,4 +1,4 @@
-//! This module defines the [DateFlag]. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [DateFlag]. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;
@@ -23,7 +23,7 @@ impl DateFlag {
         match app::validate_time_format(&value) {
             Ok(()) => Some(Self::Formatted(value[1..].to_string())),
             _ => {
-                print_error!("Not a valid date format: {}", value);
+                print_error!("Not a valid date format: {}.", value);
                 None
             }
         }
@@ -36,7 +36,7 @@ impl DateFlag {
             "relative" => Some(Self::Relative),
             _ if value.starts_with('+') => Self::from_format_string(&value),
             _ => {
-                print_error!("Not a valid date value: {}", value);
+                print_error!("Not a valid date value: {}.", value);
                 None
             }
         }

--- a/src/flags/dereference.rs
+++ b/src/flags/dereference.rs
@@ -45,8 +45,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -70,29 +68,16 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Dereference::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_true() {
-        let yaml_string = "dereference: true";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Dereference(true)),
-            Dereference::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.dereference = Some(true);
+        assert_eq!(Some(Dereference(true)), Dereference::from_config(&c));
     }
 
     #[test]
     fn test_from_config_false() {
-        let yaml_string = "dereference: false";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Dereference(false)),
-            Dereference::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.dereference = Some(false);
+        assert_eq!(Some(Dereference(false)), Dereference::from_config(&c));
     }
 }

--- a/src/flags/dereference.rs
+++ b/src/flags/dereference.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Dereference] flag. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [Dereference] flag. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use the [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;

--- a/src/flags/dereference.rs
+++ b/src/flags/dereference.rs
@@ -26,12 +26,14 @@ impl Configurable<Self> for Dereference {
 
     /// Get a potential `Dereference` value from a [Config].
     ///
-    /// If the Config's [Yaml] contains the [Boolean](Yaml::Boolean) value pointed to by
-    /// "dereference", this returns its value as the value of the `Dereference`, in a [Some].
-    /// Otherwise this returns [None].
+    /// If the `Config::dereference` has value, this returns its value
+    /// as the value of the `Dereference`, in a [Some], Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(deref) = &config.dereference {
+            Some(Self(*deref))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/dereference.rs
+++ b/src/flags/dereference.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing whether to dereference symbolic links.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -31,18 +30,8 @@ impl Configurable<Self> for Dereference {
     /// "dereference", this returns its value as the value of the `Dereference`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["dereference"] {
-                Yaml::BadValue => None,
-                Yaml::Boolean(value) => Some(Self(*value)),
-                _ => {
-                    config.print_wrong_type_warning("dereference", "boolean");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -82,7 +71,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Dereference::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Dereference::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -91,7 +80,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Dereference(true)),
-            Dereference::from_config(&Config::with_yaml(yaml))
+            Dereference::from_config(&Config::with_none())
         );
     }
 
@@ -101,7 +90,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Dereference(false)),
-            Dereference::from_config(&Config::with_yaml(yaml))
+            Dereference::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -82,8 +82,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -124,39 +122,23 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Display::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_all() {
-        let yaml_string = "display: all";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Display::All),
-            Display::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.display = Some("all".into());
+        assert_eq!(Some(Display::All), Display::from_config(&c));
     }
 
     #[test]
     fn test_from_config_almost_all() {
-        let yaml_string = "display: almost-all";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Display::AlmostAll),
-            Display::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.display = Some("almost-all".into());
+        assert_eq!(Some(Display::AlmostAll), Display::from_config(&c));
     }
 
     #[test]
     fn test_from_config_directory_only() {
-        let yaml_string = "display: directory-only";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Display::DirectoryItself),
-            Display::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.display = Some("directory-only".into());
+        assert_eq!(Some(Display::DirectoryItself), Display::from_config(&c));
     }
 }

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -18,15 +18,17 @@ pub enum Display {
 }
 
 impl Display {
-    /// Get a value from a [Yaml] string. The [Config] is used to log warnings about wrong values
-    /// in a Yaml.
-    fn from_yaml_string(value: &str, config: &Config) -> Option<Self> {
+    /// Get a value from a str
+    fn from_str(value: &str) -> Option<Self> {
         match value {
             "all" => Some(Self::All),
             "almost-all" => Some(Self::AlmostAll),
             "directory-only" => Some(Self::DirectoryItself),
             _ => {
-                print_error!("display: {}", &value);
+                print_error!(
+                    "display can only be one of all, almost-all or directory-only, but got {}",
+                    &value
+                );
                 None
             }
         }
@@ -53,12 +55,15 @@ impl Configurable<Self> for Display {
 
     /// Get a potential `Display` variant from a [Config].
     ///
-    /// If the Config's [Yaml] contains a [String](Yaml::String) value pointed to by "display" and
-    /// it is either "all", "almost-all" or "directory-only", this returns the corresponding
-    /// `Display` variant in a [Some]. Otherwise this returns [None].
+    /// If the `Config::display` has value and is one of "all", "almost-all" or "directory-only",
+    /// this returns the corresponding `Display` variant in a [Some].
+    /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(disp) = &config.display {
+            Self::from_str(&disp)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -4,9 +4,9 @@
 use super::Configurable;
 
 use crate::config_file::Config;
+use crate::print_error;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing which file system nodes to display.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -26,7 +26,7 @@ impl Display {
             "almost-all" => Some(Self::AlmostAll),
             "directory-only" => Some(Self::DirectoryItself),
             _ => {
-                config.print_invalid_value_warning("display", &value);
+                print_error!("display: {}", &value);
                 None
             }
         }
@@ -57,18 +57,8 @@ impl Configurable<Self> for Display {
     /// it is either "all", "almost-all" or "directory-only", this returns the corresponding
     /// `Display` variant in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["display"] {
-                Yaml::BadValue => None,
-                Yaml::String(value) => Self::from_yaml_string(&value, &config),
-                _ => {
-                    config.print_wrong_type_warning("display", "string");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -132,7 +122,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Display::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Display::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -141,7 +131,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Display::All),
-            Display::from_config(&Config::with_yaml(yaml))
+            Display::from_config(&Config::with_none())
         );
     }
 
@@ -151,7 +141,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Display::AlmostAll),
-            Display::from_config(&Config::with_yaml(yaml))
+            Display::from_config(&Config::with_none())
         );
     }
 
@@ -161,7 +151,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Display::DirectoryItself),
-            Display::from_config(&Config::with_yaml(yaml))
+            Display::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Display] flag. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [Display] flag. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -38,7 +38,8 @@ impl Configurable<Self> for Display {
 
     /// Get a potential `Display` variant from a [Config].
     ///
-    /// If the `Config::display` has value and is one of "all", "almost-all" or "directory-only",
+    /// If the `Config::display` has value and is one of
+    /// "all", "almost-all", "directory-only" or `visible-only`,
     /// this returns the corresponding `Display` variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
@@ -46,7 +47,7 @@ impl Configurable<Self> for Display {
     }
 }
 
-/// The default value for `Display` is [Display::DisplayOnlyVisible].
+/// The default value for `Display` is [Display::VisibleOnly].
 impl Default for Display {
     fn default() -> Self {
         Display::VisibleOnly
@@ -119,5 +120,12 @@ mod test {
         let mut c = Config::with_none();
         c.display = Some(Display::DirectoryOnly);
         assert_eq!(Some(Display::DirectoryOnly), Display::from_config(&c));
+    }
+
+    #[test]
+    fn test_from_config_visible_only() {
+        let mut c = Config::with_none();
+        c.display = Some(Display::VisibleOnly);
+        assert_eq!(Some(Display::VisibleOnly), Display::from_config(&c));
     }
 }

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -4,9 +4,9 @@
 use super::Configurable;
 
 use crate::config_file::Config;
+use crate::print_error;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// A collection of flags on how to use icons.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -46,7 +46,7 @@ impl IconOption {
             "auto" => Some(Self::Auto),
             "never" => Some(Self::Never),
             _ => {
-                config.print_invalid_value_warning("icons->when", &value);
+                print_error!("icons->when: {}", &value);
                 None
             }
         }
@@ -82,22 +82,8 @@ impl Configurable<Self> for IconOption {
     /// "when" and it is one of "always", "auto" or "never", this returns its corresponding variant
     /// in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            if let Yaml::Boolean(true) = &yaml["classic"] {
-                Some(Self::Never)
-            } else {
-                match &yaml["icons"]["when"] {
-                    Yaml::BadValue => None,
-                    Yaml::String(value) => Self::from_yaml_string(&value, &config),
-                    _ => {
-                        config.print_wrong_type_warning("icons->when", "string");
-                        None
-                    }
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -123,7 +109,7 @@ impl IconTheme {
             "fancy" => Some(Self::Fancy),
             "unicode" => Some(Self::Unicode),
             _ => {
-                config.print_invalid_value_warning("icons->theme", &value);
+                print_error!("icons->theme: {}", &value);
                 None
             }
         }
@@ -153,18 +139,8 @@ impl Configurable<Self> for IconTheme {
     /// "theme" and it is one of "fancy" or "unicode", this returns its corresponding variant in a
     /// [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["icons"]["theme"] {
-                Yaml::BadValue => None,
-                Yaml::String(value) => Self::from_yaml_string(&value, &config),
-                _ => {
-                    config.print_wrong_type_warning("icons->theme", "string");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei):
+        None
     }
 }
 
@@ -241,7 +217,7 @@ mod test_icon_option {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, IconOption::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, IconOption::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -250,7 +226,7 @@ mod test_icon_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(IconOption::Always),
-            IconOption::from_config(&Config::with_yaml(yaml))
+            IconOption::from_config(&Config::with_none())
         );
     }
 
@@ -260,7 +236,7 @@ mod test_icon_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(IconOption::Auto),
-            IconOption::from_config(&Config::with_yaml(yaml))
+            IconOption::from_config(&Config::with_none())
         );
     }
 
@@ -270,7 +246,7 @@ mod test_icon_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(IconOption::Never),
-            IconOption::from_config(&Config::with_yaml(yaml))
+            IconOption::from_config(&Config::with_none())
         );
     }
 
@@ -280,7 +256,7 @@ mod test_icon_option {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(IconOption::Never),
-            IconOption::from_config(&Config::with_yaml(yaml))
+            IconOption::from_config(&Config::with_none())
         );
     }
 }
@@ -331,7 +307,7 @@ mod test_icon_theme {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, IconTheme::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, IconTheme::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -340,7 +316,7 @@ mod test_icon_theme {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(IconTheme::Fancy),
-            IconTheme::from_config(&Config::with_yaml(yaml))
+            IconTheme::from_config(&Config::with_none())
         );
     }
 
@@ -350,7 +326,7 @@ mod test_icon_theme {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(IconTheme::Unicode),
-            IconTheme::from_config(&Config::with_yaml(yaml))
+            IconTheme::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -7,6 +7,7 @@ use crate::config_file::Config;
 use crate::print_error;
 
 use clap::ArgMatches;
+use serde::Deserialize;
 
 /// A collection of flags on how to use icons.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -30,29 +31,12 @@ impl Icons {
 }
 
 /// The flag showing when to use icons in the output.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum IconOption {
     Always,
     Auto,
     Never,
-}
-
-impl IconOption {
-    /// Get a value from a str.
-    fn from_str(value: &str) -> Option<Self> {
-        match value {
-            "always" => Some(Self::Always),
-            "auto" => Some(Self::Auto),
-            "never" => Some(Self::Never),
-            _ => {
-                print_error!(
-                    "icons/when can only be one of auto, always or never, but got {}",
-                    &value
-                );
-                None
-            }
-        }
-    }
 }
 
 impl Configurable<Self> for IconOption {
@@ -88,11 +72,7 @@ impl Configurable<Self> for IconOption {
         }
 
         if let Some(icon) = &config.icons {
-            if let Some(when) = &icon.when {
-                Self::from_str(&when)
-            } else {
-                None
-            }
+            icon.when
         } else {
             None
         }
@@ -234,7 +214,7 @@ mod test_icon_option {
     fn test_from_config_always() {
         let mut c = Config::with_none();
         c.icons = Some(Icons {
-            when: Some("always".into()),
+            when: Some(IconOption::Always),
             theme: None,
         });
         assert_eq!(Some(IconOption::Always), IconOption::from_config(&c));
@@ -244,7 +224,7 @@ mod test_icon_option {
     fn test_from_config_auto() {
         let mut c = Config::with_none();
         c.icons = Some(Icons {
-            when: Some("auto".into()),
+            when: Some(IconOption::Auto),
             theme: None,
         });
         assert_eq!(Some(IconOption::Auto), IconOption::from_config(&c));
@@ -254,7 +234,7 @@ mod test_icon_option {
     fn test_from_config_never() {
         let mut c = Config::with_none();
         c.icons = Some(Icons {
-            when: Some("never".into()),
+            when: Some(IconOption::Never),
             theme: None,
         });
         assert_eq!(Some(IconOption::Never), IconOption::from_config(&c));
@@ -265,7 +245,7 @@ mod test_icon_option {
         let mut c = Config::with_none();
         c.classic = Some(true);
         c.icons = Some(Icons {
-            when: Some("always".into()),
+            when: Some(IconOption::Always),
             theme: None,
         });
         assert_eq!(Some(IconOption::Never), IconOption::from_config(&c));

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -175,10 +175,8 @@ mod test_icon_option {
     use super::IconOption;
 
     use crate::app;
-    use crate::config_file::Config;
+    use crate::config_file::{Config, Icons};
     use crate::flags::Configurable;
-
-    use yaml_rust::YamlLoader;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -233,50 +231,44 @@ mod test_icon_option {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, IconOption::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_always() {
-        let yaml_string = "icons:\n  when: always";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(IconOption::Always),
-            IconOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.icons = Some(Icons {
+            when: Some("always".into()),
+            theme: None,
+        });
+        assert_eq!(Some(IconOption::Always), IconOption::from_config(&c));
     }
 
     #[test]
     fn test_from_config_auto() {
-        let yaml_string = "icons:\n  when: auto";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(IconOption::Auto),
-            IconOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.icons = Some(Icons {
+            when: Some("auto".into()),
+            theme: None,
+        });
+        assert_eq!(Some(IconOption::Auto), IconOption::from_config(&c));
     }
 
     #[test]
     fn test_from_config_never() {
-        let yaml_string = "icons:\n  when: never";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(IconOption::Never),
-            IconOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.icons = Some(Icons {
+            when: Some("never".into()),
+            theme: None,
+        });
+        assert_eq!(Some(IconOption::Never), IconOption::from_config(&c));
     }
 
     #[test]
     fn test_from_config_classic_mode() {
-        let yaml_string = "classic: true\nicons:\n  when: always";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(IconOption::Never),
-            IconOption::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.classic = Some(true);
+        c.icons = Some(Icons {
+            when: Some("always".into()),
+            theme: None,
+        });
+        assert_eq!(Some(IconOption::Never), IconOption::from_config(&c));
     }
 }
 
@@ -285,10 +277,8 @@ mod test_icon_theme {
     use super::IconTheme;
 
     use crate::app;
-    use crate::config_file::Config;
+    use crate::config_file::{Config, Icons};
     use crate::flags::Configurable;
-
-    use yaml_rust::YamlLoader;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -323,29 +313,22 @@ mod test_icon_theme {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, IconTheme::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_fancy() {
-        let yaml_string = "icons:\n  theme: fancy";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(IconTheme::Fancy),
-            IconTheme::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.icons = Some(Icons {
+            when: None,
+            theme: Some("fancy".into()),
+        });
+        assert_eq!(Some(IconTheme::Fancy), IconTheme::from_config(&c));
     }
 
     #[test]
     fn test_from_config_unicode() {
-        let yaml_string = "icons:\n  theme: unicode";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(IconTheme::Unicode),
-            IconTheme::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.icons = Some(Icons {
+            when: None,
+            theme: Some("unicode".into()),
+        });
+        assert_eq!(Some(IconTheme::Unicode), IconTheme::from_config(&c));
     }
 }

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -38,15 +38,17 @@ pub enum IconOption {
 }
 
 impl IconOption {
-    /// Get a value from a [Yaml] string. The [Config] is used to log warnings about wrong values
-    /// in a Yaml.
-    fn from_yaml_string(value: &str, config: &Config) -> Option<Self> {
+    /// Get a value from a str.
+    fn from_str(value: &str) -> Option<Self> {
         match value {
             "always" => Some(Self::Always),
             "auto" => Some(Self::Auto),
             "never" => Some(Self::Never),
             _ => {
-                print_error!("icons->when: {}", &value);
+                print_error!(
+                    "icons/when can only be one of auto, always or never, but got {}",
+                    &value
+                );
                 None
             }
         }
@@ -76,14 +78,24 @@ impl Configurable<Self> for IconOption {
 
     /// Get a potential `IconOption` variant from a [Config].
     ///
-    /// If the Configs' [Yaml] contains a [Boolean](Yaml::Boolean) value pointed to by "classic"
-    /// and its value is `true`, then this returns the [IconOption::Never] variant in a [Some].
-    /// Otherwise if the Yaml contains a [String](Yaml::String) value pointed to by "icons" ->
-    /// "when" and it is one of "always", "auto" or "never", this returns its corresponding variant
-    /// in a [Some]. Otherwise this returns [None].
+    /// If the `Configs::classic` has value and is "true" then this returns Some(IconOption::Never).
+    /// Otherwise if the `Config::icon::when` has value and is one of "always", "auto" or "never",
+    /// this returns its corresponding variant in a [Some].
+    /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(true) = &config.classic {
+            return Some(Self::Never);
+        }
+
+        if let Some(icon) = &config.icons {
+            if let Some(when) = &icon.when {
+                Self::from_str(&when)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 }
 
@@ -104,7 +116,7 @@ pub enum IconTheme {
 impl IconTheme {
     /// Get a value from a [Yaml] string. The [Config] is used to log warnings about wrong values
     /// in a Yaml.
-    fn from_yaml_string(value: &str, config: &Config) -> Option<Self> {
+    fn from_str(value: &str) -> Option<Self> {
         match value {
             "fancy" => Some(Self::Fancy),
             "unicode" => Some(Self::Unicode),
@@ -135,12 +147,19 @@ impl Configurable<Self> for IconTheme {
 
     /// Get a potential `IconTheme` variant from a [Config].
     ///
-    /// If the Config's [Yaml] contains a [String](Yaml::String) value pointed to by "icons" ->
-    /// "theme" and it is one of "fancy" or "unicode", this returns its corresponding variant in a
-    /// [Some]. Otherwise this returns [None].
+    /// If the `Config::icons::theme` has value and is one of "fancy" or "unicode",
+    /// this returns its corresponding variant in a [Some].
+    /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei):
-        None
+        if let Some(icon) = &config.icons {
+            if let Some(theme) = &icon.theme {
+                Self::from_str(&theme)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -4,7 +4,6 @@
 use super::Configurable;
 
 use crate::config_file::Config;
-use crate::print_error;
 
 use clap::ArgMatches;
 use serde::Deserialize;
@@ -87,24 +86,11 @@ impl Default for IconOption {
 }
 
 /// The flag showing which icon theme to use.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum IconTheme {
     Unicode,
     Fancy,
-}
-
-impl IconTheme {
-    /// Get a value from a string.
-    fn from_str(value: &str) -> Option<Self> {
-        match value {
-            "fancy" => Some(Self::Fancy),
-            "unicode" => Some(Self::Unicode),
-            _ => {
-                print_error!("Bad icons.theme config, {}", &value);
-                None
-            }
-        }
-    }
 }
 
 impl Configurable<Self> for IconTheme {
@@ -131,14 +117,11 @@ impl Configurable<Self> for IconTheme {
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
         if let Some(icon) = &config.icons {
-            if let Some(theme) = &icon.theme {
-                Self::from_str(&theme)
-            } else {
-                None
+            if let Some(theme) = icon.theme {
+                return Some(theme);
             }
-        } else {
-            None
         }
+        None
     }
 }
 
@@ -296,7 +279,7 @@ mod test_icon_theme {
         let mut c = Config::with_none();
         c.icons = Some(Icons {
             when: None,
-            theme: Some("fancy".into()),
+            theme: Some(IconTheme::Fancy),
         });
         assert_eq!(Some(IconTheme::Fancy), IconTheme::from_config(&c));
     }
@@ -306,7 +289,7 @@ mod test_icon_theme {
         let mut c = Config::with_none();
         c.icons = Some(Icons {
             when: None,
-            theme: Some("unicode".into()),
+            theme: Some(IconTheme::Unicode),
         });
         assert_eq!(Some(IconTheme::Unicode), IconTheme::from_config(&c));
     }

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -1,4 +1,4 @@
-//! This module defines the [IconOption]. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [IconOption]. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;
@@ -94,14 +94,13 @@ pub enum IconTheme {
 }
 
 impl IconTheme {
-    /// Get a value from a [Yaml] string. The [Config] is used to log warnings about wrong values
-    /// in a Yaml.
+    /// Get a value from a string.
     fn from_str(value: &str) -> Option<Self> {
         match value {
             "fancy" => Some(Self::Fancy),
             "unicode" => Some(Self::Unicode),
             _ => {
-                print_error!("icons->theme: {}", &value);
+                print_error!("Bad icons.theme config, {}", &value);
                 None
             }
         }

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -145,8 +145,6 @@ mod test {
     use crate::app;
     use crate::config_file::Config;
 
-    use yaml_rust::YamlLoader;
-
     // The following tests are implemented using match expressions instead of the assert_eq macro,
     // because clap::Error does not implement PartialEq.
     //
@@ -165,16 +163,6 @@ mod test {
 
     #[test]
     fn test_from_config_none() {
-        assert!(match IgnoreGlobs::from_config(&Config::with_none()) {
-            None => true,
-            _ => false,
-        });
-    }
-
-    #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert!(match IgnoreGlobs::from_config(&Config::with_none()) {
             None => true,
             _ => false,

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -2,7 +2,6 @@
 //! [Default] value, use the [configure_from](IgnoreGlobs::configure_from) method.
 
 use crate::config_file::Config;
-use crate::print_error;
 
 use clap::{ArgMatches, Error, ErrorKind};
 use globset::{Glob, GlobSet, GlobSetBuilder};
@@ -79,23 +78,17 @@ impl IgnoreGlobs {
     /// If the `Config::ignore-globs` contains an Array of Strings,
     /// each of its values is used to build the [GlobSet]. If the building
     /// succeeds, the [GlobSet] is returned in the [Result] in a [Some]. If any error is
-    /// encountered while building, an [Error] is returned in the Result instead. If the Yaml does
+    /// encountered while building, an [Error] is returned in the Result instead. If the Config does
     /// not contain such a key, this returns [None].
     fn from_config(config: &Config) -> Option<Result<GlobSet, Error>> {
         if let Some(globs) = &config.ignore_globs {
             let mut glob_set_builder = GlobSetBuilder::new();
             for glob in globs.iter() {
-                match glob.as_str() {
-                    Some(glob) => match Self::create_glob(glob) {
-                        Ok(glob) => {
-                            glob_set_builder.add(glob);
-                        }
-                        Err(err) => return Some(Err(err)),
-                    },
-                    None => {
-                        print_error!("ignore-globs must be a string");
-                        continue;
+                match Self::create_glob(glob) {
+                    Ok(glob) => {
+                        glob_set_builder.add(glob);
                     }
+                    Err(err) => return Some(Err(err)),
                 }
             }
             Some(Self::create_glob_set(&glob_set_builder))

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -1,4 +1,4 @@
-//! This module defines the [IgnoreGlobs]. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [IgnoreGlobs]. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use the [configure_from](IgnoreGlobs::configure_from) method.
 
 use crate::config_file::Config;
@@ -16,11 +16,6 @@ impl IgnoreGlobs {
     /// - [from_arg_matches](IgnoreGlobs::from_arg_matches)
     /// - [from_config](IgnoreGlobs::from_config)
     /// - [Default::default]
-    ///
-    /// # Note
-    ///
-    /// The configuration file's Yaml is read in any case, to be able to check for errors and print
-    /// out warnings.
     ///
     /// # Errors
     ///

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -152,6 +152,42 @@ mod test {
     // even implement PartialEq and thus can not be easily compared.
 
     #[test]
+    fn test_configuration_from_none() {
+        let argv = vec!["lsd"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert!(
+            match IgnoreGlobs::configure_from(&matches, &Config::with_none()) {
+                Ok(_) => true,
+                _ => false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_configuration_from_args() {
+        let argv = vec!["lsd", "--ignore-glob", ".git"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert!(
+            match IgnoreGlobs::configure_from(&matches, &Config::with_none()) {
+                Ok(_) => true,
+                _ => false,
+            }
+        );
+    }
+
+    #[test]
+    fn test_configuration_from_config() {
+        let argv = vec!["lsd"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        let mut c = Config::with_none();
+        c.ignore_globs = Some(vec![".git".into()].into());
+        assert!(match IgnoreGlobs::configure_from(&matches, &c) {
+            Ok(_) => true,
+            _ => false,
+        });
+    }
+
+    #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();

--- a/src/flags/indicators.rs
+++ b/src/flags/indicators.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Indicators] flag. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [Indicators] flag. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use the [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;

--- a/src/flags/indicators.rs
+++ b/src/flags/indicators.rs
@@ -46,8 +46,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -71,29 +69,16 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Indicators::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_true() {
-        let yaml_string = "indicators: true";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Indicators(true)),
-            Indicators::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.indicators = Some(true);
+        assert_eq!(Some(Indicators(true)), Indicators::from_config(&c));
     }
 
     #[test]
     fn test_from_config_false() {
-        let yaml_string = "indicators: false";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Indicators(false)),
-            Indicators::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.indicators = Some(false);
+        assert_eq!(Some(Indicators(false)), Indicators::from_config(&c));
     }
 }

--- a/src/flags/indicators.rs
+++ b/src/flags/indicators.rs
@@ -26,12 +26,15 @@ impl Configurable<Self> for Indicators {
 
     /// Get a potential `Indicators` value from a [Config].
     ///
-    /// If the Config's [Yaml] contains the [Boolean](Yaml::Boolean) value pointed to by
-    /// "indicators", this returns its value as the value of the `Indicators`, in a [Some].
+    /// If the `Config::indicators` has value,
+    /// this returns its value as the value of the `Indicators`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(ind) = &config.indicators {
+            Some(Self(*ind))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/indicators.rs
+++ b/src/flags/indicators.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing whether to print file type indicators.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -31,18 +30,8 @@ impl Configurable<Self> for Indicators {
     /// "indicators", this returns its value as the value of the `Indicators`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["indicators"] {
-                Yaml::BadValue => None,
-                Yaml::Boolean(value) => Some(Self(*value)),
-                _ => {
-                    config.print_wrong_type_warning("indicators", "boolean");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -82,7 +71,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Indicators::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Indicators::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -91,7 +80,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Indicators(true)),
-            Indicators::from_config(&Config::with_yaml(yaml))
+            Indicators::from_config(&Config::with_none())
         );
     }
 
@@ -101,7 +90,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Indicators(false)),
-            Indicators::from_config(&Config::with_yaml(yaml))
+            Indicators::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Layout] flag. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [Layout] flag. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
 use crate::config_file::Config;

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -2,14 +2,15 @@
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
 use crate::config_file::Config;
-use crate::print_error;
 
 use super::Configurable;
 
 use clap::ArgMatches;
+use serde::Deserialize;
 
 /// The flag showing which output layout to print.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Layout {
     Grid,
     Tree,
@@ -44,22 +45,7 @@ impl Configurable<Layout> for Layout {
     /// this returns the corresponding `Layout` variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(layout) = &config.layout {
-            match layout.as_ref() {
-                "tree" => Some(Self::Tree),
-                "oneline" => Some(Self::OneLine),
-                "grid" => Some(Self::Grid),
-                _ => {
-                    print_error!(
-                        "layout can only be one of tree, oneline or grid, but got {}",
-                        &layout
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        config.layout
     }
 }
 
@@ -121,21 +107,21 @@ mod test {
     #[test]
     fn test_from_config_tree() {
         let mut c = Config::with_none();
-        c.layout = Some("tree".into());
+        c.layout = Some(Layout::Tree);
         assert_eq!(Some(Layout::Tree), Layout::from_config(&c));
     }
 
     #[test]
     fn test_from_config_oneline() {
         let mut c = Config::with_none();
-        c.layout = Some("oneline".into());
+        c.layout = Some(Layout::OneLine);
         assert_eq!(Some(Layout::OneLine), Layout::from_config(&c));
     }
 
     #[test]
     fn test_from_config_grid() {
         let mut c = Config::with_none();
-        c.layout = Some("grid".into());
+        c.layout = Some(Layout::Grid);
         assert_eq!(Some(Layout::Grid), Layout::from_config(&c));
     }
 }

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -10,10 +10,11 @@ use serde::Deserialize;
 
 /// The flag showing which output layout to print.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 pub enum Layout {
     Grid,
     Tree,
+    #[serde(rename = "oneline")]
     OneLine,
 }
 

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -1,9 +1,10 @@
 //! This module defines the [Layout] flag. To set it up from [ArgMatches], a [Yaml] and its
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
-use super::Configurable;
-
 use crate::config_file::Config;
+use crate::print_error;
+
+use super::Configurable;
 
 use clap::ArgMatches;
 
@@ -39,12 +40,26 @@ impl Configurable<Layout> for Layout {
 
     /// Get a potential Layout variant from a [Config].
     ///
-    /// If the Config's [Yaml] contains a [String](Yaml::String) value pointed to by "layout" and
-    /// it is either "tree", "oneline" or "grid", this returns the corresponding `Layout` variant
-    /// in a [Some]. Otherwise this returns [None].
+    /// If the `Config::layout` has value and is one of "tree", "oneline" or "grid",
+    /// this returns the corresponding `Layout` variant in a [Some].
+    /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(layout) = &config.layout {
+            match layout.as_ref() {
+                "tree" => Some(Self::Tree),
+                "oneline" => Some(Self::OneLine),
+                "grid" => Some(Self::Grid),
+                _ => {
+                    print_error!(
+                        "layout can only be one of tree, oneline or grid, but got {}",
+                        &layout
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -78,8 +78,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -121,39 +119,23 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Layout::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_tree() {
-        let yaml_string = "layout: tree";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Layout::Tree),
-            Layout::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.layout = Some("tree".into());
+        assert_eq!(Some(Layout::Tree), Layout::from_config(&c));
     }
 
     #[test]
     fn test_from_config_oneline() {
-        let yaml_string = "layout: oneline";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Layout::OneLine),
-            Layout::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.layout = Some("oneline".into());
+        assert_eq!(Some(Layout::OneLine), Layout::from_config(&c));
     }
 
     #[test]
     fn test_from_config_grid() {
-        let yaml_string = "layout: grid";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(Layout::Grid),
-            Layout::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.layout = Some("grid".into());
+        assert_eq!(Some(Layout::Grid), Layout::from_config(&c));
     }
 }

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing which output layout to print.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -44,26 +43,8 @@ impl Configurable<Layout> for Layout {
     /// it is either "tree", "oneline" or "grid", this returns the corresponding `Layout` variant
     /// in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["layout"] {
-                Yaml::BadValue => None,
-                Yaml::String(value) => match value.as_ref() {
-                    "tree" => Some(Self::Tree),
-                    "oneline" => Some(Self::OneLine),
-                    "grid" => Some(Self::Grid),
-                    _ => {
-                        config.print_invalid_value_warning("layout", &value);
-                        None
-                    }
-                },
-                _ => {
-                    config.print_wrong_type_warning("layout", "string");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -128,7 +109,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Layout::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Layout::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -137,7 +118,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Layout::Tree),
-            Layout::from_config(&Config::with_yaml(yaml))
+            Layout::from_config(&Config::with_none())
         );
     }
 
@@ -147,7 +128,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Layout::OneLine),
-            Layout::from_config(&Config::with_yaml(yaml))
+            Layout::from_config(&Config::with_none())
         );
     }
 
@@ -157,7 +138,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(Layout::Grid),
-            Layout::from_config(&Config::with_yaml(yaml))
+            Layout::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -32,17 +32,16 @@ impl Recursion {
     /// Get the "enabled" boolean from [ArgMatches], a [Config] or the [Default] value. The first
     /// value that is not [None] is used. The order of precedence for the value used is:
     /// - [enabled_from_arg_matches](Recursion::enabled_from_arg_matches)
-    /// - [enabled_from_config](Recursion::enabled_from_config)
+    /// - [Config.recursion.enabled]
     /// - [Default::default]
     fn enabled_from(matches: &ArgMatches, config: &Config) -> bool {
+        if let Some(value) = Self::enabled_from_arg_matches(matches) {
+            return value;
+        }
         if let Some(recursion) = &config.recursion {
             if let Some(enabled) = recursion.enabled {
                 return enabled;
             }
-        }
-
-        if let Some(value) = Self::enabled_from_arg_matches(matches) {
-            return value;
         }
 
         Default::default()
@@ -63,7 +62,7 @@ impl Recursion {
     /// Get the "depth" integer from [ArgMatches], a [Config] or the [Default] value. The first
     /// value that is not [None] is used. The order of precedence for the value used is:
     /// - [depth_from_arg_matches](Recursion::depth_from_arg_matches)
-    /// - [depth_from_config](Recursion::depth_from_config)
+    /// - [Config.recursion.depth]
     /// - [Default::default]
     ///
     /// # Note
@@ -75,14 +74,14 @@ impl Recursion {
     /// If [depth_from_arg_matches](Recursion::depth_from_arg_matches) returns an [Error], this
     /// returns it.
     fn depth_from(matches: &ArgMatches, config: &Config) -> Result<usize, Error> {
+        if let Some(value) = Self::depth_from_arg_matches(matches) {
+            return value;
+        }
+
         if let Some(recursion) = &config.recursion {
             if let Some(depth) = recursion.depth {
                 return Ok(depth);
             }
-        }
-
-        if let Some(value) = Self::depth_from_arg_matches(matches) {
-            return value;
         }
 
         Ok(usize::max_value())

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -162,7 +162,7 @@ mod test {
     #[test]
     fn test_enabled_from_config_true() {
         let argv = vec!["lsd"];
-        let mut c = &Config::with_none();
+        let mut c = Config::with_none();
         c.recursion = Some(config_file::Recursion {
             enabled: Some(true),
             depth: None,
@@ -176,7 +176,7 @@ mod test {
     #[test]
     fn test_enabled_from_config_false() {
         let argv = vec!["lsd"];
-        let mut c = &Config::with_none();
+        let mut c = Config::with_none();
         c.recursion = Some(config_file::Recursion {
             enabled: Some(false),
             depth: None,
@@ -261,7 +261,7 @@ mod test {
     #[test]
     fn test_depth_from_config_pos_integer() {
         let argv = vec!["lsd"];
-        let mut c = &Config::with_none();
+        let mut c = Config::with_none();
         c.recursion = Some(config_file::Recursion {
             enabled: None,
             depth: Some(42),

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -133,7 +133,7 @@ mod test {
     use clap::ErrorKind;
 
     #[test]
-    fn test_enabled_from_arg_matches_none() {
+    fn test_enabled_from_arg_matches_empty() {
         let argv = vec!["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(None, Recursion::enabled_from_arg_matches(&matches));
@@ -147,7 +147,7 @@ mod test {
     }
 
     #[test]
-    fn test_enabled_from_config_empty() {
+    fn test_enabled_from_empty_matches_and_config() {
         let argv = vec!["lsd"];
         assert_eq!(
             false,
@@ -159,7 +159,7 @@ mod test {
     }
 
     #[test]
-    fn test_enabled_from_config_true() {
+    fn test_enabled_from_matches_empty_and_config_true() {
         let argv = vec!["lsd"];
         let mut c = Config::with_none();
         c.recursion = Some(config_file::Recursion {
@@ -173,7 +173,7 @@ mod test {
     }
 
     #[test]
-    fn test_enabled_from_config_false() {
+    fn test_enabled_from_matches_empty_and_config_false() {
         let argv = vec!["lsd"];
         let mut c = Config::with_none();
         c.recursion = Some(config_file::Recursion {
@@ -190,7 +190,7 @@ mod test {
     // of the assert_eq macro, because clap::Error does not implement PartialEq.
 
     #[test]
-    fn test_depth_from_arg_matches_none() {
+    fn test_depth_from_arg_matches_empty() {
         let argv = vec!["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert!(match Recursion::depth_from_arg_matches(&matches) {

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -4,7 +4,6 @@
 use crate::config_file::Config;
 
 use clap::{ArgMatches, Error, ErrorKind};
-use yaml_rust::Yaml;
 
 /// The options relating to recursion.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -43,11 +42,11 @@ impl Recursion {
     fn enabled_from(matches: &ArgMatches, config: &Config) -> bool {
         let mut result: bool = Default::default();
 
-        if config.has_yaml() {
-            if let Some(value) = Self::enabled_from_config(config) {
-                result = value;
-            }
-        }
+        // if config.has_yaml() {
+        //     if let Some(value) = Self::enabled_from_config(config) {
+        //         result = value;
+        //     }
+        // }
 
         if let Some(value) = Self::enabled_from_arg_matches(matches) {
             result = value;
@@ -73,18 +72,8 @@ impl Recursion {
     /// If the Config's [Yaml] contains a [Boolean](Yaml::Boolean) value pointed to by "recursion"
     /// -> "enabled", this returns its value in a [Some]. Otherwise this returns [None].
     fn enabled_from_config(config: &Config) -> Option<bool> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["recursion"]["enabled"] {
-                Yaml::BadValue => None,
-                Yaml::Boolean(value) => Some(*value),
-                _ => {
-                    config.print_wrong_type_warning("recursion->enabled", "boolean");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei):
+        None
     }
 
     /// Get the "depth" integer from [ArgMatches], a [Config] or the [Default] value. The first
@@ -105,11 +94,11 @@ impl Recursion {
     fn depth_from(matches: &ArgMatches, config: &Config) -> Result<usize, Error> {
         let mut result: Result<usize, Error> = Ok(usize::max_value());
 
-        if config.has_yaml() {
-            if let Some(value) = Self::depth_from_config(config) {
-                result = Ok(value);
-            }
-        }
+        // if config.has_yaml() {
+        //     if let Some(value) = Self::depth_from_config(config) {
+        //         result = Ok(value);
+        //     }
+        // }
 
         if let Some(value) = Self::depth_from_arg_matches(matches) {
             result = value;
@@ -148,27 +137,8 @@ impl Recursion {
     /// If the Config's [Yaml] contains a positive [Integer](Yaml::Integer) value pointed to by
     /// "recursion" -> "depth", this returns its value in a [Some]. Otherwise this returns [None].
     fn depth_from_config(config: &Config) -> Option<usize> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["recursion"]["depth"] {
-                Yaml::BadValue => None,
-                Yaml::Integer(value) => {
-                    if *value > 0 {
-                        Some(*value as usize)
-                    } else {
-                        config.print_warning(
-                            "The recursion->depth value has to be greater than zero.",
-                        );
-                        None
-                    }
-                }
-                _ => {
-                    config.print_wrong_type_warning("recursion->depth", "integer");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei):
+        None
     }
 }
 
@@ -217,7 +187,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             None,
-            Recursion::enabled_from_config(&Config::with_yaml(yaml))
+            Recursion::enabled_from_config(&Config::with_none())
         );
     }
 
@@ -227,7 +197,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(true),
-            Recursion::enabled_from_config(&Config::with_yaml(yaml))
+            Recursion::enabled_from_config(&Config::with_none())
         );
     }
 
@@ -237,7 +207,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(false),
-            Recursion::enabled_from_config(&Config::with_yaml(yaml))
+            Recursion::enabled_from_config(&Config::with_none())
         );
     }
 
@@ -308,7 +278,7 @@ mod test {
     fn test_depth_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Recursion::depth_from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Recursion::depth_from_config(&Config::with_none()));
     }
 
     #[test]
@@ -317,7 +287,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(42),
-            Recursion::depth_from_config(&Config::with_yaml(yaml))
+            Recursion::depth_from_config(&Config::with_none())
         );
     }
 
@@ -325,13 +295,13 @@ mod test {
     fn test_depth_from_config_neg_integer() {
         let yaml_string = "recursion:\n  depth: -42";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Recursion::depth_from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Recursion::depth_from_config(&Config::with_none()));
     }
 
     #[test]
     fn test_depth_from_config_string() {
         let yaml_string = "recursion:\n  depth: foo";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, Recursion::depth_from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, Recursion::depth_from_config(&Config::with_none()));
     }
 }

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Recursion] options. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [Recursion] options. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use the [configure_from](Recursion::configure_from) method.
 
 use crate::config_file::Config;

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -7,9 +7,11 @@ use crate::config_file::Config;
 use crate::print_error;
 
 use clap::ArgMatches;
+use serde::Deserialize;
 
 /// The flag showing which file size units to use.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SizeFlag {
     /// The variant to show file size with SI unit prefix and a B for bytes.
     Default,
@@ -57,10 +59,7 @@ impl Configurable<Self> for SizeFlag {
     /// this returns the corresponding `SizeFlag` variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(size) = &config.size {
-            return Self::from_str(size);
-        }
-        None
+        config.size
     }
 }
 
@@ -118,21 +117,21 @@ mod test {
     #[test]
     fn test_from_config_default() {
         let mut c = Config::with_none();
-        c.size = Some("default".into());
+        c.size = Some(SizeFlag::Default);
         assert_eq!(Some(SizeFlag::Default), SizeFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_short() {
         let mut c = Config::with_none();
-        c.size = Some("short".into());
+        c.size = Some(SizeFlag::Short);
         assert_eq!(Some(SizeFlag::Short), SizeFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_bytes() {
         let mut c = Config::with_none();
-        c.size = Some("bytes".into());
+        c.size = Some(SizeFlag::Bytes);
         assert_eq!(Some(SizeFlag::Bytes), SizeFlag::from_config(&c));
     }
 }

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -1,4 +1,4 @@
-//! This module defines the [SizeFlag]. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [SizeFlag]. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use its [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;
@@ -29,7 +29,7 @@ impl SizeFlag {
             "bytes" => Some(Self::Bytes),
             _ => {
                 print_error!(
-                    "size can only be one of default, short or bytes, but got {}",
+                    "Size can only be one of default, short or bytes, but got {}.",
                     value
                 );
                 None

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -79,8 +79,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -118,39 +116,23 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SizeFlag::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_default() {
-        let yaml_string = "size: default";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SizeFlag::Default),
-            SizeFlag::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.size = Some("default".into());
+        assert_eq!(Some(SizeFlag::Default), SizeFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_short() {
-        let yaml_string = "size: short";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SizeFlag::Short),
-            SizeFlag::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.size = Some("short".into());
+        assert_eq!(Some(SizeFlag::Short), SizeFlag::from_config(&c));
     }
 
     #[test]
     fn test_from_config_bytes() {
-        let yaml_string = "size: bytes";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SizeFlag::Bytes),
-            SizeFlag::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.size = Some("bytes".into());
+        assert_eq!(Some(SizeFlag::Bytes), SizeFlag::from_config(&c));
     }
 }

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing which file size units to use.
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]
@@ -44,26 +43,8 @@ impl Configurable<Self> for SizeFlag {
     /// is either "default", "short" or "bytes", this returns the corresponding `SizeFlag` variant
     /// in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["size"] {
-                Yaml::BadValue => None,
-                Yaml::String(value) => match value.as_ref() {
-                    "default" => Some(Self::Default),
-                    "short" => Some(Self::Short),
-                    "bytes" => Some(Self::Bytes),
-                    _ => {
-                        config.print_invalid_value_warning("size", &value);
-                        None
-                    }
-                },
-                _ => {
-                    config.print_wrong_type_warning("size", "string");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -124,7 +105,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SizeFlag::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, SizeFlag::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -133,7 +114,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SizeFlag::Default),
-            SizeFlag::from_config(&Config::with_yaml(yaml))
+            SizeFlag::from_config(&Config::with_none())
         );
     }
 
@@ -143,7 +124,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SizeFlag::Short),
-            SizeFlag::from_config(&Config::with_yaml(yaml))
+            SizeFlag::from_config(&Config::with_none())
         );
     }
 
@@ -153,7 +134,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SizeFlag::Bytes),
-            SizeFlag::from_config(&Config::with_yaml(yaml))
+            SizeFlag::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -4,7 +4,6 @@
 use super::Configurable;
 
 use crate::config_file::Config;
-use crate::print_error;
 
 use clap::ArgMatches;
 use serde::Deserialize;
@@ -28,11 +27,10 @@ impl SizeFlag {
             "short" => Some(Self::Short),
             "bytes" => Some(Self::Bytes),
             _ => {
-                print_error!(
+                panic!(
                     "Size can only be one of default, short or bytes, but got {}.",
                     value
                 );
-                None
             }
         }
     }

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -420,7 +420,7 @@ mod test_sort_order {
     }
 
     #[test]
-    fn test_from_config_reverse() {
+    fn test_from_config_reverse_true() {
         let mut c = Config::with_none();
         c.sorting = Some(Sorting {
             column: None,
@@ -428,6 +428,17 @@ mod test_sort_order {
             dir_grouping: None,
         });
         assert_eq!(Some(SortOrder::Reverse), SortOrder::from_config(&c));
+    }
+
+    #[test]
+    fn test_from_config_reverse_false() {
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: Some(false),
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortOrder::Default), SortOrder::from_config(&c));
     }
 }
 

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// A collection of flags on how to sort the output.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -69,28 +68,8 @@ impl Configurable<Self> for SortColumn {
     /// "column" and it is one of "time", "size" or "name", this returns the corresponding variant
     /// in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["sorting"]["column"] {
-                Yaml::BadValue => None,
-                Yaml::String(value) => match value.as_ref() {
-                    "extension" => Some(Self::Extension),
-                    "name" => Some(Self::Name),
-                    "time" => Some(Self::Time),
-                    "size" => Some(Self::Size),
-                    "version" => Some(Self::Version),
-                    _ => {
-                        config.print_invalid_value_warning("sorting->column", &value);
-                        None
-                    }
-                },
-                _ => {
-                    config.print_wrong_type_warning("sorting->column", "string");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -127,24 +106,8 @@ impl Configurable<Self> for SortOrder {
     /// "reverse", this returns a mapped variant in a [Some]. Otherwise [None] is returned. A
     /// `true` maps to [SortOrder::Reverse] and a `false` maps to [SortOrder::Default].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["sorting"]["reverse"] {
-                Yaml::BadValue => None,
-                Yaml::Boolean(value) => {
-                    if *value {
-                        Some(Self::Reverse)
-                    } else {
-                        Some(Self::Default)
-                    }
-                }
-                _ => {
-                    config.print_wrong_type_warning("sorting->reverse", "boolean");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei):
+        None
     }
 }
 
@@ -192,30 +155,8 @@ impl Configurable<Self> for DirGrouping {
     /// "dir-grouping" and it is one of "first", "last" or "none", this returns its corresponding
     /// variant in a [Some]. Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            if let Yaml::Boolean(true) = &yaml["classic"] {
-                Some(Self::None)
-            } else {
-                match &yaml["sorting"]["dir-grouping"] {
-                    Yaml::BadValue => None,
-                    Yaml::String(value) => match value.as_ref() {
-                        "first" => Some(Self::First),
-                        "last" => Some(Self::Last),
-                        "none" => Some(Self::None),
-                        _ => {
-                            config.print_invalid_value_warning("sorting->dir-grouping", &value);
-                            None
-                        }
-                    },
-                    _ => {
-                        config.print_wrong_type_warning("sorting->dir-grouping", "string");
-                        None
-                    }
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei):
+        None
     }
 }
 
@@ -333,14 +274,14 @@ mod test_sort_column {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SortColumn::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, SortColumn::from_config(&Config::with_none()));
     }
 
     #[test]
     fn test_from_config_invalid() {
         let yaml_string = "sorting:\n  column: foo";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SortColumn::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, SortColumn::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -349,7 +290,7 @@ mod test_sort_column {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortColumn::Extension),
-            SortColumn::from_config(&Config::with_yaml(yaml))
+            SortColumn::from_config(&Config::with_none())
         );
     }
 
@@ -359,7 +300,7 @@ mod test_sort_column {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortColumn::Name),
-            SortColumn::from_config(&Config::with_yaml(yaml))
+            SortColumn::from_config(&Config::with_none())
         );
     }
 
@@ -369,7 +310,7 @@ mod test_sort_column {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortColumn::Time),
-            SortColumn::from_config(&Config::with_yaml(yaml))
+            SortColumn::from_config(&Config::with_none())
         );
     }
 
@@ -379,7 +320,7 @@ mod test_sort_column {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortColumn::Size),
-            SortColumn::from_config(&Config::with_yaml(yaml))
+            SortColumn::from_config(&Config::with_none())
         );
     }
 
@@ -389,7 +330,7 @@ mod test_sort_column {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortColumn::Version),
-            SortColumn::from_config(&Config::with_yaml(yaml))
+            SortColumn::from_config(&Config::with_none())
         );
     }
 }
@@ -430,7 +371,7 @@ mod test_sort_order {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SortOrder::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, SortOrder::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -439,7 +380,7 @@ mod test_sort_order {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortOrder::Default),
-            SortOrder::from_config(&Config::with_yaml(yaml))
+            SortOrder::from_config(&Config::with_none())
         );
     }
 
@@ -449,7 +390,7 @@ mod test_sort_order {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortOrder::Reverse),
-            SortOrder::from_config(&Config::with_yaml(yaml))
+            SortOrder::from_config(&Config::with_none())
         );
     }
 }
@@ -520,7 +461,7 @@ mod test_dir_grouping {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, DirGrouping::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, DirGrouping::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -529,7 +470,7 @@ mod test_dir_grouping {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(DirGrouping::First),
-            DirGrouping::from_config(&Config::with_yaml(yaml))
+            DirGrouping::from_config(&Config::with_none())
         );
     }
 
@@ -539,7 +480,7 @@ mod test_dir_grouping {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(DirGrouping::Last),
-            DirGrouping::from_config(&Config::with_yaml(yaml))
+            DirGrouping::from_config(&Config::with_none())
         );
     }
 
@@ -549,7 +490,7 @@ mod test_dir_grouping {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(DirGrouping::None),
-            DirGrouping::from_config(&Config::with_yaml(yaml))
+            DirGrouping::from_config(&Config::with_none())
         );
     }
 
@@ -559,7 +500,7 @@ mod test_dir_grouping {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(DirGrouping::None),
-            DirGrouping::from_config(&Config::with_yaml(yaml))
+            DirGrouping::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -150,7 +150,10 @@ impl DirGrouping {
             "first" => Some(Self::First),
             "last" => Some(Self::Last),
             "none" => Some(Self::None),
-            _ => None,
+            _ => panic!(
+                "Group Dir can only be one of first, last or none, but got {}.",
+                value
+            ),
         }
     }
 }
@@ -295,12 +298,12 @@ mod test_sort_column {
     }
 
     #[test]
-    fn test_from_config_none() {
+    fn test_from_config_empty() {
         assert_eq!(None, SortColumn::from_config(&Config::with_none()));
     }
 
     #[test]
-    fn test_from_config_none_column() {
+    fn test_from_config_empty_column() {
         let mut c = Config::with_none();
         c.sorting = Some(Sorting {
             column: None,
@@ -393,20 +396,20 @@ mod test_sort_order {
     }
 
     #[test]
-    fn test_from_config_none() {
+    fn test_from_config_empty() {
         assert_eq!(None, SortOrder::from_config(&Config::with_none()));
     }
 
     #[test]
-    fn test_from_config_default() {
+    fn test_from_config_default_config() {
         assert_eq!(
-            Some(SortOrder::Default),
+            Some(SortOrder::default()),
             SortOrder::from_config(&Config::default())
         );
     }
 
     #[test]
-    fn test_from_config_none_reverse() {
+    fn test_from_config_empty_reverse() {
         let mut c = Config::with_none();
         c.sorting = Some(Sorting {
             column: None,
@@ -437,6 +440,9 @@ mod test_dir_grouping {
     use crate::flags::Configurable;
 
     #[test]
+    #[should_panic(
+        expected = "Group Dir can only be one of first, last or none, but got bad value."
+    )]
     fn test_from_str_bad_value() {
         assert_eq!(None, DirGrouping::from_str("bad value"));
     }
@@ -489,7 +495,7 @@ mod test_dir_grouping {
     }
 
     #[test]
-    fn test_from_config_none() {
+    fn test_from_config_empty() {
         assert_eq!(None, DirGrouping::from_config(&Config::with_none()));
     }
 
@@ -516,7 +522,7 @@ mod test_dir_grouping {
     }
 
     #[test]
-    fn test_from_config_explicit_none() {
+    fn test_from_config_explicit_empty() {
         let mut c = Config::with_none();
         c.sorting = Some(Sorting {
             column: None,

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -221,10 +221,8 @@ mod test_sort_column {
     use super::SortColumn;
 
     use crate::app;
-    use crate::config_file::Config;
+    use crate::config_file::{Config, Sorting};
     use crate::flags::Configurable;
-
-    use yaml_rust::YamlLoader;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -320,67 +318,70 @@ mod test_sort_column {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SortColumn::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_invalid() {
-        let yaml_string = "sorting:\n  column: foo";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SortColumn::from_config(&Config::with_none()));
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: Some("foo".into()),
+            reverse: None,
+            dir_grouping: None,
+        });
+
+        assert_eq!(None, SortColumn::from_config(&c));
     }
 
     #[test]
     fn test_from_config_extension() {
-        let yaml_string = "sorting:\n  column: extension";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SortColumn::Extension),
-            SortColumn::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: Some("extension".into()),
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortColumn::Extension), SortColumn::from_config(&c));
     }
 
     #[test]
     fn test_from_config_name() {
-        let yaml_string = "sorting:\n  column: name";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SortColumn::Name),
-            SortColumn::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: Some("name".into()),
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortColumn::Name), SortColumn::from_config(&c));
     }
 
     #[test]
     fn test_from_config_time() {
-        let yaml_string = "sorting:\n  column: time";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SortColumn::Time),
-            SortColumn::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: Some("time".into()),
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortColumn::Time), SortColumn::from_config(&c));
     }
 
     #[test]
     fn test_from_config_size() {
-        let yaml_string = "sorting:\n  column: size";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SortColumn::Size),
-            SortColumn::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: Some("size".into()),
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortColumn::Size), SortColumn::from_config(&c));
     }
 
     #[test]
     fn test_from_config_version() {
-        let yaml_string = "sorting:\n  column: version";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SortColumn::Version),
-            SortColumn::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: Some("version".into()),
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortColumn::Version), SortColumn::from_config(&c));
     }
 }
 
@@ -389,10 +390,8 @@ mod test_sort_order {
     use super::SortOrder;
 
     use crate::app;
-    use crate::config_file::Config;
+    use crate::config_file::{Config, Sorting};
     use crate::flags::Configurable;
-
-    use yaml_rust::YamlLoader;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -417,30 +416,22 @@ mod test_sort_order {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SortOrder::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_default() {
-        let yaml_string = "sorting:\n  reverse: false";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SortOrder::Default),
-            SortOrder::from_config(&Config::with_none())
+            SortOrder::from_config(&Config::default())
         );
     }
 
     #[test]
     fn test_from_config_reverse() {
-        let yaml_string = "sorting:\n  reverse: true";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(SortOrder::Reverse),
-            SortOrder::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: Some(true),
+            dir_grouping: None,
+        });
+        assert_eq!(Some(SortOrder::Reverse), SortOrder::from_config(&c));
     }
 }
 
@@ -449,10 +440,8 @@ mod test_dir_grouping {
     use super::DirGrouping;
 
     use crate::app;
-    use crate::config_file::Config;
+    use crate::config_file::{Config, Sorting};
     use crate::flags::Configurable;
-
-    use yaml_rust::YamlLoader;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -507,49 +496,42 @@ mod test_dir_grouping {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, DirGrouping::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_first() {
-        let yaml_string = "sorting:\n  dir-grouping: first";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DirGrouping::First),
-            DirGrouping::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: None,
+            dir_grouping: Some("first".into()),
+        });
+        assert_eq!(Some(DirGrouping::First), DirGrouping::from_config(&c));
     }
 
     #[test]
     fn test_from_config_last() {
-        let yaml_string = "sorting:\n  dir-grouping: last";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DirGrouping::Last),
-            DirGrouping::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: None,
+            dir_grouping: Some("last".into()),
+        });
+        assert_eq!(Some(DirGrouping::Last), DirGrouping::from_config(&c));
     }
 
     #[test]
     fn test_from_config_explicit_none() {
-        let yaml_string = "sorting:\n  dir-grouping: none";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DirGrouping::None),
-            DirGrouping::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(None, DirGrouping::from_config(&c));
     }
 
     #[test]
     fn test_from_config_classic_mode() {
-        let yaml_string = "classic: true\nsorting:\n  dir-grouping: first";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(DirGrouping::None),
-            DirGrouping::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.classic = Some(true);
+        assert_eq!(Some(DirGrouping::None), DirGrouping::from_config(&c));
     }
 }

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -318,6 +318,18 @@ mod test_sort_column {
     }
 
     #[test]
+    fn test_from_config_none_column() {
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: None,
+            dir_grouping: None,
+        });
+
+        assert_eq!(None, SortColumn::from_config(&c));
+    }
+
+    #[test]
     fn test_from_config_invalid() {
         let mut c = Config::with_none();
         c.sorting = Some(Sorting {
@@ -424,6 +436,17 @@ mod test_sort_order {
     }
 
     #[test]
+    fn test_from_config_none_reverse() {
+        let mut c = Config::with_none();
+        c.sorting = Some(Sorting {
+            column: None,
+            reverse: None,
+            dir_grouping: None,
+        });
+        assert_eq!(None, SortOrder::from_config(&c));
+    }
+
+    #[test]
     fn test_from_config_reverse() {
         let mut c = Config::with_none();
         c.sorting = Some(Sorting {
@@ -442,6 +465,11 @@ mod test_dir_grouping {
     use crate::app;
     use crate::config_file::{Config, Sorting};
     use crate::flags::Configurable;
+
+    #[test]
+    fn test_from_str_bad_value() {
+        assert_eq!(None, DirGrouping::from_str("bad value"));
+    }
 
     #[test]
     fn test_from_arg_matches_none() {

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -1,4 +1,4 @@
-//! This module defines the [Sorting] options. To set it up from [ArgMatches], a [Yaml]
+//! This module defines the [Sorting] options. To set it up from [ArgMatches], a [Config]
 //! and its [Default] value, use the [configure_from](Sorting::configure_from) method.
 
 use super::Configurable;

--- a/src/flags/symlink_arrow.rs
+++ b/src/flags/symlink_arrow.rs
@@ -17,12 +17,15 @@ impl Configurable<Self> for SymlinkArrow {
     }
     /// Get a potential `SymlinkArrow` value from a [Config].
     ///
-    /// If the Config's [Yaml] contains the [String](Yaml::String) value pointed to by
-    /// "symlink-arrow", this returns its value as the value of the `SymlinkArrow`, in a [Some].
+    /// If the `Config::symlink-arrow` has value,
+    /// returns its value as the value of the `SymlinkArrow`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(arrow) = &config.symlink_arrow {
+            Some(SymlinkArrow(arrow.to_string()))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/symlink_arrow.rs
+++ b/src/flags/symlink_arrow.rs
@@ -3,7 +3,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing how to display symbolic arrow.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -22,18 +21,8 @@ impl Configurable<Self> for SymlinkArrow {
     /// "symlink-arrow", this returns its value as the value of the `SymlinkArrow`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["symlink-arrow"] {
-                Yaml::BadValue => None,
-                Yaml::String(value) => Some(SymlinkArrow(value.to_string())),
-                _ => {
-                    config.print_wrong_type_warning("symlink-arrow", "string");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -66,7 +55,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(SymlinkArrow(String::from("\u{21B9}"))),
-            SymlinkArrow::from_config(&Config::with_yaml(yaml))
+            SymlinkArrow::from_config(&Config::with_none())
         );
     }
 
@@ -74,7 +63,7 @@ mod test {
     fn test_symlink_arrow_from_config_type_error() {
         let yaml_string = "symlink-arrow: false";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SymlinkArrow::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, SymlinkArrow::from_config(&Config::with_none()));
     }
 
     #[test]

--- a/src/flags/symlink_arrow.rs
+++ b/src/flags/symlink_arrow.rs
@@ -49,24 +49,15 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     use super::SymlinkArrow;
     #[test]
     fn test_symlink_arrow_from_config_utf8() {
-        let yaml_string = "symlink-arrow: ↹";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
+        let mut c = Config::with_none();
+        c.symlink_arrow = Some("↹".into());
         assert_eq!(
             Some(SymlinkArrow(String::from("\u{21B9}"))),
-            SymlinkArrow::from_config(&Config::with_none())
+            SymlinkArrow::from_config(&c)
         );
-    }
-
-    #[test]
-    fn test_symlink_arrow_from_config_type_error() {
-        let yaml_string = "symlink-arrow: false";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, SymlinkArrow::from_config(&Config::with_none()));
     }
 
     #[test]

--- a/src/flags/symlinks.rs
+++ b/src/flags/symlinks.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing whether to follow symbolic links.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -31,18 +30,8 @@ impl Configurable<Self> for NoSymlink {
     /// "no-symlink", this returns its value as the value of the `NoSymlink`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["no-symlink"] {
-                Yaml::BadValue => None,
-                Yaml::Boolean(value) => Some(Self(*value)),
-                _ => {
-                    config.print_wrong_type_warning("no-symlink", "boolean");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -79,7 +68,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, NoSymlink::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, NoSymlink::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -88,7 +77,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(NoSymlink(true)),
-            NoSymlink::from_config(&Config::with_yaml(yaml))
+            NoSymlink::from_config(&Config::with_none())
         );
     }
 
@@ -98,7 +87,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(NoSymlink(false)),
-            NoSymlink::from_config(&Config::with_yaml(yaml))
+            NoSymlink::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/symlinks.rs
+++ b/src/flags/symlinks.rs
@@ -46,8 +46,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -68,29 +66,16 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, NoSymlink::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_true() {
-        let yaml_string = "no-symlink: true";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(NoSymlink(true)),
-            NoSymlink::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.no_symlink = Some(true);
+        assert_eq!(Some(NoSymlink(true)), NoSymlink::from_config(&c));
     }
 
     #[test]
     fn test_from_config_false() {
-        let yaml_string = "no-symlink: false";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(NoSymlink(false)),
-            NoSymlink::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.no_symlink = Some(false);
+        assert_eq!(Some(NoSymlink(false)), NoSymlink::from_config(&c));
     }
 }

--- a/src/flags/symlinks.rs
+++ b/src/flags/symlinks.rs
@@ -1,4 +1,4 @@
-//! This module defines the [NoSymlink] flag. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [NoSymlink] flag. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use the [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;

--- a/src/flags/symlinks.rs
+++ b/src/flags/symlinks.rs
@@ -26,12 +26,15 @@ impl Configurable<Self> for NoSymlink {
 
     /// Get a potential `NoSymlink` value from a [Config].
     ///
-    /// If the Config's [Yaml] contains the [Boolean](Yaml::Boolean) value pointed to by
-    /// "no-symlink", this returns its value as the value of the `NoSymlink`, in a [Some].
+    /// If the `Config::no-symlink` has value,
+    /// this returns it as the value of the `NoSymlink`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(no_link) = config.no_symlink {
+            Some(Self(no_link))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/flags/total_size.rs
+++ b/src/flags/total_size.rs
@@ -46,8 +46,6 @@ mod test {
     use crate::config_file::Config;
     use crate::flags::Configurable;
 
-    use yaml_rust::YamlLoader;
-
     #[test]
     fn test_from_arg_matches_none() {
         let argv = vec!["lsd"];
@@ -68,29 +66,16 @@ mod test {
     }
 
     #[test]
-    fn test_from_config_empty() {
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, TotalSize::from_config(&Config::with_none()));
-    }
-
-    #[test]
     fn test_from_config_true() {
-        let yaml_string = "total-size: true";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(TotalSize(true)),
-            TotalSize::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.total_size = Some(true);
+        assert_eq!(Some(TotalSize(true)), TotalSize::from_config(&c));
     }
 
     #[test]
     fn test_from_config_false() {
-        let yaml_string = "total-size: false";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(
-            Some(TotalSize(false)),
-            TotalSize::from_config(&Config::with_none())
-        );
+        let mut c = Config::with_none();
+        c.total_size = Some(false);
+        assert_eq!(Some(TotalSize(false)), TotalSize::from_config(&c));
     }
 }

--- a/src/flags/total_size.rs
+++ b/src/flags/total_size.rs
@@ -1,4 +1,4 @@
-//! This module defines the [TotalSize] flag. To set it up from [ArgMatches], a [Yaml] and its
+//! This module defines the [TotalSize] flag. To set it up from [ArgMatches], a [Config] and its
 //! [Default] value, use the [configure_from](Configurable::configure_from) method.
 
 use super::Configurable;

--- a/src/flags/total_size.rs
+++ b/src/flags/total_size.rs
@@ -6,7 +6,6 @@ use super::Configurable;
 use crate::config_file::Config;
 
 use clap::ArgMatches;
-use yaml_rust::Yaml;
 
 /// The flag showing whether to show the total size for directories.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -31,18 +30,8 @@ impl Configurable<Self> for TotalSize {
     /// "total-size", this returns its value as the value of the `TotalSize`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(yaml) = &config.yaml {
-            match &yaml["total-size"] {
-                Yaml::BadValue => None,
-                Yaml::Boolean(value) => Some(Self(*value)),
-                _ => {
-                    config.print_wrong_type_warning("total-size", "boolean");
-                    None
-                }
-            }
-        } else {
-            None
-        }
+        // TODO(zhangwei)
+        None
     }
 }
 
@@ -79,7 +68,7 @@ mod test {
     fn test_from_config_empty() {
         let yaml_string = "---";
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
-        assert_eq!(None, TotalSize::from_config(&Config::with_yaml(yaml)));
+        assert_eq!(None, TotalSize::from_config(&Config::with_none()));
     }
 
     #[test]
@@ -88,7 +77,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(TotalSize(true)),
-            TotalSize::from_config(&Config::with_yaml(yaml))
+            TotalSize::from_config(&Config::with_none())
         );
     }
 
@@ -98,7 +87,7 @@ mod test {
         let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         assert_eq!(
             Some(TotalSize(false)),
-            TotalSize::from_config(&Config::with_yaml(yaml))
+            TotalSize::from_config(&Config::with_none())
         );
     }
 }

--- a/src/flags/total_size.rs
+++ b/src/flags/total_size.rs
@@ -26,12 +26,15 @@ impl Configurable<Self> for TotalSize {
 
     /// Get a potential `TotalSize` value from a [Config].
     ///
-    /// If the Config's [Yaml] contains the [Boolean](Yaml::Boolean) value pointed to by
-    /// "total-size", this returns its value as the value of the `TotalSize`, in a [Some].
+    /// If the `Config::total-size` has value,
+    /// this returns it as the value of the `TotalSize`, in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        // TODO(zhangwei)
-        None
+        if let Some(total) = config.total_size {
+            Some(Self(total))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
     let config = if matches.is_present("ignore-config") {
         Config::with_none()
     } else {
-        Config::read_config()
+        Config::default()
     };
     let flags = Flags::configure_from(&matches, &config).unwrap_or_else(|err| err.exit());
     let core = Core::new(flags);

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,8 @@ macro_rules! print_error {
                 let mut handle = stderr.lock();
                 // We can write on stderr, so we simply ignore the error and don't print
                 // and stop with success.
-                let res = handle.write_all(std::format!($($arg)*).as_bytes());
+                let res = handle.write_all(std::format!("lsd: {}\n\n",
+                                                        std::format!($($arg)*)).as_bytes());
                 if res.is_err() {
                     std::process::exit(0);
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,17 +48,19 @@ use std::path::PathBuf;
 #[macro_export]
 macro_rules! print_error {
     ($($arg:tt)*) => {
-        use std::io::Write;
-
-        let stderr = std::io::stderr();
-
         {
-            let mut handle = stderr.lock();
-            // We can write on stderr, so we simply ignore the error and don't print
-            // and stop with success.
-            let res = handle.write_all(std::format!($($arg)*).as_bytes());
-            if res.is_err() {
-                std::process::exit(0);
+            use std::io::Write;
+
+            let stderr = std::io::stderr();
+
+            {
+                let mut handle = stderr.lock();
+                // We can write on stderr, so we simply ignore the error and don't print
+                // and stop with success.
+                let res = handle.write_all(std::format!($($arg)*).as_bytes());
+                if res.is_err() {
+                    std::process::exit(0);
+                }
             }
         }
     };

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -54,7 +54,7 @@ impl Meta {
             return Ok(None);
         }
 
-        if flags.display == Display::DirectoryItself && flags.layout != Layout::Tree {
+        if flags.display == Display::DirectoryOnly && flags.layout != Layout::Tree {
             return Ok(None);
         }
 
@@ -103,7 +103,7 @@ impl Meta {
                 continue;
             }
 
-            if let Display::DisplayOnlyVisible = flags.display {
+            if let Display::VisibleOnly = flags.display {
                 if name.to_string_lossy().starts_with('.') {
                     continue;
                 }
@@ -119,7 +119,7 @@ impl Meta {
 
             // skip files for --tree -d
             if flags.layout == Layout::Tree {
-                if let Display::DirectoryItself = flags.display {
+                if let Display::DirectoryOnly = flags.display {
                     if !entry.file_type()?.is_dir() {
                         continue;
                     }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -71,7 +71,7 @@ impl Meta {
         let entries = match self.path.read_dir() {
             Ok(entries) => entries,
             Err(err) => {
-                print_error!("lsd: {}: {}\n", self.path.display(), err);
+                print_error!("{}: {}.", self.path.display(), err);
                 return Ok(None);
             }
         };
@@ -112,7 +112,7 @@ impl Meta {
             let mut entry_meta = match Self::from_path(&path, flags.dereference.0) {
                 Ok(res) => res,
                 Err(err) => {
-                    print_error!("lsd: {}: {}\n", path.display(), err);
+                    print_error!("{}: {}.", path.display(), err);
                     continue;
                 }
             };
@@ -129,7 +129,7 @@ impl Meta {
             match entry_meta.recurse_into(depth - 1, &flags) {
                 Ok(content) => entry_meta.content = content,
                 Err(err) => {
-                    print_error!("lsd: {}: {}\n", path.display(), err);
+                    print_error!("{}: {}.", path.display(), err);
                     continue;
                 }
             };
@@ -167,7 +167,7 @@ impl Meta {
         let metadata = match metadata {
             Ok(meta) => meta,
             Err(err) => {
-                print_error!("lsd: {}: {}\n", path.display(), err);
+                print_error!("{}: {}.", path.display(), err);
                 return 0;
             }
         };
@@ -180,7 +180,7 @@ impl Meta {
             let entries = match path.read_dir() {
                 Ok(entries) => entries,
                 Err(err) => {
-                    print_error!("lsd: {}: {}\n", path.display(), err);
+                    print_error!("{}: {}.", path.display(), err);
                     return size;
                 }
             };
@@ -188,7 +188,7 @@ impl Meta {
                 let path = match entry {
                     Ok(entry) => entry.path(),
                     Err(err) => {
-                        print_error!("lsd: {}: {}\n", path.display(), err);
+                        print_error!("{}: {}.", path.display(), err);
                         continue;
                     }
                 };

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -80,15 +80,13 @@ mod tests {
     use crate::color::{Colors, Theme};
     use crate::config_file::Config;
     use crate::flags::Flags;
-    use yaml_rust::YamlLoader;
+
     #[test]
     fn test_symlink_render_default_valid_target_nocolor() {
         let link = SymLink {
             target: Some("/target".to_string()),
             valid: true,
         };
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         let argv = vec!["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(
@@ -107,8 +105,6 @@ mod tests {
             target: Some("/target".to_string()),
             valid: false,
         };
-        let yaml_string = "---";
-        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
         let argv = vec!["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -95,7 +95,7 @@ mod tests {
             format!("{}", " ⇒ /target"),
             link.render(
                 &Colors::new(Theme::NoColor),
-                &Flags::configure_from(&matches, &Config::with_yaml(yaml)).unwrap()
+                &Flags::configure_from(&matches, &Config::with_none()).unwrap()
             )
             .to_string()
         );
@@ -115,7 +115,7 @@ mod tests {
             format!("{}", " ⇒ /target"),
             link.render(
                 &Colors::new(Theme::NoColor),
-                &Flags::configure_from(&matches, &Config::with_yaml(yaml)).unwrap()
+                &Flags::configure_from(&matches, &Config::with_none()).unwrap()
             )
             .to_string()
         );


### PR DESCRIPTION
Hi @meain , recently I was working on the symlink and theme features, finding that we were using raw rust_yaml to parse the config file.
I have tried to refactor it using `serde_yaml` so that we can parse the yaml file into a Rust struct, with args check, type check, and some other advanced. also we can isolate the config file logic inside the config_file modules.

for example, the config struct:

```rust
pub struct Config {
    pub classic: Option<bool>,
    pub blocks: Option<Sequence>,
    pub color: Option<Color>,
    pub date: Option<String>, // enum?
    pub dereference: Option<bool>,
    pub display: Option<String>, // enum?
    pub icons: Option<Icons>,
    pub ignore_globs: Option<Sequence>,
    pub indicators: Option<bool>,
    pub layout: Option<String>, // enum?
    pub recursion: Option<Recursion>,
    pub size: Option<String>, // enum?
    pub sorting: Option<Sorting>,
    pub no_symlink: Option<bool>,
    pub total_size: Option<bool>,
    pub styling: Option<Styling>,
}
```