### PR TITLE
Add MacPorts as installation option on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ via [Homebrew](https://brew.sh/):
 brew install lsd
 ```
 
+or [MacPorts](https://www.macports.org/):
+
+```sh
+sudo port install lsd
+```
+
 ### On NixOS/From nix
 
 ```sh


### PR DESCRIPTION
`lsd` is also available via MacPorts. Thought it was worth mentioning in the README.