### PR TITLE
supplementing PR for tree -d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `--extensionsort` `-X` from [aldhsu](https://github.com/aldhsu)
 - Add support for `--versionsort` `-v` from [zwpaper](https://github.com/zwpaper)
 - Add support for config symlink arrow from [zwpaper](https://github.com/zwpaper) [#409](https://github.com/Peltoche/lsd/issues/409)
-- Implement `--tree -d`, analogous to `tree -d` from [0jdxt](https://github.com/0jdxt)
+- Implement `--tree -d`, analogous to `tree -d` from [0jdxt](https://github.com/0jdxt) and [Utah Rust](https://github.com/utah-rust)
 ### Changed
 - Use last sort flag for sort field from [meain](https://github.com/meain)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `--extensionsort` `-X` from [aldhsu](https://github.com/aldhsu)
 - Add support for `--versionsort` `-v` from [zwpaper](https://github.com/zwpaper)
 - Add support for config symlink arrow from [zwpaper](https://github.com/zwpaper) [#409](https://github.com/Peltoche/lsd/issues/409)
+- Implement `--tree -d`, analogous to `tree -d` from [0jdxt](https://github.com/0jdxt)
 ### Changed
 - Use last sort flag for sort field from [meain](https://github.com/meain)
 ### Fixed

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,7 @@ pub fn build() -> App<'static, 'static> {
                 .conflicts_with("almost-all")
                 .conflicts_with("depth")
                 .conflicts_with("recursive")
-                .help("Display directories themselves, and not their contents"),
+                .help("Display directories themselves, and not their contents (recursively when used with --tree)"),
         )
         .arg(
             Arg::with_name("size")

--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,6 @@ pub fn build() -> App<'static, 'static> {
                 .conflicts_with("almost-all")
                 .conflicts_with("depth")
                 .conflicts_with("recursive")
-                .conflicts_with("tree")
                 .help("Display directories themselves, and not their contents"),
         )
         .arg(

--- a/src/core.rs
+++ b/src/core.rs
@@ -94,22 +94,21 @@ impl Core {
                 }
             };
 
-            match self.flags.display {
-                Display::DirectoryItself => {
-                    meta_list.push(meta);
-                }
-                _ => {
-                    match meta.recurse_into(depth, &self.flags) {
-                        Ok(content) => {
-                            meta.content = content;
-                            meta_list.push(meta);
-                        }
-                        Err(err) => {
-                            print_error!("lsd: {}: {}\n", path.display(), err);
-                            continue;
-                        }
-                    };
-                }
+            let recurse =
+                self.flags.layout == Layout::Tree || self.flags.display != Display::DirectoryItself;
+            if recurse {
+                match meta.recurse_into(depth, &self.flags) {
+                    Ok(content) => {
+                        meta.content = content;
+                        meta_list.push(meta);
+                    }
+                    Err(err) => {
+                        print_error!("lsd: {}: {}\n", path.display(), err);
+                        continue;
+                    }
+                };
+            } else {
+                meta_list.push(meta);
             };
         }
         if self.flags.total_size.0 {

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -15,7 +15,6 @@ pub enum Display {
     AlmostAll,
     DirectoryItself,
     DisplayOnlyVisible,
-    TreeD,
 }
 
 impl Display {
@@ -46,11 +45,7 @@ impl Configurable<Self> for Display {
         } else if matches.is_present("almost-all") {
             Some(Self::AlmostAll)
         } else if matches.is_present("directory-only") {
-            if matches.is_present("tree") {
-                Some(Self::TreeD)
-            } else {
-                Some(Self::DirectoryItself)
-            }
+            Some(Self::DirectoryItself)
         } else {
             None
         }
@@ -126,13 +121,6 @@ mod test {
             Some(Display::DirectoryItself),
             Display::from_arg_matches(&matches)
         );
-    }
-
-    #[test]
-    fn test_from_arg_matches_display_only_directories() {
-        let argv = vec!["lsd", "--tree", "-d"];
-        let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert_eq!(Some(Display::TreeD), Display::from_arg_matches(&matches));
     }
 
     #[test]

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -129,6 +129,13 @@ mod test {
     }
 
     #[test]
+    fn test_from_arg_matches_display_only_directories() {
+        let argv = vec!["lsd", "--tree", "-d"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(Some(Display::TreeD), Display::from_arg_matches(&matches));
+    }
+
+    #[test]
     fn test_from_config_none() {
         assert_eq!(None, Display::from_config(&Config::with_none()));
     }

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -15,6 +15,7 @@ pub enum Display {
     AlmostAll,
     DirectoryItself,
     DisplayOnlyVisible,
+    TreeD,
 }
 
 impl Display {
@@ -45,7 +46,11 @@ impl Configurable<Self> for Display {
         } else if matches.is_present("almost-all") {
             Some(Self::AlmostAll)
         } else if matches.is_present("directory-only") {
-            Some(Self::DirectoryItself)
+            if matches.is_present("tree") {
+                Some(Self::TreeD)
+            } else {
+                Some(Self::DirectoryItself)
+            }
         } else {
             None
         }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -54,7 +54,7 @@ impl Meta {
             return Ok(None);
         }
 
-        if flags.display == Display::DirectoryItself {
+        if flags.display == Display::DirectoryItself && flags.layout != Layout::Tree {
             return Ok(None);
         }
 
@@ -118,9 +118,11 @@ impl Meta {
             };
 
             // skip files for --tree -d
-            if let Display::TreeD = flags.display {
-                if !entry.file_type()?.is_dir() {
-                    continue;
+            if flags.layout == Layout::Tree {
+                if let Display::DirectoryItself = flags.display {
+                    if !entry.file_type()?.is_dir() {
+                        continue;
+                    }
                 }
             }
 

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -116,6 +116,11 @@ impl Meta {
                 }
             };
 
+            // skip files for --tree -d
+            if flags.display == Display::TreeD && !entry_meta.file_type.is_dirlike() {
+                continue;
+            }
+
             match entry_meta.recurse_into(depth - 1, &flags) {
                 Ok(content) => entry_meta.content = content,
                 Err(err) => {

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -92,7 +92,8 @@ impl Meta {
         }
 
         for entry in entries {
-            let path = entry?.path();
+            let entry = entry?;
+            let path = entry.path();
 
             let name = path
                 .file_name()
@@ -117,8 +118,10 @@ impl Meta {
             };
 
             // skip files for --tree -d
-            if flags.display == Display::TreeD && !entry_meta.file_type.is_dirlike() {
-                continue;
+            if let Display::TreeD = flags.display {
+                if !entry.file_type()?.is_dir() {
+                    continue;
+                }
             }
 
             match entry_meta.recurse_into(depth - 1, &flags) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -398,6 +398,20 @@ fn test_bad_utf_8_name() {
 }
 
 #[test]
+fn test_tree() {
+    let tmp = tempdir();
+    tmp.child("one").touch().unwrap();
+    tmp.child("one.d").create_dir_all().unwrap();
+    tmp.child("one.d/two").touch().unwrap();
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--tree")
+        .assert()
+        .stdout(predicate::str::is_match("├── one\n└── one.d\n   └── two\n$").unwrap());
+}
+
+#[test]
 fn test_tree_d() {
     let tmp = tempdir();
     tmp.child("one").touch().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -397,6 +397,24 @@ fn test_bad_utf_8_name() {
         .stdout(predicate::str::is_match("bad-name\u{fffd}\u{fffd}.ext\n$").unwrap());
 }
 
+#[test]
+fn test_tree_d() {
+    let tmp = tempdir();
+    tmp.child("one").touch().unwrap();
+    tmp.child("two").touch().unwrap();
+    tmp.child("one.d").create_dir_all().unwrap();
+    tmp.child("one.d/one").touch().unwrap();
+    tmp.child("one.d/one.d").create_dir_all().unwrap();
+    tmp.child("two.d").create_dir_all().unwrap();
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--tree")
+        .arg("-d")
+        .assert()
+        .stdout(predicate::str::is_match("├── one.d\n│  └── one.d\n└── two.d\n$").unwrap());
+}
+
 fn cmd() -> Command {
     Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap()
 }


### PR DESCRIPTION
Re: https://github.com/Peltoche/lsd/issues/295 https://github.com/Peltoche/lsd/pull/426

- only follows regular directories (no `-l` implementation)
- adds test for flags/display.rs

I'm not clear on how the test should work with for the YAML files. I tried this, expecting that it would parse the same as the flags, but it did not work as I had hoped:

```rs
    #[test]
    fn test_from_config_tree_d() {
        let yaml_string = "display: directory-only\nlayout: tree";
        let yaml = YamlLoader::load_from_str(yaml_string).unwrap()[0].clone();
        assert_eq!(
            Some(Display::TreeD),
            Display::from_config(&Config::with_yaml(yaml))
        );
    }
```