### PR TITLE
Fix for #407: Show number of hardlinks for lsd -l

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add case-insensitive matching of known filenames and extensions from [poita66](https://github.com/poita66)
 - Add Macports installation instructions from [ylluminarious](https://github.com/ylluminarious)
 - Implement `--tree -d`, analogous to `tree -d` from [0jdxt](https://github.com/0jdxt) and [Utah Rust](https://github.com/utah-rust)
+- Add support for displaying number of hard links from [thealakzam](https://github.com/thealakazam) [#407](https://github.com/Peltoche/lsd/issues/407)
 
 ### Changed
 - Use last sort flag for sort field from [meain](https://github.com/meain)

--- a/src/app.rs
+++ b/src/app.rs
@@ -233,7 +233,7 @@ pub fn build() -> App<'static, 'static> {
                     "date",
                     "name",
                     "inode",
-                    "inode_count",
+                    "links",
                 ])
                 .help("Specify the blocks that will be displayed and in what order"),
         )

--- a/src/app.rs
+++ b/src/app.rs
@@ -233,6 +233,7 @@ pub fn build() -> App<'static, 'static> {
                     "date",
                     "name",
                     "inode",
+                    "inode_count",
                 ])
                 .help("Specify the blocks that will be displayed and in what order"),
         )

--- a/src/color.rs
+++ b/src/color.rs
@@ -49,7 +49,7 @@ pub enum Elem {
         valid: bool,
     },
 
-    INodeCount {
+    Links {
         valid: bool,
     },
 }
@@ -169,7 +169,7 @@ impl Colors {
                 true => Some("so"),
                 false => Some("no"),
             },
-            Elem::INodeCount { valid } => match valid {
+            Elem::Links { valid } => match valid {
                 true => Some("so"),
                 false => Some("no"),
             },
@@ -251,8 +251,8 @@ impl Colors {
         // INode
         m.insert(Elem::INode { valid: true }, Colour::Fixed(13)); // Pink
         m.insert(Elem::INode { valid: false }, Colour::Fixed(245)); // Grey
-        m.insert(Elem::INodeCount { valid: true }, Colour::Fixed(134));
-        m.insert(Elem::INodeCount { valid: false }, Colour::Fixed(222));
+        m.insert(Elem::Links { valid: true }, Colour::Fixed(134));
+        m.insert(Elem::Links { valid: false }, Colour::Fixed(222));
 
         m
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -251,8 +251,8 @@ impl Colors {
         // INode
         m.insert(Elem::INode { valid: true }, Colour::Fixed(13)); // Pink
         m.insert(Elem::INode { valid: false }, Colour::Fixed(245)); // Grey
-        m.insert(Elem::Links { valid: true }, Colour::Fixed(134));
-        m.insert(Elem::Links { valid: false }, Colour::Fixed(222));
+        m.insert(Elem::Links { valid: true }, Colour::Fixed(13));
+        m.insert(Elem::Links { valid: false }, Colour::Fixed(245));
 
         m
     }

--- a/src/color.rs
+++ b/src/color.rs
@@ -48,6 +48,10 @@ pub enum Elem {
     INode {
         valid: bool,
     },
+
+    INodeCount {
+        valid: bool,
+    },
 }
 
 impl Elem {
@@ -165,6 +169,10 @@ impl Colors {
                 true => Some("so"),
                 false => Some("no"),
             },
+            Elem::INodeCount { valid } => match valid {
+                true => Some("so"),
+                false => Some("no"),
+            },
             _ => None,
         };
 
@@ -243,6 +251,8 @@ impl Colors {
         // INode
         m.insert(Elem::INode { valid: true }, Colour::Fixed(13)); // Pink
         m.insert(Elem::INode { valid: false }, Colour::Fixed(245)); // Grey
+        m.insert(Elem::INodeCount { valid: true }, Colour::Fixed(134));
+        m.insert(Elem::INodeCount { valid: false }, Colour::Fixed(222));
 
         m
     }

--- a/src/display.rs
+++ b/src/display.rs
@@ -257,6 +257,7 @@ fn get_output<'a>(
     for block in flags.blocks.0.iter() {
         match block {
             Block::INode => strings.push(meta.inode.render(colors)),
+            Block::INodeCount => strings.push(meta.inode_count.render(colors)),
             Block::Permission => {
                 let s: &[ColoredString] = &[
                     meta.file_type.render(colors),

--- a/src/display.rs
+++ b/src/display.rs
@@ -257,7 +257,7 @@ fn get_output<'a>(
     for block in flags.blocks.0.iter() {
         match block {
             Block::INode => strings.push(meta.inode.render(colors)),
-            Block::INodeCount => strings.push(meta.inode_count.render(colors)),
+            Block::Links => strings.push(meta.links.render(colors)),
             Block::Permission => {
                 let s: &[ColoredString] = &[
                     meta.file_type.render(colors),

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -126,6 +126,7 @@ impl Blocks {
             Block::Size,
             Block::Date,
             Block::Name,
+            Block::INodeCount,
         ])
     }
 
@@ -137,7 +138,6 @@ impl Blocks {
     /// Prepends a [Block] of variant [INode](Block::INode) to `self`.
     fn prepend_inode(&mut self) {
         self.0.insert(0, Block::INode);
-        self.0.insert(1, Block::INodeCount)
     }
 
     /// Prepends a [Block] of variant [INode](Block::INode), if `self` does not already contain a
@@ -183,7 +183,7 @@ impl TryFrom<&str> for Block {
             "date" => Ok(Self::Date),
             "name" => Ok(Self::Name),
             "inode" => Ok(Self::INode),
-            "inode_count" => Ok(Self::INodeCount),
+            "links" => Ok(Self::INodeCount),
             _ => Err(format!("Not a valid block name: {}", &string)),
         }
     }
@@ -509,6 +509,6 @@ mod test_block {
 
     #[test]
     fn test_inode_count() {
-        assert_eq!(Ok(Block::INodeCount), Block::try_from("inode_count"));
+        assert_eq!(Ok(Block::INodeCount), Block::try_from("links"));
     }
 }

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -124,7 +124,6 @@ impl Blocks {
             Block::Size,
             Block::Date,
             Block::Name,
-            Block::Links,
         ])
     }
 

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -124,7 +124,7 @@ impl Blocks {
             Block::Size,
             Block::Date,
             Block::Name,
-            Block::INodeCount,
+            Block::Links,
         ])
     }
 
@@ -165,7 +165,7 @@ pub enum Block {
     Date,
     Name,
     INode,
-    INodeCount,
+    Links,
 }
 
 impl TryFrom<&str> for Block {
@@ -181,7 +181,7 @@ impl TryFrom<&str> for Block {
             "date" => Ok(Self::Date),
             "name" => Ok(Self::Name),
             "inode" => Ok(Self::INode),
-            "links" => Ok(Self::INodeCount),
+            "links" => Ok(Self::Links),
             _ => Err(format!("Not a valid block name: {}", &string)),
         }
     }
@@ -504,7 +504,7 @@ mod test_block {
     }
 
     #[test]
-    fn test_inode_count() {
-        assert_eq!(Ok(Block::INodeCount), Block::try_from("links"));
+    fn test_links() {
+        assert_eq!(Ok(Block::Links), Block::try_from("links"));
     }
 }

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -136,7 +136,8 @@ impl Blocks {
 
     /// Prepends a [Block] of variant [INode](Block::INode) to `self`.
     fn prepend_inode(&mut self) {
-        self.0.insert(0, Block::INode)
+        self.0.insert(0, Block::INode);
+        self.0.insert(1, Block::INodeCount)
     }
 
     /// Prepends a [Block] of variant [INode](Block::INode), if `self` does not already contain a
@@ -166,6 +167,7 @@ pub enum Block {
     Date,
     Name,
     INode,
+    INodeCount,
 }
 
 impl TryFrom<&str> for Block {
@@ -181,6 +183,7 @@ impl TryFrom<&str> for Block {
             "date" => Ok(Self::Date),
             "name" => Ok(Self::Name),
             "inode" => Ok(Self::INode),
+            "inode_count" => Ok(Self::INodeCount),
             _ => Err(format!("Not a valid block name: {}", &string)),
         }
     }
@@ -502,5 +505,10 @@ mod test_block {
     #[test]
     fn test_inode() {
         assert_eq!(Ok(Block::INode), Block::try_from("inode"));
+    }
+
+    #[test]
+    fn test_inode_count() {
+        assert_eq!(Ok(Block::INodeCount), Block::try_from("inode_count"));
     }
 }

--- a/src/meta/inode_count.rs
+++ b/src/meta/inode_count.rs
@@ -1,0 +1,62 @@
+use crate::color::{ColoredString, Colors, Elem};
+use std::fs::Metadata;
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct INodeCount {
+    nlink: Option<u64>,
+}
+
+impl<'a> From<&'a Metadata> for INodeCount {
+    #[cfg(unix)]
+    fn from(meta: &Metadata) -> Self {
+        use std::os::unix::fs::MetadataExt;
+
+        let nlink = meta.nlink();
+
+        Self { nlink: Some(nlink) }
+    }
+
+    #[cfg(windows)]
+    fn from(_: &Metadata) -> Self {
+        Self { nlink: None }
+    }
+}
+
+impl INodeCount {
+    pub fn render(&self, colors: &Colors) -> ColoredString {
+        match self.nlink {
+            Some(i) => colors.colorize(i.to_string(), &Elem::INodeCount { valid: true }),
+            None => colors.colorize(String::from("-"), &Elem::INodeCount { valid: false }),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod tests {
+    use super::INodeCount;
+    use std::env;
+    use std::io;
+    use std::path::Path;
+    use std::process::{Command, ExitStatus};
+
+    fn cross_platform_touch(path: &Path) -> io::Result<ExitStatus> {
+        Command::new("touch").arg(&path).status()
+    }
+
+    #[test]
+    fn test_hardlinks_no_zero() {
+        let mut file_path = env::temp_dir();
+        file_path.push("inode.tmp");
+
+        let success = cross_platform_touch(&file_path).unwrap().success();
+        assert!(success, "failed to exec touch");
+
+        let inode = INodeCount::from(&file_path.metadata().unwrap());
+
+        #[cfg(unix)]
+        assert!(inode.nlink.is_some());
+        #[cfg(windows)]
+        assert!(inode.nlink.is_none());
+    }
+}

--- a/src/meta/links.rs
+++ b/src/meta/links.rs
@@ -2,11 +2,11 @@ use crate::color::{ColoredString, Colors, Elem};
 use std::fs::Metadata;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
-pub struct INodeCount {
+pub struct Links {
     nlink: Option<u64>,
 }
 
-impl<'a> From<&'a Metadata> for INodeCount {
+impl<'a> From<&'a Metadata> for Links {
     #[cfg(unix)]
     fn from(meta: &Metadata) -> Self {
         use std::os::unix::fs::MetadataExt;
@@ -22,11 +22,11 @@ impl<'a> From<&'a Metadata> for INodeCount {
     }
 }
 
-impl INodeCount {
+impl Links {
     pub fn render(&self, colors: &Colors) -> ColoredString {
         match self.nlink {
-            Some(i) => colors.colorize(i.to_string(), &Elem::INodeCount { valid: true }),
-            None => colors.colorize(String::from("-"), &Elem::INodeCount { valid: false }),
+            Some(i) => colors.colorize(i.to_string(), &Elem::Links { valid: true }),
+            None => colors.colorize(String::from("-"), &Elem::Links { valid: false }),
         }
     }
 }
@@ -34,7 +34,7 @@ impl INodeCount {
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
-    use super::INodeCount;
+    use super::Links;
     use std::env;
     use std::io;
     use std::path::Path;
@@ -52,11 +52,11 @@ mod tests {
         let success = cross_platform_touch(&file_path).unwrap().success();
         assert!(success, "failed to exec touch");
 
-        let inode = INodeCount::from(&file_path.metadata().unwrap());
+        let links = Links::from(&file_path.metadata().unwrap());
 
         #[cfg(unix)]
-        assert!(inode.nlink.is_some());
+        assert!(links.nlink.is_some());
         #[cfg(windows)]
-        assert!(inode.nlink.is_none());
+        assert!(links.nlink.is_none());
     }
 }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -2,7 +2,7 @@ mod date;
 mod filetype;
 mod indicator;
 mod inode;
-mod inode_count;
+mod links;
 pub mod name;
 mod owner;
 mod permissions;
@@ -16,7 +16,7 @@ pub use self::date::Date;
 pub use self::filetype::FileType;
 pub use self::indicator::Indicator;
 pub use self::inode::INode;
-pub use self::inode_count::INodeCount;
+pub use self::links::Links;
 pub use self::name::Name;
 pub use self::owner::Owner;
 pub use self::permissions::Permissions;
@@ -43,7 +43,7 @@ pub struct Meta {
     pub symlink: SymLink,
     pub indicator: Indicator,
     pub inode: INode,
-    pub inode_count: INodeCount,
+    pub links: Links,
     pub content: Option<Vec<Meta>>,
 }
 
@@ -222,11 +222,11 @@ impl Meta {
         let file_type = FileType::new(&metadata, symlink_meta.as_ref(), &permissions);
         let name = Name::new(&path, file_type);
         let inode = INode::from(&metadata);
-        let inode_count = INodeCount::from(&metadata);
+        let links = Links::from(&metadata);
 
         Ok(Self {
             inode,
-            inode_count,
+            links,
             path: path.to_path_buf(),
             symlink: SymLink::from(path),
             size: Size::from(&metadata),

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -2,6 +2,7 @@ mod date;
 mod filetype;
 mod indicator;
 mod inode;
+mod inode_count;
 pub mod name;
 mod owner;
 mod permissions;
@@ -15,6 +16,7 @@ pub use self::date::Date;
 pub use self::filetype::FileType;
 pub use self::indicator::Indicator;
 pub use self::inode::INode;
+pub use self::inode_count::INodeCount;
 pub use self::name::Name;
 pub use self::owner::Owner;
 pub use self::permissions::Permissions;
@@ -41,6 +43,7 @@ pub struct Meta {
     pub symlink: SymLink,
     pub indicator: Indicator,
     pub inode: INode,
+    pub inode_count: INodeCount,
     pub content: Option<Vec<Meta>>,
 }
 
@@ -219,9 +222,11 @@ impl Meta {
         let file_type = FileType::new(&metadata, symlink_meta.as_ref(), &permissions);
         let name = Name::new(&path, file_type);
         let inode = INode::from(&metadata);
+        let inode_count = INodeCount::from(&metadata);
 
         Ok(Self {
             inode,
+            inode_count,
             path: path.to_path_buf(),
             symlink: SymLink::from(path),
             size: Size::from(&metadata),


### PR DESCRIPTION
<!--- PR Description --->
+ Added implementation for displaying number of hardlinks to a file.
+ Displays '-' in windows
---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry