### PR TITLE
Respect blocks passed without long from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 ### Fixed
+- Fix handling blocks passed without -l in cli from [meain](https://github.com/meain)
 
 ## [0.19.0] - 2020-12-13
 ### Added

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -35,16 +35,14 @@ impl Blocks {
             Ok(Default::default())
         };
 
-        if matches.is_present("long") {
-            if !matches.is_present("ignore-config") {
-                if let Some(value) = Self::from_config(config) {
-                    result = Ok(value);
-                }
+        if matches.is_present("long") && !matches.is_present("ignore-config") {
+            if let Some(value) = Self::from_config(config) {
+                result = Ok(value);
             }
+        }
 
-            if let Some(value) = Self::from_arg_matches(matches) {
-                result = value;
-            }
+        if let Some(value) = Self::from_arg_matches(matches) {
+            result = value;
         }
 
         if matches.is_present("inode") {
@@ -238,7 +236,7 @@ mod test_blocks {
     #[test]
     fn test_configure_from_with_blocks_and_without_long() {
         let argv = vec!["lsd", "--blocks", "permission"];
-        let target = Ok::<_, Error>(Blocks::default());
+        let target = Ok::<_, Error>(Blocks(vec![Block::Permission]));
 
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let result = Blocks::configure_from(&matches, &Config::with_none());
@@ -275,7 +273,7 @@ mod test_blocks {
     fn test_configure_from_prepend_inode_without_long() {
         let argv = vec!["lsd", "--blocks", "permission", "--inode"];
 
-        let mut target_blocks = Blocks::default();
+        let mut target_blocks = Blocks(vec![Block::Permission]);
         target_blocks.0.insert(0, Block::INode);
         let target = Ok::<_, Error>(target_blocks);
 
@@ -300,9 +298,7 @@ mod test_blocks {
     fn test_configure_from_ignore_prepend_inode_without_long() {
         let argv = vec!["lsd", "--blocks", "permission,inode", "--inode"];
 
-        let mut target_blocks = Blocks::default();
-        target_blocks.0.insert(0, Block::INode);
-        let target = Ok::<_, Error>(target_blocks);
+        let target = Ok::<_, Error>(Blocks(vec![Block::Permission, Block::INode]));
 
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let result = Blocks::configure_from(&matches, &Config::with_none());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -128,7 +128,10 @@ fn test_list_block_inode_populated_directory_without_long() {
     dir.child("one").touch().unwrap();
     dir.child("two").touch().unwrap();
 
-    let matched = "one\ntwo\n$";
+    #[cfg(windows)]
+    let matched = "- one\n\\- two\n$";
+    #[cfg(unix)]
+    let matched = "\\d+ one\n\\d+ two\n$";
 
     cmd()
         .arg("--blocks")


### PR DESCRIPTION
When reading from config, we do not take into consideration the value of blocks until we pass `-l` in the cli args, but if the user passes in blocks via the cli, the `-l` flag is implied.

Fixes #461


<!--- PR Description --->

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry