### PR TITLE
Report unidentified on Microsoft Windows for foriegn items

### DIFF
--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -255,10 +255,12 @@ unsafe fn lookup_account_sid(sid: *mut c_void) -> Result<(Vec<u16>, Vec<u16>), s
             // name_size and domain_size are already set, just loop
             continue;
         } else {
-            // Some other failure
-            // Assumptions: None (GetLastError shouldn't ever fail)
-            return Err(io::Error::from_raw_os_error(
-                winapi::um::errhandlingapi::GetLastError() as i32,
+            // Unknown account and or system domain identification
+            // Possibly foreign item coming from another machine
+            // TODO: Calculate permissions since it has to be possible if Explorer knows.
+            return Ok((
+                buf_from_os(OsStr::new("UNIDENTIFIED")),
+                buf_from_os(OsStr::new("UNIDENTIFIED")),
             ));
         }
     }


### PR DESCRIPTION
Decided to smoke test what goes wrong when enumerating items in a directory, and it turns out that the function `lookup_account_sid` in `meta\windows_utils.rs` was the culprit! According to the Win32 API documentation on [LookupAccountSidW](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-lookupaccountsidw):
```
If the function cannot find an account name for the SID, GetLastError returns ERROR_NONE_MAPPED. This can occur if a network time-out prevents the function from finding the name. It also occurs for SIDs that have no corresponding account name, such as a logon SID that identifies a logon session.
```
This can generally happen if you create a file or folder on a system using NTFS and copy it over to another system using NTFS as information about the name and domain are preserved and not pummeled. This may or may not happen and is probably dependent on the filesystem and or OS configurations. Instead of failing this function outright, and since we already know the item exists if we got up to this point, we should just report that we don't actually know what permissions we can use or, account name, and domain owns this item. There is probably some way to calculate this properly since Explorer does it, but for now this is good enough.

Fixes https://github.com/Peltoche/lsd/issues/356