### PR TITLE
Speedup windows by only fetching the necessary blocks

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -88,13 +88,14 @@ impl Core {
         };
 
         for path in paths {
-            let mut meta = match Meta::from_path(&path, self.flags.dereference.0, &self.flags.blocks) {
-                Ok(meta) => meta,
-                Err(err) => {
-                    print_error!("{}: {}.", path.display(), err);
-                    continue;
-                }
-            };
+            let mut meta =
+                match Meta::from_path(&path, self.flags.dereference.0, &self.flags.blocks) {
+                    Ok(meta) => meta,
+                    Err(err) => {
+                        print_error!("{}: {}.", path.display(), err);
+                        continue;
+                    }
+                };
 
             let recurse =
                 self.flags.layout == Layout::Tree || self.flags.display != Display::DirectoryOnly;

--- a/src/core.rs
+++ b/src/core.rs
@@ -88,7 +88,7 @@ impl Core {
         };
 
         for path in paths {
-            let mut meta = match Meta::from_path(&path, self.flags.dereference.0) {
+            let mut meta = match Meta::from_path(&path, self.flags.dereference.0, &self.flags.blocks) {
                 Ok(meta) => meta,
                 Err(err) => {
                     print_error!("{}: {}.", path.display(), err);

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -116,7 +116,7 @@ impl Blocks {
     ///
     /// It contains the [Block]s [Permission](Block::Permission), [User](Block::User),
     /// [Group](Block::Group), [Size](Block::Size), [Date](Block::Date) and [Name](Block::Name).
-    fn long() -> Self {
+    pub fn long() -> Self {
         Self(vec![
             Block::Permission,
             Block::User,

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -346,10 +346,10 @@ impl Icons {
 #[cfg(test)]
 mod test {
     use super::{Icons, Theme};
+    use crate::flags::Blocks;
     use crate::meta::Meta;
     use std::fs::File;
     use tempfile::tempdir;
-    use crate::flags::Blocks;
 
     #[test]
     fn get_no_icon() {

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -349,13 +349,14 @@ mod test {
     use crate::meta::Meta;
     use std::fs::File;
     use tempfile::tempdir;
+    use crate::flags::Blocks;
 
     #[test]
     fn get_no_icon() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, &Blocks::long()).unwrap();
 
         let icon = Icons::new(Theme::NoIcon, " ".to_string());
         let icon = icon.get(&meta.name);
@@ -368,7 +369,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, &Blocks::long()).unwrap();
 
         let icon = Icons::new(Theme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -381,7 +382,7 @@ mod test {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path().join("file");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, &Blocks::long()).unwrap();
 
         let icon = Icons::new(Theme::Unicode, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -393,7 +394,7 @@ mod test {
     fn get_directory_icon() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(&file_path.to_path_buf(), false).unwrap();
+        let meta = Meta::from_path(&file_path.to_path_buf(), false, &Blocks::long()).unwrap();
 
         let icon = Icons::new(Theme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -405,7 +406,7 @@ mod test {
     fn get_directory_icon_unicode() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(&file_path.to_path_buf(), false).unwrap();
+        let meta = Meta::from_path(&file_path.to_path_buf(), false, &Blocks::long()).unwrap();
 
         let icon = Icons::new(Theme::Unicode, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -417,7 +418,7 @@ mod test {
     fn get_directory_icon_with_ext() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(&file_path.to_path_buf(), false).unwrap();
+        let meta = Meta::from_path(&file_path.to_path_buf(), false, &Blocks::long()).unwrap();
 
         let icon = Icons::new(Theme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -432,7 +433,7 @@ mod test {
         for (file_name, file_icon) in &Icons::get_default_icons_by_name() {
             let file_path = tmp_dir.path().join(file_name);
             File::create(&file_path).expect("failed to create file");
-            let meta = Meta::from_path(&file_path, false).unwrap();
+            let meta = Meta::from_path(&file_path, false, &Blocks::long()).unwrap();
 
             let icon = Icons::new(Theme::Fancy, " ".to_string());
             let icon_str = icon.get(&meta.name);
@@ -448,7 +449,7 @@ mod test {
         for (ext, file_icon) in &Icons::get_default_icons_by_extension() {
             let file_path = tmp_dir.path().join(format!("file.{}", ext));
             File::create(&file_path).expect("failed to create file");
-            let meta = Meta::from_path(&file_path, false).unwrap();
+            let meta = Meta::from_path(&file_path, false, &Blocks::long()).unwrap();
 
             let icon = Icons::new(Theme::Fancy, " ".to_string());
             let icon_str = icon.get(&meta.name);

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -108,6 +108,7 @@ impl FileType {
 mod test {
     use super::FileType;
     use crate::color::{Colors, Theme};
+    use crate::flags::Blocks;
     use crate::meta::Meta;
     #[cfg(unix)]
     use crate::meta::Permissions;
@@ -121,7 +122,6 @@ mod test {
     #[cfg(unix)]
     use std::process::Command;
     use tempfile::tempdir;
-    use crate::flags::Blocks;
 
     #[test]
     #[cfg(unix)] // Windows uses different default permissions

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -121,6 +121,7 @@ mod test {
     #[cfg(unix)]
     use std::process::Command;
     use tempfile::tempdir;
+    use crate::flags::Blocks;
 
     #[test]
     #[cfg(unix)] // Windows uses different default permissions
@@ -141,7 +142,7 @@ mod test {
     #[test]
     fn test_dir_type() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
-        let meta = Meta::from_path(&tmp_dir.path().to_path_buf(), false)
+        let meta = Meta::from_path(&tmp_dir.path().to_path_buf(), false, &Blocks::long())
             .expect("failed to get tempdir path");
         let metadata = tmp_dir.path().metadata().expect("failed to get metas");
 

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -22,7 +22,7 @@ pub use self::size::Size;
 pub use self::symlink::SymLink;
 pub use crate::icon::Icons;
 
-use crate::flags::{Display, Flags, Layout, Blocks, Block};
+use crate::flags::{Block, Blocks, Display, Flags, Layout};
 use crate::print_error;
 
 use std::fs::read_link;
@@ -84,8 +84,11 @@ impl Meta {
             current_meta = self.clone();
             current_meta.name.name = ".".to_owned();
 
-            let parent_meta =
-                Self::from_path(&self.path.join(Component::ParentDir), flags.dereference.0, &flags.blocks)?;
+            let parent_meta = Self::from_path(
+                &self.path.join(Component::ParentDir),
+                flags.dereference.0,
+                &flags.blocks,
+            )?;
 
             content.push(current_meta);
             content.push(parent_meta);
@@ -200,7 +203,11 @@ impl Meta {
         }
     }
 
-    pub fn from_path(path: &Path, dereference: bool, blocks: &Blocks) -> Result<Self, std::io::Error> {
+    pub fn from_path(
+        path: &Path,
+        dereference: bool,
+        blocks: &Blocks,
+    ) -> Result<Self, std::io::Error> {
         // If the file is a link then retrieve link metadata instead with target metadata (if present).
         let (metadata, symlink_meta) = if read_link(path).is_ok() && !dereference {
             (path.symlink_metadata()?, path.metadata().ok())
@@ -218,7 +225,8 @@ impl Meta {
         let permissions = Permissions::from(&metadata);
 
         #[cfg(windows)]
-        let (owner, permissions) = windows_utils::get_file_data(&path, get_owner, get_group, get_permissions)?;
+        let (owner, permissions) =
+            windows_utils::get_file_data(&path, get_owner, get_group, get_permissions)?;
 
         let file_type = FileType::new(&metadata, symlink_meta.as_ref(), &permissions);
         let name = Name::new(&path, file_type);

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -180,6 +180,7 @@ mod test {
     #[cfg(unix)]
     use std::process::Command;
     use tempfile::tempdir;
+    use crate::flags::Blocks;
 
     #[test]
     #[cfg(unix)] // Windows uses different default permissions
@@ -210,7 +211,7 @@ mod test {
         // Chreate the directory
         let dir_path = tmp_dir.path().join("directory");
         fs::create_dir(&dir_path).expect("failed to create the dir");
-        let meta = Meta::from_path(&dir_path, false).unwrap();
+        let meta = Meta::from_path(&dir_path, false, &Blocks::long()).unwrap();
 
         let colors = Colors::new(color::Theme::NoLscolors);
 
@@ -310,7 +311,7 @@ mod test {
         // Create the file;
         let file_path = tmp_dir.path().join("file.txt");
         File::create(&file_path).expect("failed to create file");
-        let meta = Meta::from_path(&file_path, false).unwrap();
+        let meta = Meta::from_path(&file_path, false, &Blocks::long()).unwrap();
 
         let colors = Colors::new(color::Theme::NoColor);
 

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -166,6 +166,7 @@ mod test {
     use super::DisplayOption;
     use super::Name;
     use crate::color::{self, Colors};
+    use crate::flags::Blocks;
     use crate::icon::{self, Icons};
     use crate::meta::FileType;
     use crate::meta::Meta;
@@ -180,7 +181,6 @@ mod test {
     #[cfg(unix)]
     use std::process::Command;
     use tempfile::tempdir;
-    use crate::flags::Blocks;
 
     #[test]
     #[cfg(unix)] // Windows uses different default permissions

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -2,7 +2,7 @@ use crate::color::{ColoredString, Colors, Elem};
 use ansi_term::ANSIStrings;
 use std::fs::Metadata;
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
 pub struct Permissions {
     pub user_read: bool,
     pub user_write: bool,

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -69,7 +69,7 @@ fn by_extension(a: &Meta, b: &Meta) -> Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flags::{Flags, Blocks};
+    use crate::flags::{Blocks, Flags};
     use std::fs::{create_dir, File};
     use std::process::Command;
     use tempfile::tempdir;

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -69,7 +69,7 @@ fn by_extension(a: &Meta, b: &Meta) -> Ordering {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::flags::Flags;
+    use crate::flags::{Flags, Blocks};
     use std::fs::{create_dir, File};
     use std::process::Command;
     use tempfile::tempdir;
@@ -81,12 +81,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("zzz");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("aaa");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::First;
@@ -109,12 +109,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("zzz");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("aaa");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::Last;
@@ -135,12 +135,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("aaa");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("zzz");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::None;
@@ -163,12 +163,12 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("zzz");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         // Create a dir;
         let path_z = tmp_dir.path().join("aaa");
         create_dir(&path_z).expect("failed to create dir");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.dir_grouping = DirGrouping::None;
@@ -191,7 +191,7 @@ mod tests {
         // Create the file;
         let path_a = tmp_dir.path().join("aaa");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         // Create the file;
         let path_z = tmp_dir.path().join("zzz");
@@ -217,7 +217,7 @@ mod tests {
             .success();
 
         assert_eq!(true, success, "failed to change file timestamp");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::Time;
@@ -239,22 +239,22 @@ mod tests {
         // Create the file with rs extension;
         let path_a = tmp_dir.path().join("aaa.rs");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         // Create the file with rs extension;
         let path_z = tmp_dir.path().join("zzz.rs");
         File::create(&path_z).expect("failed to create file");
-        let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
+        let meta_z = Meta::from_path(&path_z, false, &Blocks::long()).expect("failed to get meta");
 
         // Create the file with js extension;
         let path_j = tmp_dir.path().join("zzz.js");
         File::create(&path_j).expect("failed to create file");
-        let meta_j = Meta::from_path(&path_j, false).expect("failed to get meta");
+        let meta_j = Meta::from_path(&path_j, false, &Blocks::long()).expect("failed to get meta");
 
         // Create the file with txt extension;
         let path_t = tmp_dir.path().join("zzz.txt");
         File::create(&path_t).expect("failed to create file");
-        let meta_t = Meta::from_path(&path_t, false).expect("failed to get meta");
+        let meta_t = Meta::from_path(&path_t, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::Extension;
@@ -276,15 +276,15 @@ mod tests {
 
         let path_a = tmp_dir.path().join("2");
         File::create(&path_a).expect("failed to create file");
-        let meta_a = Meta::from_path(&path_a, false).expect("failed to get meta");
+        let meta_a = Meta::from_path(&path_a, false, &Blocks::long()).expect("failed to get meta");
 
         let path_b = tmp_dir.path().join("11");
         File::create(&path_b).expect("failed to create file");
-        let meta_b = Meta::from_path(&path_b, false).expect("failed to get meta");
+        let meta_b = Meta::from_path(&path_b, false, &Blocks::long()).expect("failed to get meta");
 
         let path_c = tmp_dir.path().join("12");
         File::create(&path_c).expect("failed to create file");
-        let meta_c = Meta::from_path(&path_c, false).expect("failed to get meta");
+        let meta_c = Meta::from_path(&path_c, false, &Blocks::long()).expect("failed to get meta");
 
         let mut flags = Flags::default();
         flags.sorting.column = SortColumn::Version;


### PR DESCRIPTION
Now from_path is aware of blocks, so it will not fetch permissions and owner and group data if they are not needed.

That creates massive speedup on Domain machines.

Based on the discussion in: https://github.com/Peltoche/lsd/pull/297

---

- [ X] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry