### PR TITLE
not showing . and .. when tree with all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for `TIME_STYLE` environment variable from [999eagle](https://github.com/999eagle)
 - Add man page from [edneville](https://github.com/edneville)
 ### Changed
+- Not showing `.` and `..` when `--tree` with `--all` from [zwpaper](https://github.com/zwpaper) [#477](https://github.com/Peltoche/lsd/issues/477)
 ### Fixed
 - Fix handling blocks passed without -l in cli from [meain](https://github.com/meain)
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -345,11 +345,14 @@ fn get_padding_rules(metas: &[Meta], flags: &Flags) -> HashMap<Block, usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app;
     use crate::color;
     use crate::color::Colors;
     use crate::icon;
     use crate::icon::Icons;
     use crate::meta::{FileType, Name};
+    use crate::Config;
+    use assert_fs::prelude::*;
     use std::path::Path;
 
     #[test]
@@ -484,5 +487,32 @@ mod tests {
 
             assert_eq!(get_visible_width(&output), *l);
         }
+    }
+
+    #[test]
+    fn test_display_tree_with_all() {
+        let argv = vec!["lsd", "--tree", "--all"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        let flags = Flags::configure_from(&matches, &Config::with_none()).unwrap();
+
+        let dir = assert_fs::TempDir::new().unwrap();
+        dir.child("one.d").create_dir_all().unwrap();
+        dir.child("one.d/two").touch().unwrap();
+        dir.child("one.d/.hidden").touch().unwrap();
+        let metas = Meta::from_path(Path::new(dir.path()), false)
+            .unwrap()
+            .recurse_into(42, &flags)
+            .unwrap()
+            .unwrap();
+        let output = inner_display_tree(
+            &metas,
+            &flags,
+            &Colors::new(color::Theme::NoColor),
+            &Icons::new(icon::Theme::NoIcon, " ".to_string()),
+            0,
+            "",
+        );
+
+        assert_eq!("one.d\n├── .hidden\n└── two\n", output);
     }
 }

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -81,7 +81,7 @@ impl Meta {
 
         let mut content: Vec<Meta> = Vec::new();
 
-        if let Display::All = flags.display {
+        if Display::All == flags.display && flags.layout != Layout::Tree {
             let mut current_meta;
 
             current_meta = self.clone();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -415,6 +415,24 @@ fn test_tree() {
 }
 
 #[test]
+fn test_tree_all_not_show_self() {
+    let tmp = tempdir();
+    tmp.child("one").touch().unwrap();
+    tmp.child("one.d").create_dir_all().unwrap();
+    tmp.child("one.d/two").touch().unwrap();
+    tmp.child("one.d/.hidden").touch().unwrap();
+
+    cmd()
+        .arg(tmp.path())
+        .arg("--tree")
+        .arg("--all")
+        .assert()
+        .stdout(
+            predicate::str::is_match("├── one\n└── one.d\n   ├── .hidden\n   └── two\n$").unwrap(),
+        );
+}
+
+#[test]
 fn test_tree_d() {
     let tmp = tempdir();
     tmp.child("one").touch().unwrap();


### PR DESCRIPTION
Not showing `.` and `..` when `--tree` with `--all`

fix https://github.com/Peltoche/lsd/issues/477

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry