### PR TITLE
Fix sorting with almost-all flag and a folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 ### Fixed
 - Fix handling blocks passed without -l in cli from [meain](https://github.com/meain)
+- Fixed sorting of . and .. when used with folder from [meain](https://github.com/meain)
 
 ## [0.19.0] - 2020-12-13
 ### Added

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -87,8 +87,9 @@ impl Meta {
             current_meta = self.clone();
             current_meta.name.name = ".".to_owned();
 
-            let parent_meta =
+            let mut parent_meta =
                 Self::from_path(&self.path.join(Component::ParentDir), flags.dereference.0)?;
+            parent_meta.name.name = "..".to_owned();
 
             content.push(current_meta);
             content.push(parent_meta);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -98,6 +98,21 @@ fn test_list_all_populated_directory() {
 }
 
 #[test]
+fn test_almost_sort_with_folder() {
+    let tmp = tempdir();
+    tmp.child("z").create_dir_all().unwrap();
+    tmp.child("z/a").touch().unwrap();
+
+    cmd()
+        .current_dir(tmp.path())
+        .arg("-a")
+        .arg("--ignore-config")
+        .arg("z")
+        .assert()
+        .stdout(predicate::str::is_match("\\.\n\\.\\.\na\n$").unwrap());
+}
+
+#[test]
 fn test_list_inode_populated_directory() {
     let dir = tempdir();
     dir.child("one").touch().unwrap();


### PR DESCRIPTION
With a folder structure (a folder `z` with a file `a`), if we do `lsd
-a z` it used to be:

```
. a ..
```

instead of

```
. .. a
```

This was caused to the the parent meta having full path and us using
z/.. to sort .. entry. This should now be fixed with manually changing
the name to a .. .


<!--- PR Description --->

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry