### PR TITLE
Fix arg value parsing for flags that allow multiple inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix handling blocks passed without -l in cli from [meain](https://github.com/meain)
 - Fixed sorting of . and .. when used with folder from [meain](https://github.com/meain)
+- Fix arg parsing for flags that allow multiple values from [meain](https://github.com/meain)
 
 ## [0.19.0] - 2020-12-13
 ### Added

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -63,7 +63,7 @@ impl Configurable<Self> for ColorOption {
         if matches.is_present("classic") {
             Some(Self::Never)
         } else if matches.occurrences_of("color") > 0 {
-            if let Some(color) = matches.value_of("color") {
+            if let Some(color) = matches.values_of("color")?.last() {
                 Self::from_str(&color)
             } else {
                 panic!("Bad color args. This should not be reachable!");
@@ -124,7 +124,7 @@ mod test_color_option {
     }
 
     #[test]
-    fn test_from_arg_matches_autp() {
+    fn test_from_arg_matches_auto() {
         let argv = vec!["lsd", "--color", "auto"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(
@@ -146,6 +146,16 @@ mod test_color_option {
     #[test]
     fn test_from_arg_matches_classic_mode() {
         let argv = vec!["lsd", "--color", "always", "--classic"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(
+            Some(ColorOption::Never),
+            ColorOption::from_arg_matches(&matches)
+        );
+    }
+
+    #[test]
+    fn test_from_arg_matches_color_multiple() {
+        let argv = vec!["lsd", "--color", "always", "--color", "never"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(
             Some(ColorOption::Never),

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -54,7 +54,7 @@ impl Configurable<Self> for DateFlag {
         if matches.is_present("classic") {
             Some(Self::Date)
         } else if matches.occurrences_of("date") > 0 {
-            match matches.value_of("date") {
+            match matches.values_of("date")?.last() {
                 Some("date") => Some(Self::Date),
                 Some("relative") => Some(Self::Relative),
                 Some(format) if format.starts_with('+') => {
@@ -164,6 +164,13 @@ mod test {
     #[test]
     fn test_from_arg_matches_classic_mode() {
         let argv = vec!["lsd", "--date", "date", "--classic"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(Some(DateFlag::Date), DateFlag::from_arg_matches(&matches));
+    }
+
+    #[test]
+    fn test_from_arg_matches_date_multi() {
+        let argv = vec!["lsd", "--date", "relative", "--date", "date"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(Some(DateFlag::Date), DateFlag::from_arg_matches(&matches));
     }

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -55,7 +55,7 @@ impl Configurable<Self> for IconOption {
         if matches.is_present("classic") {
             Some(Self::Never)
         } else if matches.occurrences_of("icon") > 0 {
-            match matches.value_of("icon") {
+            match matches.values_of("icon")?.last() {
                 Some("always") => Some(Self::Always),
                 Some("auto") => Some(Self::Auto),
                 Some("never") => Some(Self::Never),
@@ -107,7 +107,7 @@ impl Configurable<Self> for IconTheme {
     /// [Some]. Otherwise this returns [None].
     fn from_arg_matches(matches: &ArgMatches) -> Option<Self> {
         if matches.occurrences_of("icon-theme") > 0 {
-            match matches.value_of("icon-theme") {
+            match matches.values_of("icon-theme")?.last() {
                 Some("fancy") => Some(Self::Fancy),
                 Some("unicode") => Some(Self::Unicode),
                 _ => panic!("This should not be reachable!"),
@@ -229,6 +229,16 @@ mod test_icon_option {
     }
 
     #[test]
+    fn test_from_arg_matches_icon_when_multi() {
+        let argv = vec!["lsd", "--icon", "always", "--icon", "never"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(
+            Some(IconOption::Never),
+            IconOption::from_arg_matches(&matches)
+        );
+    }
+
+    #[test]
     fn test_from_config_none() {
         assert_eq!(None, IconOption::from_config(&Config::with_none()));
     }
@@ -307,6 +317,16 @@ mod test_icon_theme {
     #[test]
     fn test_from_arg_matches_unicode() {
         let argv = vec!["lsd", "--icon-theme", "unicode"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(
+            Some(IconTheme::Unicode),
+            IconTheme::from_arg_matches(&matches)
+        );
+    }
+
+    #[test]
+    fn test_from_arg_matches_icon_multi() {
+        let argv = vec!["lsd", "--icon-theme", "fancy", "--icon-theme", "unicode"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(
             Some(IconTheme::Unicode),

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -98,7 +98,11 @@ impl Recursion {
     /// If the parameter to the "depth" argument can not be parsed, this returns an [Error] in a
     /// [Some].
     fn depth_from_arg_matches(matches: &ArgMatches) -> Option<Result<usize, Error>> {
-        if let Some(str) = matches.value_of("depth") {
+        let depth = match matches.values_of("depth") {
+            Some(d) => d.last(),
+            None => None,
+        };
+        if let Some(str) = depth {
             match str.parse::<usize>() {
                 Ok(value) => return Some(Ok(value)),
                 Err(_) => {
@@ -208,6 +212,21 @@ mod test {
             Some(result) => {
                 match result {
                     Ok(value) => value == 42,
+                    Err(_) => false,
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn test_depth_from_arg_matches_depth_multi() {
+        let argv = vec!["lsd", "--depth", "4", "--depth", "2"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert!(match Recursion::depth_from_arg_matches(&matches) {
+            None => false,
+            Some(result) => {
+                match result {
+                    Ok(value) => value == 2,
                     Err(_) => false,
                 }
             }

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -44,7 +44,7 @@ impl Configurable<Self> for SizeFlag {
     /// [None].
     fn from_arg_matches(matches: &ArgMatches) -> Option<Self> {
         if matches.occurrences_of("size") > 0 {
-            if let Some(size) = matches.value_of("size") {
+            if let Some(size) = matches.values_of("size")?.last() {
                 return Self::from_str(size);
             }
         }
@@ -105,6 +105,13 @@ mod test {
         let args = vec!["lsd", "--size", "bytes"];
         let matches = app::build().get_matches_from_safe(args).unwrap();
         assert_eq!(Some(SizeFlag::Bytes), SizeFlag::from_arg_matches(&matches));
+    }
+
+    #[test]
+    fn test_from_arg_matches_size_multi() {
+        let args = vec!["lsd", "--size", "bytes", "--size", "short"];
+        let matches = app::build().get_matches_from_safe(args).unwrap();
+        assert_eq!(Some(SizeFlag::Short), SizeFlag::from_arg_matches(&matches));
     }
 
     #[test]


### PR DESCRIPTION
<!--- PR Description --->

```
lsd --icon never --icon always
```
This now takes the last one (`always`) instead of the first one (`never`).

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry