### PR TITLE
add --config-file flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change size to use btyes in classic mode from [meain](https://github.com/meain)
 - Show tree edge before name block or first column if no name block from [zwpaper](https://github.com/zwpaper) [#468](https://github.com/Peltoche/lsd/issues/468)
 - Added icons for Perl modules (.pm) and test scripts (.t)
+- Add `--config-file` flag to read configuration file from a custom location
 ### Fixed
 
 ## [0.20.1] - 2021-03-07

--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ For most people it should be enough to put their config file at
 On Windows systems `lsd` only looks for the `config.yaml` files in one location:
 `%APPDATA%\lsd\`
 
+#### Custom
+
+You can also provide a configuration file from a non standard location:
+`lsd --config-file [PATH]`
+
 ### Config file content
 
 This is an example config file with the default values and some additional

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -47,6 +47,9 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 `--ignore-config`
 : Ignore the configuration file
 
+`--config-file <path>`
+: Provide the config file from a custom location
+
 `-F`, `--classify`
 : Append indicator (one of \*/=>@|) at the end of the file names
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -74,9 +74,10 @@ pub fn build() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name("config-file")
-                .short("f")
                 .long("config-file")
                 .help("Provide a custom lsd configuration file")
+                .value_name("config-file")
+                .takes_value(true)
         )
         .arg(
             Arg::with_name("oneline")

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,6 +73,12 @@ pub fn build() -> App<'static, 'static> {
                 .help("Ignore the configuration file"),
         )
         .arg(
+            Arg::with_name("config-file")
+                .short("f")
+                .long("config-file")
+                .help("Provide a custom lsd configuration file")
+        )
+        .arg(
             Arg::with_name("oneline")
                 .short("1")
                 .long("oneline")

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -117,6 +117,12 @@ impl Config {
         serde_yaml::from_str::<Self>(yaml)
     }
 
+    #[cfg(not(windows))]
+    fn _custom_config_path(_file: String) -> Option<PathBuf> {
+        // somehow get file path from args here...
+        todo!()
+    }
+
     /// This provides the path for a configuration file, according to the XDG_BASE_DIRS specification.
     /// return None if error like PermissionDenied
     #[cfg(not(windows))]

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -117,12 +117,6 @@ impl Config {
         serde_yaml::from_str::<Self>(yaml)
     }
 
-    #[cfg(not(windows))]
-    fn _custom_config_path(_file: String) -> Option<PathBuf> {
-        // somehow get file path from args here...
-        todo!()
-    }
-
     /// This provides the path for a configuration file, according to the XDG_BASE_DIRS specification.
     /// return None if error like PermissionDenied
     #[cfg(not(windows))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,9 @@ fn main() {
 
     let config = if matches.is_present("ignore-config") {
         Config::with_none()
+    } else if matches.is_present("config-file") {
+        // Here we should call new method to load from custom path
+        Config::default()
     } else {
         Config::default()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,8 +105,12 @@ fn main() {
     let config = if matches.is_present("ignore-config") {
         Config::with_none()
     } else if matches.is_present("config-file") {
-        // Here we should call new method to load from custom path
-        Config::default()
+        let path = matches
+            .value_of("config-file")
+            .expect("Invalid config file path")
+            .into();
+
+        Config::from_file(path).expect("Provided file path is invalid")
     } else {
         Config::default()
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -551,3 +551,20 @@ fn test_upper_case_ext_icon_match() {
         .assert()
         .stdout(predicate::str::contains("\u{f410}"));
 }
+
+#[cfg(unix)]
+#[test]
+fn test_custom_config_file_parsing() {
+    let dir = tempdir();
+    dir.child("config.yaml").write_str("layout: tree").unwrap();
+    dir.child("folder").create_dir_all().unwrap();
+    dir.child("folder/file").touch().unwrap();
+    let custom_config = dir.path().join("config.yaml");
+
+    cmd()
+        .arg("--config-file")
+        .arg(custom_config)
+        .arg(dir.child("folder").path())
+        .assert()
+        .stdout(predicate::str::is_match("folder\n└── file").unwrap());
+}


### PR DESCRIPTION
So here it is my progress so far. I figured that if we are assembling a custom Config object it should be parsed before parsing the arguments, correct?

I might be terribly wrong tho.