### PR TITLE
Clarify custom date format for config in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show tree edge before name block or first column if no name block from [zwpaper](https://github.com/zwpaper) [#468](https://github.com/Peltoche/lsd/issues/468)
 - Added icons for Perl modules (.pm) and test scripts (.t)
 - Add `--config-file` flag to read configuration file from a custom location
+- Clarify custom date format for `date` field in configuration file in the README.
 ### Fixed
 
 ## [0.20.1] - 2021-03-07

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ color:
 # This specifies the date format for the date column. The freeform format
 # accepts an strftime like string.
 # When "classic" is set, this is set to "date".
-# Possible values: date, relative, +<date_format>
+# Possible values: date, relative, '+<strftime_date_format>'
 date: date
 
 # == Dereference ==

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [External Configurations](#external-configurations)
-  * [Required](#required)
-  * [Optional](#optional)
+  - [Required](#required)
+  - [Optional](#optional)
 - [F.A.Q.](#faq)
 - [Contributors](#contributors)
 - [Credits](#credits)
@@ -63,8 +63,8 @@ sudo dpkg -i lsd_0.20.1_amd64.deb # adapt version number and architecture
 ```sh
 sudo emerge sys-apps/lsd
 ```
-(Ebuild maintained by Georgy Yakovlev)
 
+(Ebuild maintained by Georgy Yakovlev)
 
 ### On macOS
 
@@ -112,6 +112,7 @@ Using the package manager:
 ``` sh
 pkgin install lsd
 ```
+
 Building from source:
 
 ``` sh
@@ -122,14 +123,19 @@ make install
 ### On Windows
 
 Install with [Scoop](https://scoop.sh):
+
 ```powershell
 scoop install lsd
 ```
+
 ### On Android (via Termux)
+
 ```sh
 pkg install lsd
 ```
+
 [Setup Nerd Fonts in Termux](https://github.com/Peltoche/lsd/issues/423)
+
 ### From Sources
 
 With Rust's package manager cargo, you can install lsd via:
@@ -139,6 +145,7 @@ cargo install lsd
 ```
 
 If you want to install the latest master branch commit:
+
 ```sh
 cargo install --git https://github.com/Peltoche/lsd.git --branch master
 ```
@@ -211,7 +218,8 @@ color:
 # This specifies the date format for the date column. The freeform format
 # accepts an strftime like string.
 # When "classic" is set, this is set to "date".
-# Possible values: date, relative, '+<strftime_date_format>'
+# Possible values: date, relative, '+<date_format>' e.g. date: '+%d %b %y %X' will give you 
+# a date like this: 17 Jun 21 20:14:55
 date: date
 
 # == Dereference ==
@@ -303,12 +311,12 @@ symlink-arrow: ⇒
 Enable nerd fonts for your terminal, URxvt for example:
 
 .Xresources
+
 ```
 URxvt*font:    xft:Hack Nerd Font:style=Regular:size=11
 ```
 
 ### Optional
-
 
 In order to use lsd when entering the `ls` command, you need to add this to your shell
 configuration file  (~/.bashrc, ~/.zshrc, etc.):
@@ -326,7 +334,7 @@ Some further examples of useful aliases:
   alias lt='ls --tree'
   ```
 
-## F.A.Q.
+## F.A.Q
 
 ### Default Colors
 

--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ color:
 # This specifies the date format for the date column. The freeform format
 # accepts an strftime like string.
 # When "classic" is set, this is set to "date".
-# Possible values: date, relative, '+<date_format>' e.g. date: '+%d %b %y %X' will give you 
-# a date like this: 17 Jun 21 20:14:55
+# Possible values: date, relative, '+<date_format>' 
+# `date_format` will be a `strftime` formatted value. e.g. `date: '+%d %b %y %X'` will give you a date like this: 17 Jun 21 20:14:55
 date: date
 
 # == Dereference ==


### PR DESCRIPTION
As per #527 , it is a bit confusing what is written in the README for the `date` field of the configuration file. In my case, I was also using an older version - v0.16.0 as a snap - which also meant that even if I entered a correctly formatted custom date, it didnt work! 😅 This might save someone else in the future!