### PR TITLE
build: :hammer: update minimal rust version to 1.42.0 for matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)
 ### Changed
 - Change size to use btyes in classic mode from [meain](https://github.com/meain)
 - Show tree edge before name block or first column if no name block from [zwpaper](https://github.com/zwpaper) [#468](https://github.com/Peltoche/lsd/issues/468)

--- a/build.rs
+++ b/build.rs
@@ -18,11 +18,11 @@ use std::process::exit;
 include!("src/app.rs");
 
 fn main() {
-    match version_check::is_min_version("1.33.0") {
+    match version_check::is_min_version("1.42.0") {
         Some(true) => {}
         // rustc version too small or can't figure it out
         _ => {
-            writeln!(&mut io::stderr(), "'lsd' requires rustc >= 1.33.0").unwrap();
+            writeln!(&mut io::stderr(), "'lsd' requires rustc >= 1.42.0").unwrap();
             exit(1);
         }
     }


### PR DESCRIPTION
we used `matches` macro, it is stable on v1.42.0

fix https://github.com/Peltoche/lsd/issues/534

<!--- PR Description --->

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [x] Add changelog entry