### PR TITLE
Non-zero exit status in case of failure

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -108,9 +108,10 @@ impl Core {
                 self.flags.layout == Layout::Tree || self.flags.display != Display::DirectoryOnly;
             if recurse {
                 match meta.recurse_into(depth, &self.flags) {
-                    Ok(content) => {
+                    Ok((content, exit_code)) => {
                         meta.content = content;
                         meta_list.push(meta);
+                        self.exit_code.set_if_greater(exit_code);
                     }
                     Err(err) => {
                         print_error!("{}: {}\n", path.display(), err);

--- a/src/display.rs
+++ b/src/display.rs
@@ -523,11 +523,11 @@ mod tests {
         dir.child("one.d").create_dir_all().unwrap();
         dir.child("one.d/two").touch().unwrap();
         dir.child("one.d/.hidden").touch().unwrap();
-        let mut metas = Meta::from_path(Path::new(dir.path()), false)
+        let (metas_, _) = Meta::from_path(Path::new(dir.path()), false)
             .unwrap()
             .recurse_into(42, &flags)
-            .unwrap()
             .unwrap();
+        let mut metas = metas_.unwrap();
         sort(&mut metas, &sort::assemble_sorters(&flags));
         let output = tree(
             &metas,
@@ -554,11 +554,11 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("dir").create_dir_all().unwrap();
         dir.child("dir/file").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let (metas_, _) = Meta::from_path(Path::new(dir.path()), false)
             .unwrap()
             .recurse_into(42, &flags)
-            .unwrap()
             .unwrap();
+        let metas = metas_.unwrap();
         let output = tree(
             &metas,
             &flags,
@@ -593,11 +593,12 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("dir").create_dir_all().unwrap();
         dir.child("dir/file").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let (metas_, _) = Meta::from_path(Path::new(dir.path()), false)
             .unwrap()
             .recurse_into(42, &flags)
-            .unwrap()
             .unwrap();
+
+        let metas = metas_.unwrap();
         let output = tree(
             &metas,
             &flags,
@@ -631,11 +632,12 @@ mod tests {
         let dir = assert_fs::TempDir::new().unwrap();
         dir.child("one.d").create_dir_all().unwrap();
         dir.child("one.d/two").touch().unwrap();
-        let metas = Meta::from_path(Path::new(dir.path()), false)
+        let (metas_, _) = Meta::from_path(Path::new(dir.path()), false)
             .unwrap()
             .recurse_into(42, &flags)
-            .unwrap()
             .unwrap();
+
+        let metas = metas_.unwrap();
         let output = tree(
             &metas,
             &flags,

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,26 +41,7 @@ mod sort;
 use crate::config_file::Config;
 use crate::core::Core;
 use crate::flags::Flags;
-use std::fmt;
-use std::io::Error;
 use std::path::PathBuf;
-
-struct PathError {
-    path: PathBuf,
-    error: Error,
-}
-
-impl PathError {
-    fn new(path: PathBuf, error: Error) -> Self {
-        Self { path, error }
-    }
-}
-
-impl fmt::Display for PathError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.path.display(), self.error)
-    }
-}
 
 #[derive(PartialEq, PartialOrd, Copy, Clone)]
 enum ExitCode {
@@ -68,28 +49,13 @@ enum ExitCode {
     MinorIssue,
     MajorIssue,
 }
-pub struct ExitStatus {
-    code: ExitCode,
-    errors: Vec<PathError>,
-}
-
-impl ExitStatus {
-    fn new() -> Self {
-        Self {
-            code: ExitCode::OK,
-            errors: vec![],
+impl ExitCode {
+    fn set_if_greater(&mut self, mut code: ExitCode) {
+        if self < &mut code {
+            *self = code.clone()
         }
     }
-
-    fn push_error(&mut self, code: ExitCode, error: PathError) {
-        if self.code < code {
-            self.code = code;
-        }
-
-        self.errors.push(error);
-    }
 }
-
 /// Macro used to avoid panicking when the lsd method is used with a pipe and
 /// stderr close before our program.
 #[macro_export]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,13 +44,13 @@ use crate::flags::Flags;
 use std::path::PathBuf;
 
 #[derive(PartialEq, PartialOrd, Copy, Clone)]
-enum ExitCode {
+pub enum ExitCode {
     OK,
     MinorIssue,
     MajorIssue,
 }
 impl ExitCode {
-    fn set_if_greater(&mut self, mut code: ExitCode) {
+    pub fn set_if_greater(&mut self, mut code: ExitCode) {
         if self < &mut code {
             *self = code.clone()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,5 +117,7 @@ fn main() {
     let flags = Flags::configure_from(&matches, &config).unwrap_or_else(|err| err.exit());
     let core = Core::new(flags);
 
-    core.run(inputs);
+    let exit_status = core.run(inputs);
+
+    std::process::exit(exit_status)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,7 @@ extern crate predicates;
 use assert_cmd::prelude::*;
 use assert_fs::prelude::*;
 use predicates::prelude::*;
+use std::os::unix::fs::PermissionsExt;
 use std::process::Command;
 
 #[cfg(unix)]
@@ -568,3 +569,21 @@ fn test_custom_config_file_parsing() {
         .assert()
         .stdout(predicate::str::is_match("folder\n└── file").unwrap());
 }
+
+#[test]
+fn test_cannot_access_file_exit_status() {
+    let dir = tempdir();
+    let does_not_exist = dir.path().join("does_not_exist");
+
+    let status = cmd()
+        .arg("-l")
+        .arg("--ignore-config")
+        .arg(does_not_exist)
+        .status()
+        .unwrap()
+        .code()
+        .unwrap();
+
+    assert_eq!(status, 2)
+}
+

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -587,3 +587,24 @@ fn test_cannot_access_file_exit_status() {
     assert_eq!(status, 2)
 }
 
+#[cfg(unix)]
+#[test]
+fn test_cannot_access_subdir_exit_status() {
+    let tmp = tempdir();
+
+    let readonly = std::fs::Permissions::from_mode(0o400);
+    tmp.child("d/subdir/onemore").create_dir_all().unwrap();
+
+    std::fs::set_permissions(tmp.child("d").path().join("subdir"), readonly).unwrap();
+
+    let status = cmd()
+        .arg("--tree")
+        .arg("--ignore-config")
+        .arg(tmp.child("d").path())
+        .status()
+        .unwrap()
+        .code()
+        .unwrap();
+
+    assert_eq!(status, 1)
+}


### PR DESCRIPTION
Mimics the value of exit status from GNU ls in case of failure:

> Exit status:
> 0      if OK,
> 1      if minor problems (e.g., cannot access subdirectory),
> 2      if serious trouble (e.g., cannot access command-line argument).

Closes #502


<!--- PR Description --->

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry