### PR TITLE
Add NO_COLOR env support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Added
 - update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)
-- [`NO_COLOR`](https://no-color.org/) environment variable support. 
+- [`NO_COLOR`](https://no-color.org/) environment variable support from [AnInternetTroll](https://github.com/aninternettroll)
 ### Changed
 - Change size to use btyes in classic mode from [meain](https://github.com/meain)
 - Show tree edge before name block or first column if no name block from [zwpaper](https://github.com/zwpaper) [#468](https://github.com/Peltoche/lsd/issues/468)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Added
 - update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)
+- [`NO_COLOR`](https://no-color.org/) environment variable support. 
 ### Changed
 - Change size to use btyes in classic mode from [meain](https://github.com/meain)
 - Show tree edge before name block or first column if no name block from [zwpaper](https://github.com/zwpaper) [#468](https://github.com/Peltoche/lsd/issues/468)

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -6,9 +6,9 @@ use super::Configurable;
 use crate::config_file::Config;
 use crate::print_error;
 
-use std::env;
 use clap::ArgMatches;
 use serde::Deserialize;
+use std::env;
 
 /// A collection of flags on how to use colors.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
@@ -93,7 +93,7 @@ impl Configurable<Self> for ColorOption {
 
     fn from_environment() -> Option<Self> {
         if env::var("NO_COLOR").is_ok() {
-            return Some(Self::Never)
+            return Some(Self::Never);
         } else {
             None
         }
@@ -114,6 +114,8 @@ mod test_color_option {
     use crate::app;
     use crate::config_file::{self, Config};
     use crate::flags::Configurable;
+
+    use std::env::set_var;
 
     #[test]
     fn test_from_arg_matches_none() {
@@ -150,6 +152,12 @@ mod test_color_option {
             Some(ColorOption::Never),
             ColorOption::from_arg_matches(&matches)
         );
+    }
+
+    #[test]
+    fn test_from_env_no_color() {
+        set_var("NO_COLOR", "true");
+        assert_eq!(Some(ColorOption::Never), ColorOption::from_environment());
     }
 
     #[test]

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -6,6 +6,7 @@ use super::Configurable;
 use crate::config_file::Config;
 use crate::print_error;
 
+use std::env;
 use clap::ArgMatches;
 use serde::Deserialize;
 
@@ -85,6 +86,14 @@ impl Configurable<Self> for ColorOption {
 
         if let Some(color) = &config.color {
             Some(color.when)
+        } else {
+            None
+        }
+    }
+
+    fn from_environment() -> Option<Self> {
+        if env::var("NO_COLOR").is_ok() {
+            return Some(Self::Never)
         } else {
             None
         }

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -93,7 +93,7 @@ impl Configurable<Self> for ColorOption {
 
     fn from_environment() -> Option<Self> {
         if env::var("NO_COLOR").is_ok() {
-            return Some(Self::Never);
+            Some(Self::Never)
         } else {
             None
         }


### PR DESCRIPTION
This allows the program to not output colours when using the `NO_COLOR` environmental variable. For example when running `NO_COLOR=1 lsd`. To read more about this environmental variable take a look at https://no-color.org/

#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry