### PR TITLE
Add support for MISSING  / mi= missing symlink target LS_COLORS value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ### Added
+- Added support for the MISSING / mi= dircolors variable for broken symlink targets.
 - Add support for theme from [zwpaper](https://github.com/zwpaper) [#452](https://github.com/Peltoche/lsd/pull/452)
 - Update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)
 - [`NO_COLOR`](https://no-color.org/) environment variable support from [AnInternetTroll](https://github.com/aninternettroll)

--- a/src/color.rs
+++ b/src/color.rs
@@ -19,6 +19,7 @@ pub enum Elem {
     },
     SymLink,
     BrokenSymLink,
+    MissingSymLinkTarget,
     Dir {
         uid: bool,
     },
@@ -87,6 +88,7 @@ impl Elem {
             } => theme.file_type.file.no_exec_no_uid,
             Elem::SymLink => theme.file_type.symlink.default,
             Elem::BrokenSymLink => theme.file_type.symlink.broken,
+            Elem::MissingSymLinkTarget => theme.file_type.symlink.missing_target,
             Elem::Dir { uid: true } => theme.file_type.dir.uid,
             Elem::Dir { uid: false } => theme.file_type.dir.no_uid,
             Elem::Pipe => theme.file_type.pipe,
@@ -216,6 +218,7 @@ impl Colors {
             Elem::BlockDevice => Some("bd"),
             Elem::CharDevice => Some("cd"),
             Elem::BrokenSymLink => Some("or"),
+            Elem::MissingSymLinkTarget => Some("mi"),
             Elem::INode { valid } => match valid {
                 true => Some("so"),
                 false => Some("no"),
@@ -345,8 +348,9 @@ mod elem {
                 },
                 pipe: Color::AnsiValue(44), // DarkTurquoise
                 symlink: theme::Symlink {
-                    default: Color::AnsiValue(44), // DarkTurquoise
-                    broken: Color::AnsiValue(124), // Red3
+                    default: Color::AnsiValue(44),         // DarkTurquoise
+                    broken: Color::AnsiValue(124),         // Red3
+                    missing_target: Color::AnsiValue(124), // Red3
                 },
                 block_device: Color::AnsiValue(44), // DarkTurquoise
                 char_device: Color::AnsiValue(172), // Orange3

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -76,6 +76,7 @@ pub struct Dir {
 pub struct Symlink {
     pub default: Color,
     pub broken: Color,
+    pub missing_target: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -200,8 +201,9 @@ impl Theme {
                 },
                 pipe: Color::AnsiValue(44), // DarkTurquoise
                 symlink: Symlink {
-                    default: Color::AnsiValue(44), // DarkTurquoise
-                    broken: Color::AnsiValue(124), // Red3
+                    default: Color::AnsiValue(44),         // DarkTurquoise
+                    broken: Color::AnsiValue(124),         // Red3
+                    missing_target: Color::AnsiValue(124), // Red3
                 },
                 block_device: Color::AnsiValue(44), // DarkTurquoise
                 char_device: Color::AnsiValue(172), // Orange3

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -52,7 +52,7 @@ impl SymLink {
             let elem = if self.valid {
                 &Elem::SymLink
             } else {
-                &Elem::BrokenSymLink
+                &Elem::MissingSymLinkTarget
             };
 
             let strings: &[ColoredString] = &[

--- a/src/meta/symlink.rs
+++ b/src/meta/symlink.rs
@@ -115,4 +115,22 @@ mod tests {
             .to_string()
         );
     }
+
+    #[test]
+    fn test_symlink_render_default_invalid_target_withcolor() {
+        let link = SymLink {
+            target: Some("/target".to_string()),
+            valid: false,
+        };
+        let argv = vec!["lsd"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(
+            format!("{}", " ⇒ \u{1b}[38;5;124m/target\u{1b}[39m"),
+            link.render(
+                &Colors::new(ThemeOption::NoLscolors),
+                &Flags::configure_from(&matches, &Config::with_none()).unwrap()
+            )
+            .to_string()
+        );
+    }
 }


### PR DESCRIPTION
<!--- PR Description --->
Added support for the MISSING / mi= dircolors variable for broken symlink targets.

See: https://github.com/arcticicestudio/nord-dircolors for an example setting of "MISSING".

Before:
<img width="237" alt="CleanShot 2021-10-01 at 10 41 37@2x" src="https://user-images.githubusercontent.com/22371/135664119-dda41ae3-c6e6-4e81-bd19-129d9cdfb178.png">

After:
<img width="239" alt="CleanShot 2021-10-01 at 10 41 53@2x" src="https://user-images.githubusercontent.com/22371/135664108-6b439ce6-0c4b-4d87-8eaf-4c0733cb3a7f.png">

---
- [X] Use `cargo fmt`
- [] Add necessary tests
- [X] Add changelog entry