### PR TITLE
Allow human-readable to be set multiple times

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -98,6 +98,7 @@ pub fn build() -> App<'static, 'static> {
             Arg::with_name("human_readable")
                 .short("h")
                 .long("human-readable")
+                .multiple(true)
                 .help("For ls compatibility purposes ONLY, currently set by default"),
         )
         .arg(


### PR DESCRIPTION
This improves compatibility with `ls`.

For example: in my `~/.zshrc` I have the following:
```bash
alias ls='lsd -lFah'
```

When I'm off-guard and type `ls -lah` I now get the following:

```
error: The argument '--human-readable' was provided more than once, but cannot be used multiple times

USAGE:
    lsd --all --color <color>... --date <date>... --group-dirs <group-dirs>... --human-readable --icon <icon>... --icon-theme <icon-theme>... --ignore-glob <pattern>... --classify --long --size <size>...

For more information try --help
```

This should solve that.