### PR TITLE
theme: :sparkles: add default and update the others optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for the MISSING / mi= dircolors variable for broken symlink targets.
 - Add support for theme from [zwpaper](https://github.com/zwpaper) [#452](https://github.com/Peltoche/lsd/pull/452)
+- Update theme to support partial themes [zwpaper](https://github.com/zwpaper) [#591](https://github.com/Peltoche/lsd/pull/591)
 - Update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)
 - [`NO_COLOR`](https://no-color.org/) environment variable support from [AnInternetTroll](https://github.com/aninternettroll)
 ### Changed
@@ -17,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `--config-file` flag to read configuration file from a custom location
 - Clarify custom date format for `date` field in configuration file in the README.
 ### Fixed
-- Support all `strftime` like formatting [#532](https://github.com/Peltoche/lsd/issues/532)   
+- Support all `strftime` like formatting [#532](https://github.com/Peltoche/lsd/issues/532)
 
 ## [0.20.1] - 2021-03-07
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Please notice that color value would ignore case, both lowercase and UPPERCASE i
 This is the default theme scheme shipped with `lsd`.
 
 ```yaml
+default: 245
 user: 230
 group: 187
 permission:
@@ -263,6 +264,9 @@ links:
   invalid: 245
 tree-edge: 245
 ```
+
+The `default` item is required while the others are optional,
+it will use the `default` value as color for the items missed.
 
 ## External Configurations
 
@@ -306,11 +310,11 @@ To check if the font you are using is setup correctly, try running the following
 ```sh
 echo $'\uf115'
 ```
-  
+
 ### Icons missing or not rendering correctly using PuTTY/KiTTY on Windows
-  
+
 First of all, make sure a patched font is installed and PuTTY/KiTTY is configurated to use it, please check [Prerequisites](#prerequisites).
-  
+
 There are problems for PuTTY/KiTTY to show 2 char wide icons, make sure using a 1 char wide font like [Hack Regular Nerd Font Complete Mono Windows Compatible](https://github.com/ryanoasis/nerd-fonts/blob/master/patched-fonts/Hack/Regular/complete/Hack%20Regular%20Nerd%20Font%20Complete%20Mono%20Windows%20Compatible.ttf), check [this issue](https://github.com/Peltoche/lsd/issues/331) for detail.
 
 ### Colors

--- a/README.md
+++ b/README.md
@@ -228,17 +228,16 @@ Check [Theme file content](#theme-file-content) for details.
 ### Theme file content
 
 Theme file use the [crossterm](https://crates.io/crates/crossterm)
-configure the colors, check [crossterm](https://docs.rs/crossterm/0.20.0/crossterm/style/enum.Color.html)
-for the supported colors.
+to configure the colors, check [crossterm](https://docs.rs/crossterm/0.20.0/crossterm/style/enum.Color.html)
+for supported colors.
 
 Color table: https://upload.wikimedia.org/wikipedia/commons/1/15/Xterm_256color_chart.svg
 
-Please notice that color value would ignore case, both lowercase and UPPERCASE is supported.
+Please notice that color values would ignore the case, both lowercase and UPPERCASE is supported.
 
 This is the default theme scheme shipped with `lsd`.
 
 ```yaml
-default: 245
 user: 230
 group: 187
 permission:
@@ -265,8 +264,11 @@ links:
 tree-edge: 245
 ```
 
-The `default` item is required while the others are optional,
-it will use the `default` value as color for the items missed.
+When creating a theme for `lsd`, you can specify any part of the default theme,
+and then change its colors, the items missed would fallback to use the default colors.
+
+Please also notice that an empty theme is **NOT** supported due to
+[a bug in serde lib](https://github.com/dtolnay/serde-yaml/issues/86).
 
 ## External Configurations
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -324,81 +324,57 @@ mod elem {
     #[cfg(test)]
     fn test_theme() -> Theme {
         Theme {
-            user: Some(Color::AnsiValue(230)),  // Cornsilk1
-            group: Some(Color::AnsiValue(187)), // LightYellow3
-            permission: Some(theme::Permission {
-                read: Some(Color::Green),
-                write: Some(Color::Yellow),
-                exec: Some(Color::Red),
-                exec_sticky: Some(Color::Magenta),
-                no_access: Some(Color::AnsiValue(245)), // Grey
-            }),
-            file_type: theme::FileType {
-                file: Some(theme::File {
-                    exec_uid: Some(Color::AnsiValue(40)),        // Green3
-                    uid_no_exec: Some(Color::AnsiValue(184)),    // Yellow3
-                    exec_no_uid: Some(Color::AnsiValue(40)),     // Green3
-                    no_exec_no_uid: Some(Color::AnsiValue(184)), // Yellow3
-                }),
-                dir: Some(theme::Dir {
-                    uid: Some(Color::AnsiValue(33)),    // DodgerBlue1
-                    no_uid: Some(Color::AnsiValue(33)), // DodgerBlue1
-                }),
-                pipe: Some(Color::AnsiValue(44)), // DarkTurquoise
-                symlink: Some(theme::Symlink {
-                    default: Some(Color::AnsiValue(44)),         // DarkTurquoise
-                    broken: Some(Color::AnsiValue(124)),         // Red3
-                    missing_target: Some(Color::AnsiValue(124)), // Red3
-                }),
-                block_device: Some(Color::AnsiValue(44)), // DarkTurquoise
-                char_device: Some(Color::AnsiValue(172)), // Orange3
-                socket: Some(Color::AnsiValue(44)),       // DarkTurquoise
-                special: Some(Color::AnsiValue(44)),      // DarkTurquoise
+            user: Color::AnsiValue(230),  // Cornsilk1
+            group: Color::AnsiValue(187), // LightYellow3
+            permission: theme::Permission {
+                read: Color::Green,
+                write: Color::Yellow,
+                exec: Color::Red,
+                exec_sticky: Color::Magenta,
+                no_access: Color::AnsiValue(245), // Grey
             },
-            date: Some(theme::Date {
-                hour_old: Some(Color::AnsiValue(40)), // Green3
-                day_old: Some(Color::AnsiValue(42)),  // SpringGreen2
-                older: Some(Color::AnsiValue(36)),    // DarkCyan
-            }),
-            size: Some(theme::Size {
-                none: Some(Color::AnsiValue(245)),   // Grey
-                small: Some(Color::AnsiValue(229)),  // Wheat1
-                medium: Some(Color::AnsiValue(216)), // LightSalmon1
-                large: Some(Color::AnsiValue(172)),  // Orange3
-            }),
-            inode: Some(theme::INode {
-                valid: Some(Color::AnsiValue(13)),    // Pink
-                invalid: Some(Color::AnsiValue(245)), // Grey
-            }),
-            links: Some(theme::Links {
-                valid: Some(Color::AnsiValue(13)),    // Pink
-                invalid: Some(Color::AnsiValue(245)), // Grey
-            }),
-            tree_edge: Some(Color::AnsiValue(245)), // Grey
-        }
-    }
-
-    fn none_theme() -> Theme {
-        Theme {
-            default: Color::Green,
             file_type: theme::FileType {
-                file: None,
-                dir: None,
-                pipe: None,
-                symlink: None,
-                block_device: None,
-                char_device: None,
-                socket: None,
-                special: None,
+                file: theme::File {
+                    exec_uid: Color::AnsiValue(40),        // Green3
+                    uid_no_exec: Color::AnsiValue(184),    // Yellow3
+                    exec_no_uid: Color::AnsiValue(40),     // Green3
+                    no_exec_no_uid: Color::AnsiValue(184), // Yellow3
+                },
+                dir: theme::Dir {
+                    uid: Color::AnsiValue(33),    // DodgerBlue1
+                    no_uid: Color::AnsiValue(33), // DodgerBlue1
+                },
+                pipe: Color::AnsiValue(44), // DarkTurquoise
+                symlink: theme::Symlink {
+                    default: Color::AnsiValue(44),         // DarkTurquoise
+                    broken: Color::AnsiValue(124),         // Red3
+                    missing_target: Color::AnsiValue(124), // Red3
+                },
+                block_device: Color::AnsiValue(44), // DarkTurquoise
+                char_device: Color::AnsiValue(172), // Orange3
+                socket: Color::AnsiValue(44),       // DarkTurquoise
+                special: Color::AnsiValue(44),      // DarkTurquoise
             },
-            group: None,
-            user: None,
-            permission: None,
-            date: None,
-            size: None,
-            inode: None,
-            links: None,
-            tree_edge: None,
+            date: theme::Date {
+                hour_old: Color::AnsiValue(40), // Green3
+                day_old: Color::AnsiValue(42),  // SpringGreen2
+                older: Color::AnsiValue(36),    // DarkCyan
+            },
+            size: theme::Size {
+                none: Color::AnsiValue(245),   // Grey
+                small: Color::AnsiValue(229),  // Wheat1
+                medium: Color::AnsiValue(216), // LightSalmon1
+                large: Color::AnsiValue(172),  // Orange3
+            },
+            inode: theme::INode {
+                valid: Color::AnsiValue(13),    // Pink
+                invalid: Color::AnsiValue(245), // Grey
+            },
+            links: theme::Links {
+                valid: Color::AnsiValue(13),    // Pink
+                invalid: Color::AnsiValue(245), // Grey
+            },
+            tree_edge: Color::AnsiValue(245), // Grey
         }
     }
 
@@ -435,20 +411,6 @@ mod elem {
             }
             .get_color(&test_theme()),
             Color::AnsiValue(184),
-        );
-    }
-
-    #[test]
-    fn test_default_theme_default() {
-        assert_eq!(Elem::User.get_color(&none_theme()), none_theme().default,);
-        assert_eq!(Elem::Group.get_color(&none_theme()), none_theme().default,);
-        assert_eq!(
-            Elem::INode { valid: false }.get_color(&none_theme()),
-            none_theme().default,
-        );
-        assert_eq!(
-            Elem::Links { valid: true }.get_color(&none_theme()),
-            none_theme().default,
         );
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -63,6 +63,16 @@ pub enum Elem {
     TreeEdge,
 }
 
+macro_rules! color_or_default {
+    ($elem:expr, $color:tt, $default:expr) => {
+        if let Some(color) = $elem {
+            color.$color.unwrap_or($default)
+        } else {
+            $default
+        }
+    };
+}
+
 impl Elem {
     pub fn has_suid(&self) -> bool {
         matches!(self, Elem::Dir { uid: true } | Elem::File { uid: true, .. })
@@ -73,54 +83,60 @@ impl Elem {
             Elem::File {
                 exec: true,
                 uid: true,
-            } => theme.file_type.file.exec_uid,
+            } => color_or_default!(&theme.file_type.file, exec_uid, theme.default),
             Elem::File {
                 exec: false,
                 uid: true,
-            } => theme.file_type.file.uid_no_exec,
+            } => color_or_default!(&theme.file_type.file, uid_no_exec, theme.default),
             Elem::File {
                 exec: true,
                 uid: false,
-            } => theme.file_type.file.exec_no_uid,
+            } => color_or_default!(&theme.file_type.file, exec_no_uid, theme.default),
             Elem::File {
                 exec: false,
                 uid: false,
-            } => theme.file_type.file.no_exec_no_uid,
-            Elem::SymLink => theme.file_type.symlink.default,
-            Elem::BrokenSymLink => theme.file_type.symlink.broken,
-            Elem::MissingSymLinkTarget => theme.file_type.symlink.missing_target,
-            Elem::Dir { uid: true } => theme.file_type.dir.uid,
-            Elem::Dir { uid: false } => theme.file_type.dir.no_uid,
-            Elem::Pipe => theme.file_type.pipe,
-            Elem::BlockDevice => theme.file_type.block_device,
-            Elem::CharDevice => theme.file_type.char_device,
-            Elem::Socket => theme.file_type.socket,
-            Elem::Special => theme.file_type.special,
+            } => color_or_default!(&theme.file_type.file, no_exec_no_uid, theme.default),
+            Elem::SymLink => color_or_default!(&theme.file_type.symlink, default, theme.default),
+            Elem::BrokenSymLink => {
+                color_or_default!(&theme.file_type.symlink, broken, theme.default)
+            }
+            Elem::MissingSymLinkTarget => {
+                color_or_default!(&theme.file_type.symlink, missing_target, theme.default)
+            }
+            Elem::Dir { uid: true } => color_or_default!(&theme.file_type.dir, uid, theme.default),
+            Elem::Dir { uid: false } => {
+                color_or_default!(&theme.file_type.dir, no_uid, theme.default)
+            }
+            Elem::Pipe => theme.file_type.pipe.unwrap_or(theme.default),
+            Elem::BlockDevice => theme.file_type.block_device.unwrap_or(theme.default),
+            Elem::CharDevice => theme.file_type.char_device.unwrap_or(theme.default),
+            Elem::Socket => theme.file_type.socket.unwrap_or(theme.default),
+            Elem::Special => theme.file_type.special.unwrap_or(theme.default),
 
-            Elem::Read => theme.permission.read,
-            Elem::Write => theme.permission.write,
-            Elem::Exec => theme.permission.exec,
-            Elem::ExecSticky => theme.permission.exec_sticky,
-            Elem::NoAccess => theme.permission.no_access,
+            Elem::Read => color_or_default!(&theme.permission, read, theme.default),
+            Elem::Write => color_or_default!(&theme.permission, write, theme.default),
+            Elem::Exec => color_or_default!(&theme.permission, exec, theme.default),
+            Elem::ExecSticky => color_or_default!(&theme.permission, exec_sticky, theme.default),
+            Elem::NoAccess => color_or_default!(&theme.permission, no_access, theme.default),
 
-            Elem::DayOld => theme.date.day_old,
-            Elem::HourOld => theme.date.hour_old,
-            Elem::Older => theme.date.older,
+            Elem::DayOld => color_or_default!(&theme.date, day_old, theme.default),
+            Elem::HourOld => color_or_default!(&theme.date, hour_old, theme.default),
+            Elem::Older => color_or_default!(&theme.date, older, theme.default),
 
-            Elem::User => theme.user,
-            Elem::Group => theme.group,
+            Elem::User => theme.user.unwrap_or(theme.default),
+            Elem::Group => theme.group.unwrap_or(theme.default),
 
-            Elem::NonFile => theme.size.none,
-            Elem::FileLarge => theme.size.large,
-            Elem::FileMedium => theme.size.medium,
-            Elem::FileSmall => theme.size.small,
+            Elem::NonFile => color_or_default!(&theme.size, none, theme.default),
+            Elem::FileLarge => color_or_default!(&theme.size, large, theme.default),
+            Elem::FileMedium => color_or_default!(&theme.size, medium, theme.default),
+            Elem::FileSmall => color_or_default!(&theme.size, small, theme.default),
 
-            Elem::INode { valid: false } => theme.inode.valid,
-            Elem::INode { valid: true } => theme.inode.invalid,
+            Elem::INode { valid: false } => color_or_default!(&theme.inode, valid, theme.default),
+            Elem::INode { valid: true } => color_or_default!(&theme.inode, invalid, theme.default),
 
-            Elem::TreeEdge => theme.tree_edge,
-            Elem::Links { valid: false } => theme.links.invalid,
-            Elem::Links { valid: true } => theme.links.valid,
+            Elem::TreeEdge => theme.tree_edge.unwrap_or(theme.default),
+            Elem::Links { valid: false } => color_or_default!(&theme.links, invalid, theme.default),
+            Elem::Links { valid: true } => color_or_default!(&theme.links, valid, theme.default),
         }
     }
 }
@@ -326,62 +342,87 @@ mod elem {
     #[cfg(test)]
     fn test_theme() -> Theme {
         Theme {
-            user: Color::AnsiValue(230),  // Cornsilk1
-            group: Color::AnsiValue(187), // LightYellow3
-            permission: theme::Permission {
-                read: Color::Green,
-                write: Color::Yellow,
-                exec: Color::Red,
-                exec_sticky: Color::Magenta,
-                no_access: Color::AnsiValue(245), // Grey
-            },
+            default: Color::AnsiValue(245),
+            user: Some(Color::AnsiValue(230)),  // Cornsilk1
+            group: Some(Color::AnsiValue(187)), // LightYellow3
+            permission: Some(theme::Permission {
+                read: Some(Color::Green),
+                write: Some(Color::Yellow),
+                exec: Some(Color::Red),
+                exec_sticky: Some(Color::Magenta),
+                no_access: Some(Color::AnsiValue(245)), // Grey
+            }),
             file_type: theme::FileType {
-                file: theme::File {
-                    exec_uid: Color::AnsiValue(40),        // Green3
-                    uid_no_exec: Color::AnsiValue(184),    // Yellow3
-                    exec_no_uid: Color::AnsiValue(40),     // Green3
-                    no_exec_no_uid: Color::AnsiValue(184), // Yellow3
-                },
-                dir: theme::Dir {
-                    uid: Color::AnsiValue(33),    // DodgerBlue1
-                    no_uid: Color::AnsiValue(33), // DodgerBlue1
-                },
-                pipe: Color::AnsiValue(44), // DarkTurquoise
-                symlink: theme::Symlink {
-                    default: Color::AnsiValue(44),         // DarkTurquoise
-                    broken: Color::AnsiValue(124),         // Red3
-                    missing_target: Color::AnsiValue(124), // Red3
-                },
-                block_device: Color::AnsiValue(44), // DarkTurquoise
-                char_device: Color::AnsiValue(172), // Orange3
-                socket: Color::AnsiValue(44),       // DarkTurquoise
-                special: Color::AnsiValue(44),      // DarkTurquoise
+                file: Some(theme::File {
+                    exec_uid: Some(Color::AnsiValue(40)),        // Green3
+                    uid_no_exec: Some(Color::AnsiValue(184)),    // Yellow3
+                    exec_no_uid: Some(Color::AnsiValue(40)),     // Green3
+                    no_exec_no_uid: Some(Color::AnsiValue(184)), // Yellow3
+                }),
+                dir: Some(theme::Dir {
+                    uid: Some(Color::AnsiValue(33)),    // DodgerBlue1
+                    no_uid: Some(Color::AnsiValue(33)), // DodgerBlue1
+                }),
+                pipe: Some(Color::AnsiValue(44)), // DarkTurquoise
+                symlink: Some(theme::Symlink {
+                    default: Some(Color::AnsiValue(44)),         // DarkTurquoise
+                    broken: Some(Color::AnsiValue(124)),         // Red3
+                    missing_target: Some(Color::AnsiValue(124)), // Red3
+                }),
+                block_device: Some(Color::AnsiValue(44)), // DarkTurquoise
+                char_device: Some(Color::AnsiValue(172)), // Orange3
+                socket: Some(Color::AnsiValue(44)),       // DarkTurquoise
+                special: Some(Color::AnsiValue(44)),      // DarkTurquoise
             },
-            date: theme::Date {
-                hour_old: Color::AnsiValue(40), // Green3
-                day_old: Color::AnsiValue(42),  // SpringGreen2
-                older: Color::AnsiValue(36),    // DarkCyan
+            date: Some(theme::Date {
+                hour_old: Some(Color::AnsiValue(40)), // Green3
+                day_old: Some(Color::AnsiValue(42)),  // SpringGreen2
+                older: Some(Color::AnsiValue(36)),    // DarkCyan
+            }),
+            size: Some(theme::Size {
+                none: Some(Color::AnsiValue(245)),   // Grey
+                small: Some(Color::AnsiValue(229)),  // Wheat1
+                medium: Some(Color::AnsiValue(216)), // LightSalmon1
+                large: Some(Color::AnsiValue(172)),  // Orange3
+            }),
+            inode: Some(theme::INode {
+                valid: Some(Color::AnsiValue(13)),    // Pink
+                invalid: Some(Color::AnsiValue(245)), // Grey
+            }),
+            links: Some(theme::Links {
+                valid: Some(Color::AnsiValue(13)),    // Pink
+                invalid: Some(Color::AnsiValue(245)), // Grey
+            }),
+            tree_edge: Some(Color::AnsiValue(245)), // Grey
+        }
+    }
+
+    fn none_theme() -> Theme {
+        Theme {
+            default: Color::Green,
+            file_type: theme::FileType {
+                file: None,
+                dir: None,
+                pipe: None,
+                symlink: None,
+                block_device: None,
+                char_device: None,
+                socket: None,
+                special: None,
             },
-            size: theme::Size {
-                none: Color::AnsiValue(245),   // Grey
-                small: Color::AnsiValue(229),  // Wheat1
-                medium: Color::AnsiValue(216), // LightSalmon1
-                large: Color::AnsiValue(172),  // Orange3
-            },
-            inode: theme::INode {
-                valid: Color::AnsiValue(13),    // Pink
-                invalid: Color::AnsiValue(245), // Grey
-            },
-            links: theme::Links {
-                valid: Color::AnsiValue(13),    // Pink
-                invalid: Color::AnsiValue(245), // Grey
-            },
-            tree_edge: Color::AnsiValue(245), // Grey
+            group: None,
+            user: None,
+            permission: None,
+            date: None,
+            size: None,
+            inode: None,
+            links: None,
+            tree_edge: None,
         }
     }
 
     #[test]
-    fn test_default_file() {
+    fn test_default_theme_color() {
         assert_eq!(
             Elem::File {
                 exec: true,
@@ -413,6 +454,32 @@ mod elem {
             }
             .get_color(&test_theme()),
             Color::AnsiValue(184),
+        );
+    }
+
+    #[test]
+    fn test_default_theme_default() {
+        assert_eq!(
+            Elem::User.get_color(&none_theme()),
+            none_theme().default,
+        );
+        assert_eq!(
+            Elem::Group.get_color(&none_theme()),
+            none_theme().default,
+        );
+        assert_eq!(
+            Elem::INode {
+                valid: false
+            }
+            .get_color(&none_theme()),
+            none_theme().default,
+        );
+        assert_eq!(
+            Elem::Links {
+                valid: true
+            }
+            .get_color(&none_theme()),
+            none_theme().default,
         );
     }
 }

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -13,16 +13,16 @@ use std::path::Path;
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Theme {
-    pub default: Color,
-    pub user: Option<Color>,
-    pub group: Option<Color>,
-    pub permission: Option<Permission>,
-    pub date: Option<Date>,
-    pub size: Option<Size>,
-    pub inode: Option<INode>,
-    pub tree_edge: Option<Color>,
-    pub links: Option<Links>,
+    pub user: Color,
+    pub group: Color,
+    pub permission: Permission,
+    pub date: Date,
+    pub size: Size,
+    pub inode: INode,
+    pub tree_edge: Color,
+    pub links: Links,
 
     #[serde(skip)]
     pub file_type: FileType,
@@ -31,93 +31,184 @@ pub struct Theme {
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Permission {
-    pub read: Option<Color>,
-    pub write: Option<Color>,
-    pub exec: Option<Color>,
-    pub exec_sticky: Option<Color>,
-    pub no_access: Option<Color>,
+    pub read: Color,
+    pub write: Color,
+    pub exec: Color,
+    pub exec_sticky: Color,
+    pub no_access: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct FileType {
-    pub file: Option<File>,
-    pub dir: Option<Dir>,
-    pub pipe: Option<Color>,
-    pub symlink: Option<Symlink>,
-    pub block_device: Option<Color>,
-    pub char_device: Option<Color>,
-    pub socket: Option<Color>,
-    pub special: Option<Color>,
+    pub file: File,
+    pub dir: Dir,
+    pub pipe: Color,
+    pub symlink: Symlink,
+    pub block_device: Color,
+    pub char_device: Color,
+    pub socket: Color,
+    pub special: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct File {
-    pub exec_uid: Option<Color>,
-    pub uid_no_exec: Option<Color>,
-    pub exec_no_uid: Option<Color>,
-    pub no_exec_no_uid: Option<Color>,
+    pub exec_uid: Color,
+    pub uid_no_exec: Color,
+    pub exec_no_uid: Color,
+    pub no_exec_no_uid: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Dir {
-    pub uid: Option<Color>,
-    pub no_uid: Option<Color>,
+    pub uid: Color,
+    pub no_uid: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Symlink {
-    pub default: Option<Color>,
-    pub broken: Option<Color>,
-    pub missing_target: Option<Color>,
+    pub default: Color,
+    pub broken: Color,
+    pub missing_target: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Date {
-    pub hour_old: Option<Color>,
-    pub day_old: Option<Color>,
-    pub older: Option<Color>,
+    pub hour_old: Color,
+    pub day_old: Color,
+    pub older: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Size {
-    pub none: Option<Color>,
-    pub small: Option<Color>,
-    pub medium: Option<Color>,
-    pub large: Option<Color>,
+    pub none: Color,
+    pub small: Color,
+    pub medium: Color,
+    pub large: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct INode {
-    pub valid: Option<Color>,
-    pub invalid: Option<Color>,
+    pub valid: Color,
+    pub invalid: Color,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
+#[serde(default)]
 pub struct Links {
-    pub valid: Option<Color>,
-    pub invalid: Option<Color>,
+    pub valid: Color,
+    pub invalid: Color,
 }
 
+impl Default for Permission {
+    fn default() -> Self {
+        Permission {
+            read: Color::DarkGreen,
+            write: Color::DarkYellow,
+            exec: Color::DarkRed,
+            exec_sticky: Color::AnsiValue(5),
+            no_access: Color::AnsiValue(245), // Grey
+        }
+    }
+}
 impl Default for FileType {
     fn default() -> Self {
-        Theme::default_dark().file_type
+        FileType {
+            file: File::default(),
+            dir: Dir::default(),
+            symlink: Symlink::default(),
+            pipe: Color::AnsiValue(44),         // DarkTurquoise
+            block_device: Color::AnsiValue(44), // DarkTurquoise
+            char_device: Color::AnsiValue(172), // Orange3
+            socket: Color::AnsiValue(44),       // DarkTurquoise
+            special: Color::AnsiValue(44),      // DarkTurquoise
+        }
+    }
+}
+impl Default for File {
+    fn default() -> Self {
+        File {
+            exec_uid: Color::AnsiValue(40),        // Green3
+            uid_no_exec: Color::AnsiValue(184),    // Yellow3
+            exec_no_uid: Color::AnsiValue(40),     // Green3
+            no_exec_no_uid: Color::AnsiValue(184), // Yellow3
+        }
+    }
+}
+impl Default for Dir {
+    fn default() -> Self {
+        Dir {
+            uid: Color::AnsiValue(33),    // DodgerBlue1
+            no_uid: Color::AnsiValue(33), // DodgerBlue1
+        }
+    }
+}
+impl Default for Symlink {
+    fn default() -> Self {
+        Symlink {
+            default: Color::AnsiValue(44),         // DarkTurquoise
+            broken: Color::AnsiValue(124),         // Red3
+            missing_target: Color::AnsiValue(124), // Red3
+        }
+    }
+}
+impl Default for Date {
+    fn default() -> Self {
+        Date {
+            hour_old: Color::AnsiValue(40), // Green3
+            day_old: Color::AnsiValue(42),  // SpringGreen2
+            older: Color::AnsiValue(36),    // DarkCyan
+        }
+    }
+}
+impl Default for Size {
+    fn default() -> Self {
+        Size {
+            none: Color::AnsiValue(245),   // Grey
+            small: Color::AnsiValue(229),  // Wheat1
+            medium: Color::AnsiValue(216), // LightSalmon1
+            large: Color::AnsiValue(172),  // Orange3
+        }
+    }
+}
+impl Default for INode {
+    fn default() -> Self {
+        INode {
+            valid: Color::AnsiValue(13),    // Pink
+            invalid: Color::AnsiValue(245), // Grey
+        }
+    }
+}
+impl Default for Links {
+    fn default() -> Self {
+        Links {
+            valid: Color::AnsiValue(13),    // Pink
+            invalid: Color::AnsiValue(245), // Grey
+        }
     }
 }
 
@@ -180,65 +271,21 @@ impl Theme {
 
     pub fn default_dark() -> Self {
         Theme {
-            default: Color::AnsiValue(245),
-            user: Some(Color::AnsiValue(230)),  // Cornsilk1
-            group: Some(Color::AnsiValue(187)), // LightYellow3
-            permission: Some(Permission {
-                read: Some(Color::DarkGreen),
-                write: Some(Color::DarkYellow),
-                exec: Some(Color::DarkRed),
-                exec_sticky: Some(Color::AnsiValue(5)),
-                no_access: Some(Color::AnsiValue(245)), // Grey
-            }),
-            file_type: FileType {
-                file: Some(File {
-                    exec_uid: Some(Color::AnsiValue(40)),        // Green3
-                    uid_no_exec: Some(Color::AnsiValue(184)),    // Yellow3
-                    exec_no_uid: Some(Color::AnsiValue(40)),     // Green3
-                    no_exec_no_uid: Some(Color::AnsiValue(184)), // Yellow3
-                }),
-                dir: Some(Dir {
-                    uid: Some(Color::AnsiValue(33)),    // DodgerBlue1
-                    no_uid: Some(Color::AnsiValue(33)), // DodgerBlue1
-                }),
-                pipe: Some(Color::AnsiValue(44)), // DarkTurquoise
-                symlink: Some(Symlink {
-                    default: Some(Color::AnsiValue(44)),         // DarkTurquoise
-                    broken: Some(Color::AnsiValue(124)),         // Red3
-                    missing_target: Some(Color::AnsiValue(124)), // Red3
-                }),
-                block_device: Some(Color::AnsiValue(44)), // DarkTurquoise
-                char_device: Some(Color::AnsiValue(172)), // Orange3
-                socket: Some(Color::AnsiValue(44)),       // DarkTurquoise
-                special: Some(Color::AnsiValue(44)),      // DarkTurquoise
-            },
-            date: Some(Date {
-                hour_old: Some(Color::AnsiValue(40)), // Green3
-                day_old: Some(Color::AnsiValue(42)),  // SpringGreen2
-                older: Some(Color::AnsiValue(36)),    // DarkCyan
-            }),
-            size: Some(Size {
-                none: Some(Color::AnsiValue(245)),   // Grey
-                small: Some(Color::AnsiValue(229)),  // Wheat1
-                medium: Some(Color::AnsiValue(216)), // LightSalmon1
-                large: Some(Color::AnsiValue(172)),  // Orange3
-            }),
-            inode: Some(INode {
-                valid: Some(Color::AnsiValue(13)),    // Pink
-                invalid: Some(Color::AnsiValue(245)), // Grey
-            }),
-            links: Some(Links {
-                valid: Some(Color::AnsiValue(13)),    // Pink
-                invalid: Some(Color::AnsiValue(245)), // Grey
-            }),
-            tree_edge: Some(Color::AnsiValue(245)), // Grey
+            user: Color::AnsiValue(230),  // Cornsilk1
+            group: Color::AnsiValue(187), // LightYellow3
+            permission: Permission::default(),
+            file_type: FileType::default(),
+            date: Date::default(),
+            size: Size::default(),
+            inode: INode::default(),
+            links: Links::default(),
+            tree_edge: Color::AnsiValue(245), // Grey
         }
     }
 
     #[cfg(test)]
     pub fn default_yaml() -> &'static str {
         r#"---
-default: 245
 user: 230
 group: 187
 permission:

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -340,4 +340,41 @@ mod tests {
             Theme::from_path(theme.to_str().unwrap()).unwrap()
         );
     }
+
+    #[test]
+    fn test_empty_theme_return_default() {
+        // Must contain one field at least
+        // ref https://github.com/dtolnay/serde-yaml/issues/86
+        let empty_theme = Theme::with_yaml("user: 230".into()).unwrap();
+        let default_theme = Theme::default_dark();
+        assert_eq!(empty_theme, default_theme);
+    }
+
+    #[test]
+    fn test_first_level_theme_return_default_but_changed() {
+        // Must contain one field at least
+        // ref https://github.com/dtolnay/serde-yaml/issues/86
+        let empty_theme = Theme::with_yaml("user: 130".into()).unwrap();
+        let mut theme = Theme::default_dark();
+        use crossterm::style::Color;
+        theme.user = Color::AnsiValue(130);
+        assert_eq!(empty_theme, theme);
+    }
+
+    #[test]
+    fn test_second_level_theme_return_default_but_changed() {
+        // Must contain one field at least
+        // ref https://github.com/dtolnay/serde-yaml/issues/86
+        let empty_theme = Theme::with_yaml(
+            r#"---
+permission:
+  read: 130"#
+                .into(),
+        )
+        .unwrap();
+        let mut theme = Theme::default_dark();
+        use crossterm::style::Color;
+        theme.permission.read = Color::AnsiValue(130);
+        assert_eq!(empty_theme, theme);
+    }
 }

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -14,14 +14,15 @@ use std::path::Path;
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Theme {
-    pub user: Color,
-    pub group: Color,
-    pub permission: Permission,
-    pub date: Date,
-    pub size: Size,
-    pub inode: INode,
-    pub tree_edge: Color,
-    pub links: Links,
+    pub default: Color,
+    pub user: Option<Color>,
+    pub group: Option<Color>,
+    pub permission: Option<Permission>,
+    pub date: Option<Date>,
+    pub size: Option<Size>,
+    pub inode: Option<INode>,
+    pub tree_edge: Option<Color>,
+    pub links: Option<Links>,
 
     #[serde(skip)]
     pub file_type: FileType,
@@ -31,87 +32,87 @@ pub struct Theme {
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Permission {
-    pub read: Color,
-    pub write: Color,
-    pub exec: Color,
-    pub exec_sticky: Color,
-    pub no_access: Color,
+    pub read: Option<Color>,
+    pub write: Option<Color>,
+    pub exec: Option<Color>,
+    pub exec_sticky: Option<Color>,
+    pub no_access: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct FileType {
-    pub file: File,
-    pub dir: Dir,
-    pub pipe: Color,
-    pub symlink: Symlink,
-    pub block_device: Color,
-    pub char_device: Color,
-    pub socket: Color,
-    pub special: Color,
+    pub file: Option<File>,
+    pub dir: Option<Dir>,
+    pub pipe: Option<Color>,
+    pub symlink: Option<Symlink>,
+    pub block_device: Option<Color>,
+    pub char_device: Option<Color>,
+    pub socket: Option<Color>,
+    pub special: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct File {
-    pub exec_uid: Color,
-    pub uid_no_exec: Color,
-    pub exec_no_uid: Color,
-    pub no_exec_no_uid: Color,
+    pub exec_uid: Option<Color>,
+    pub uid_no_exec: Option<Color>,
+    pub exec_no_uid: Option<Color>,
+    pub no_exec_no_uid: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Dir {
-    pub uid: Color,
-    pub no_uid: Color,
+    pub uid: Option<Color>,
+    pub no_uid: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Symlink {
-    pub default: Color,
-    pub broken: Color,
-    pub missing_target: Color,
+    pub default: Option<Color>,
+    pub broken: Option<Color>,
+    pub missing_target: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Date {
-    pub hour_old: Color,
-    pub day_old: Color,
-    pub older: Color,
+    pub hour_old: Option<Color>,
+    pub day_old: Option<Color>,
+    pub older: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Size {
-    pub none: Color,
-    pub small: Color,
-    pub medium: Color,
-    pub large: Color,
+    pub none: Option<Color>,
+    pub small: Option<Color>,
+    pub medium: Option<Color>,
+    pub large: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct INode {
-    pub valid: Color,
-    pub invalid: Color,
+    pub valid: Option<Color>,
+    pub invalid: Option<Color>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 #[serde(deny_unknown_fields)]
 pub struct Links {
-    pub valid: Color,
-    pub invalid: Color,
+    pub valid: Option<Color>,
+    pub invalid: Option<Color>,
 }
 
 impl Default for FileType {
@@ -179,63 +180,65 @@ impl Theme {
 
     pub fn default_dark() -> Self {
         Theme {
-            user: Color::AnsiValue(230),  // Cornsilk1
-            group: Color::AnsiValue(187), // LightYellow3
-            permission: Permission {
-                read: Color::DarkGreen,
-                write: Color::DarkYellow,
-                exec: Color::DarkRed,
-                exec_sticky: Color::AnsiValue(5),
-                no_access: Color::AnsiValue(245), // Grey
-            },
+            default: Color::AnsiValue(245),
+            user: Some(Color::AnsiValue(230)),  // Cornsilk1
+            group: Some(Color::AnsiValue(187)), // LightYellow3
+            permission: Some(Permission {
+                read: Some(Color::DarkGreen),
+                write: Some(Color::DarkYellow),
+                exec: Some(Color::DarkRed),
+                exec_sticky: Some(Color::AnsiValue(5)),
+                no_access: Some(Color::AnsiValue(245)), // Grey
+            }),
             file_type: FileType {
-                file: File {
-                    exec_uid: Color::AnsiValue(40),        // Green3
-                    uid_no_exec: Color::AnsiValue(184),    // Yellow3
-                    exec_no_uid: Color::AnsiValue(40),     // Green3
-                    no_exec_no_uid: Color::AnsiValue(184), // Yellow3
-                },
-                dir: Dir {
-                    uid: Color::AnsiValue(33),    // DodgerBlue1
-                    no_uid: Color::AnsiValue(33), // DodgerBlue1
-                },
-                pipe: Color::AnsiValue(44), // DarkTurquoise
-                symlink: Symlink {
-                    default: Color::AnsiValue(44),         // DarkTurquoise
-                    broken: Color::AnsiValue(124),         // Red3
-                    missing_target: Color::AnsiValue(124), // Red3
-                },
-                block_device: Color::AnsiValue(44), // DarkTurquoise
-                char_device: Color::AnsiValue(172), // Orange3
-                socket: Color::AnsiValue(44),       // DarkTurquoise
-                special: Color::AnsiValue(44),      // DarkTurquoise
+                file: Some(File {
+                    exec_uid: Some(Color::AnsiValue(40)),        // Green3
+                    uid_no_exec: Some(Color::AnsiValue(184)),    // Yellow3
+                    exec_no_uid: Some(Color::AnsiValue(40)),     // Green3
+                    no_exec_no_uid: Some(Color::AnsiValue(184)), // Yellow3
+                }),
+                dir: Some(Dir {
+                    uid: Some(Color::AnsiValue(33)),    // DodgerBlue1
+                    no_uid: Some(Color::AnsiValue(33)), // DodgerBlue1
+                }),
+                pipe: Some(Color::AnsiValue(44)), // DarkTurquoise
+                symlink: Some(Symlink {
+                    default: Some(Color::AnsiValue(44)),         // DarkTurquoise
+                    broken: Some(Color::AnsiValue(124)),         // Red3
+                    missing_target: Some(Color::AnsiValue(124)), // Red3
+                }),
+                block_device: Some(Color::AnsiValue(44)), // DarkTurquoise
+                char_device: Some(Color::AnsiValue(172)), // Orange3
+                socket: Some(Color::AnsiValue(44)),       // DarkTurquoise
+                special: Some(Color::AnsiValue(44)),      // DarkTurquoise
             },
-            date: Date {
-                hour_old: Color::AnsiValue(40), // Green3
-                day_old: Color::AnsiValue(42),  // SpringGreen2
-                older: Color::AnsiValue(36),    // DarkCyan
-            },
-            size: Size {
-                none: Color::AnsiValue(245),   // Grey
-                small: Color::AnsiValue(229),  // Wheat1
-                medium: Color::AnsiValue(216), // LightSalmon1
-                large: Color::AnsiValue(172),  // Orange3
-            },
-            inode: INode {
-                valid: Color::AnsiValue(13),    // Pink
-                invalid: Color::AnsiValue(245), // Grey
-            },
-            links: Links {
-                valid: Color::AnsiValue(13),    // Pink
-                invalid: Color::AnsiValue(245), // Grey
-            },
-            tree_edge: Color::AnsiValue(245), // Grey
+            date: Some(Date {
+                hour_old: Some(Color::AnsiValue(40)), // Green3
+                day_old: Some(Color::AnsiValue(42)),  // SpringGreen2
+                older: Some(Color::AnsiValue(36)),    // DarkCyan
+            }),
+            size: Some(Size {
+                none: Some(Color::AnsiValue(245)),   // Grey
+                small: Some(Color::AnsiValue(229)),  // Wheat1
+                medium: Some(Color::AnsiValue(216)), // LightSalmon1
+                large: Some(Color::AnsiValue(172)),  // Orange3
+            }),
+            inode: Some(INode {
+                valid: Some(Color::AnsiValue(13)),    // Pink
+                invalid: Some(Color::AnsiValue(245)), // Grey
+            }),
+            links: Some(Links {
+                valid: Some(Color::AnsiValue(13)),    // Pink
+                invalid: Some(Color::AnsiValue(245)), // Grey
+            }),
+            tree_edge: Some(Color::AnsiValue(245)), // Grey
         }
     }
 
     #[cfg(test)]
     pub fn default_yaml() -> &'static str {
         r#"---
+default: 245
 user: 230
 group: 187
 permission:

--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -345,7 +345,7 @@ mod tests {
     fn test_empty_theme_return_default() {
         // Must contain one field at least
         // ref https://github.com/dtolnay/serde-yaml/issues/86
-        let empty_theme = Theme::with_yaml("user: 230".into()).unwrap();
+        let empty_theme = Theme::with_yaml("user: 230".into()).unwrap(); // 230 is the default value
         let default_theme = Theme::default_dark();
         assert_eq!(empty_theme, default_theme);
     }

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -11,7 +11,6 @@ use clap::ArgMatches;
 
 /// The flag showing which kind of time stamps to display.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[allow(clippy::upper_case_acronyms)]
 pub enum DateFlag {
     Date,
     Relative,

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -11,6 +11,7 @@ use clap::ArgMatches;
 
 /// The flag showing which kind of time stamps to display.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum DateFlag {
     Date,
     Relative,

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -159,7 +159,7 @@ impl Meta {
         }
     }
 
-    fn calculate_total_file_size(path: &PathBuf) -> u64 {
+    fn calculate_total_file_size(path: &Path) -> u64 {
         let metadata = path.symlink_metadata();
         let metadata = match metadata {
             Ok(meta) => meta,

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -1,7 +1,6 @@
 use crate::color::{ColoredString, Colors, Elem};
 use crate::flags::{Flags, SizeFlag};
 use std::fs::Metadata;
-use std::iter::repeat;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Unit {
@@ -62,9 +61,7 @@ impl Size {
         let unit_content = self.render_unit(colors, flags);
 
         let left_pad = if let Some(align) = val_alignment {
-            repeat(" ")
-                .take(align - val_content.content().len())
-                .collect::<String>()
+            " ".repeat(align - val_content.content().len())
         } else {
             "".to_string()
         };


### PR DESCRIPTION
<!--- PR Description --->

fix https://github.com/Peltoche/lsd/issues/549

difference:

1. use a `default` value as fallback color instead of falling back to the default theme, one may copy the default theme value from README
2. no options for the terminal default foreground color, still suffering how to represent this

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry