### PR TITLE
made the group-dirs flag require a value

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -221,7 +221,6 @@ pub fn build() -> App<'static, 'static> {
                 .possible_value("none")
                 .possible_value("first")
                 .possible_value("last")
-                .default_value("none")
                 .multiple(true)
                 .number_of_values(1)
                 .help("Sort the directories then the files"),


### PR DESCRIPTION
<!--- PR Description --->
group-dirs flag requires a value
---
Hi! I saw this issue https://github.com/Peltoche/lsd/issues/580. Should be straightforward. Let me know if there's any other changes I need to make.
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry