### PR TITLE
Workaround for Konsole first character not rendering (F.A.Q section update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The default colors are:
 _Checkout [trapd00r/LS_COLORS](https://github.com/trapd00r/LS_COLORS) and [sharkdp/vivid](https://github.com/sharkdp/vivid) for help in themeing using `LS_COLORS`._
 
 ### First char of folder/file getting trimmed
-For Konsole: ㅤEdit the config file (or create it if it doesn't exist) and paste the following into it (contains invisible unicode characters):
+Workaround for Konsole: ㅤEdit the config file(or [create it](#config-file-location) if it doesn't already exist) and paste the following into it (contains invisible unicode characters):
   ```yml
 icons:
     separator: " ㅤ"

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ The default colors are:
 _Checkout [trapd00r/LS_COLORS](https://github.com/trapd00r/LS_COLORS) and [sharkdp/vivid](https://github.com/sharkdp/vivid) for help in themeing using `LS_COLORS`._
 
 ### First char of folder/file getting trimmed
-Workaround for Konsole: ㅤEdit the config file(or [create it](#config-file-location) if it doesn't already exist) and paste the following into it (contains invisible unicode characters):
+Workaround for Konsole: ㅤEdit the config file (or [create it](#config-file-location) if it doesn't already exist) and paste the following into it (contains invisible unicode characters):
   ```yml
 icons:
     separator: " ㅤ"

--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ The default colors are:
 _Checkout [trapd00r/LS_COLORS](https://github.com/trapd00r/LS_COLORS) and [sharkdp/vivid](https://github.com/sharkdp/vivid) for help in themeing using `LS_COLORS`._
 
 ### First char of folder/file getting trimmed
+For Konsole: ㅤEdit the config file (or create it if it doesn't exist) and paste the following into it (contains invisible unicode characters):
+  ```yml
+icons:
+    separator: " ㅤ"
+```
+  
 
 This is a known issue in a few terminal emulator. Try using a different terminal emulator like. [Alacritty](https://github.com/alacritty/alacritty) and [Kitty](https://github.com/kovidgoyal/kitty) are really good alternatives. You might also want to check if your font is responsible for causing this.
 To verify this, try running lsd with icons disabled and if it still does not have the first character, then this is an lsd bug:


### PR DESCRIPTION
Updated the README file to contain a fix for the first character of each file not rendering in the F.A.Q section (by adding a U+3164 unicode invisible spacer after the icon in the spacer string in the config file).
The fix that is described in this new FAQ section is working for Konsole on Arch.

#118 #363 
