### PR TITLE
Add an icon for .iso files

### DIFF
--- a/src/icon.rs
+++ b/src/icon.rs
@@ -344,6 +344,7 @@ impl Icons {
         m.insert("zsh", "\u{f489}"); // ""
         m.insert("zsh-theme", "\u{f489}"); // ""
         m.insert("zshrc", "\u{f489}"); // ""
+        m.insert("iso", "\u{faed}"); // "﫭"
 
         m
     }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -145,6 +145,7 @@ impl Icons {
 
         m.insert("7z", "\u{f410}"); // ""
         m.insert("apk", "\u{e70e}"); // ""
+        m.insert("ass", "\u{f6f6}"); // ""
         m.insert("avi", "\u{f03d}"); // ""
         m.insert("avro", "\u{e60b}"); // ""
         m.insert("awk", "\u{f489}"); // ""

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -227,6 +227,7 @@ impl Icons {
         m.insert("iml", "\u{e7b5}"); // ""
         m.insert("ini", "\u{e615}"); // ""
         m.insert("ipynb", "\u{e606}"); // ""
+        m.insert("iso", "\u{faed}"); // "﫭"
         m.insert("jar", "\u{e204}"); // ""
         m.insert("java", "\u{e204}"); // ""
         m.insert("jpeg", "\u{f1c5}"); // ""
@@ -344,7 +345,6 @@ impl Icons {
         m.insert("zsh", "\u{f489}"); // ""
         m.insert("zsh-theme", "\u{f489}"); // ""
         m.insert("zshrc", "\u{f489}"); // ""
-        m.insert("iso", "\u{faed}"); // "﫭"
 
         m
     }


### PR DESCRIPTION
This PR adds an icon for .iso files with the "﫭" ('faed') disk icon.