### PR TITLE
Add --group-directories-first as an alias for --group-dirs=first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ReleaseDate
-# Added
+### Added
 - Add `--group-directories-first` as an alias for `--group-dirs=first` to improve compatibility with `coreutils/ls`
 
 ## [0.21.0] - 2022-01-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ReleaseDate
+# Added
+- Add `--group-directories-first` as an alias for `--group-dirs=first` to improve compatibility with `coreutils/ls`
 
 ## [0.21.0] - 2022-01-16
 ### Added

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -105,7 +105,7 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 : Sort the directories then the files [default: none]  [possible values: none, first, last]
 
 `--group-directories-first`
-: Groups the directories at the top before the files. Same as `--group-dirs=first`. Same as `--group-dirs=first`
+: Groups the directories at the top before the files. Same as `--group-dirs=first`
 
 `--icon <icon>...`
 : When to print the icons [default: auto]  [possible values: always, auto, never]

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -104,6 +104,9 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 `--group-dirs <group-dirs>...`
 : Sort the directories then the files [default: none]  [possible values: none, first, last]
 
+`--group-directories-first`
+: Groups the directories at the top before the files. Same as `--group-dirs=first`. Same as `--group-dirs=first`
+
 `--icon <icon>...`
 : When to print the icons [default: auto]  [possible values: always, auto, never]
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -225,6 +225,11 @@ pub fn build() -> App<'static, 'static> {
                 .help("Sort the directories then the files"),
         )
         .arg(
+            Arg::with_name("group-directories-first")
+                .long("group-directories-first")
+                .help("Groups the directories at the top before the files. Same as --group-dirs=first")
+        )
+        .arg(
             Arg::with_name("blocks")
                 .long("blocks")
                 .multiple(true)

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -171,6 +171,10 @@ impl Configurable<Self> for DirGrouping {
             return Some(Self::None);
         }
 
+        if matches.is_present("group-directories-first") {
+            return Some(Self::First);
+        }
+
         if matches.occurrences_of("group-dirs") > 0 {
             if let Some(group_dirs) = matches.values_of("group-dirs")?.last() {
                 return Self::from_str(group_dirs);
@@ -524,6 +528,16 @@ mod test_dir_grouping {
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         assert_eq!(
             Some(DirGrouping::Last),
+            DirGrouping::from_arg_matches(&matches)
+        );
+    }
+
+    #[test]
+    fn test_from_arg_matches_group_directories_first() {
+        let argv = vec!["lsd", "--group-directories-first"];
+        let matches = app::build().get_matches_from_safe(argv).unwrap();
+        assert_eq!(
+            Some(DirGrouping::First),
             DirGrouping::from_arg_matches(&matches)
         );
     }


### PR DESCRIPTION
`ls` from coreutils has the `--group-directories-first` flag as the only
directory grouping option. This pull request improves compatibility so that
users switching to `lsd` can continue using `--group-directories-first`.


<!--- PR Description --->

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry