### PR TITLE
impr: Add short `-T` arg for `--tree`

### DIFF
--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -80,7 +80,7 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 `--total-size`
 : Display the total size of directories
 
-`--tree`
+`-T` `--tree`
 : Recurse into directories and present the result as a tree
 
 `-V`, `--version`

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,6 +103,7 @@ pub fn build() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name("tree")
+                .short("T")
                 .long("tree")
                 .multiple(true)
                 .conflicts_with("recursive")


### PR DESCRIPTION
I feel that this is a reasonable request, given `-T` is not used by anything else right now.

I don't feel that integration tests for the short option are necessary when the long option works, and I'm not sure how to make a changelog entry. 

If it is necessary, I would be more than happy to fix it.

<!--- PR Description --->

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [x] Update man page at lsd/doc/lsd.md (if applicable)