### PR TITLE
Show Docker icon for files with Dockerfile extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Display MAC contexts and MAC and ACL indicators from [mmatous](https://github.com/mmatous)
 - Add `--hyperlink` flag for adding hyperlinks to files from [KSXGitHub](https://github.com/KSXGitHub) and [meain](https://github.com/meain)
 - Add icons for HEIC, PEM and TOML from [Nix](https://github.com/nix6839)
+### Changed
+- Show Docker icon for files with Dockerfile extension [#652](https://github.com/Peltoche/lsd/pull/652) from [TeamTamoad](https://github.com/TeamTamoad)
 ### Fixed
 - Support non-bold bright colors [#248](https://github.com/Peltoche/lsd/issues/248) from [meain](https://github.com/meain)
 - Don't automatically dereference symlinks in tree/recursive [#637](https://github.com/Peltoche/lsd/issues/637) from [meain](https://github.com/meain)

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -182,6 +182,7 @@ impl Icons {
         m.insert("db", "\u{f1c0}"); // ""
         m.insert("diff", "\u{f440}"); // ""
         m.insert("doc", "\u{f1c2}"); // ""
+        m.insert("dockerfile", "\u{f308}"); // ""
         m.insert("docx", "\u{f1c2}"); // ""
         m.insert("ds_store", "\u{f179}"); // ""
         m.insert("dump", "\u{f1c0}"); // ""


### PR DESCRIPTION
<!--- PR Description --->
There are some situation that developers need to put multiple Dockerfiles in the same directory. This is one of the recommended naming convention.

**Before**
![image](https://user-images.githubusercontent.com/43115371/166137419-3da204fe-0741-4b61-a700-cc81dd52f1c6.png)


**After**
![image](https://user-images.githubusercontent.com/43115371/166137441-21c23a0d-b7f3-4045-bd69-f281a5a45ebe.png)

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [x] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)