### PR TITLE
Removed error message when file is broken symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Support non-bold bright colors [#248](https://github.com/Peltoche/lsd/issues/248) from [meain](https://github.com/meain)
 - Don't automatically dereference symlinks in tree/recursive [#637](https://github.com/Peltoche/lsd/issues/637) from [meain](https://github.com/meain)
+- Removed useless error message when attempting to make a hyperlink for a broken symlink from [KodiCraft](https://github.com/KodiCraft)
 
 ## [0.21.0] - 2022-01-16
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -895,9 +895,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a01404663e3db436ed2746d9fefef640d868edae3cceb81c3b8d5732fda678f"
+checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-normalization"

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -118,8 +118,16 @@ impl Name {
                         }
                     }
                     Err(err) => {
-                        print_error!("{}: {}.", name, err);
-                        name
+                        match err.kind() {
+                            std::io::ErrorKind::NotFound => {
+                                // If this happens, it just means the file is a broken symlink. This is not an error, and the user is already warned that the symlink is broken by the colors.
+                                name
+                            }
+                            _ => {
+                                print_error!("{}: {}", name, err);
+                                name
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!--- PR Description --->
Removed error message when attempting to make a hyperlink to a broken symlink. This shouldn't be an issue, since the user is already warned of a broken symlink.
---
#### TODO

- [X] Use `cargo fmt`
- [X] Add necessary tests
- [X] Add changelog entry
- [X] Update default config/theme in README (if applicable)
- [X] Update man page at lsd/doc/lsd.md (if applicable)