### PR TITLE
Improve Permissions rendering performance

### DIFF
--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -115,7 +115,7 @@ impl Permissions {
                 .fold(String::with_capacity(4), |mut acc, x| {
                     acc.push(
                         char::from_digit(x as u32, 8)
-                            .expect("Octal value of permission should not greater than 7."),
+                            .expect("octal value of permission should not be greater than 7"),
                     );
                     acc
                 });

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -113,7 +113,10 @@ impl Permissions {
                 ]
                 .into_iter()
                 .fold(String::with_capacity(4), |mut acc, x| {
-                    acc.push(char::from_digit(x as u32, 8).unwrap());
+                    acc.push(
+                        char::from_digit(x as u32, 8)
+                            .expect("Octal value of permission should not greater than 7."),
+                    );
                     acc
                 });
 


### PR DESCRIPTION
<!--- PR Description --->
In this PR, I improve the rendering of permission block by the following method
- Remove `Vector` allocation
- Pre-allocate `String` with the some capacity
- Remove `format!` macro

I write some very basic benchmark code to verify that the changes really improve the performance. The benchmark code is far from perfect and not exactly the same as the changes. However, it should give you some idea.

**Benchmark snippet**
```Rust
#[macro_use]
extern crate bencher;

use bencher::Bencher;

fn string_format(bench: &mut Bencher) {
    let a: u8 = 8;
    let b: u8 = 3;
    let c: u8 = 4;
    let d: u8 = 7;

    bench.iter(|| format!("{a}{b}{c}{d}"))
}

fn string_push_char(bench: &mut Bencher) {
    let a: u8 = 0;
    let b: u8 = 3;
    let c: u8 = 4;
    let d: u8 = 7;

    bench.iter(|| {
        let mut res = String::with_capacity(4);
        res.push(char::from_digit(a as u32, 8).unwrap());
        res.push(char::from_digit(b as u32, 8).unwrap());
        res.push(char::from_digit(c as u32, 8).unwrap());
        res.push(char::from_digit(d as u32, 8).unwrap());
    })
}
benchmark_group!(string, string_format, string_push_char);
benchmark_main!(string);
```
![image](https://user-images.githubusercontent.com/43115371/173668049-bb333a1a-a0c6-4fae-ad4e-0922990cb981.png)

```Rust
fn collect_and_join_string(bench: &mut Bencher) {
    let strings = ["LSD", "is", "really", "awesome", ".", "Narawit", "Rakket"];
    bench.iter(|| {
        strings
            .into_iter()
            .map(|x| x.to_string())
            .collect::<Vec<String>>()
            .join("")
    });
}

fn allocate_and_fold_string(bench: &mut Bencher) {
    let strings = ["LSD", "is", "really", "awesome", ".", "Narawit", "Rakket"];
    bench.iter(|| {
        strings
            .into_iter()
            .map(|x| x.to_string())
            .fold(String::with_capacity(36), |mut acc, x| {
                acc.push_str(&x);
                acc
            })
    });
}
```
![image](https://user-images.githubusercontent.com/43115371/173668531-db260f21-afbc-4686-a0f8-63f30b5a11e8.png)

---
**Experiment**
I also inspect size of the `String` result to find the good capacity to pre-allocate.

![image](https://user-images.githubusercontent.com/43115371/173662156-a66c07af-ff36-4ba9-84ed-838f7493aa15.png)
![image](https://user-images.githubusercontent.com/43115371/173670138-a5000e6b-9074-45f5-b3ee-4e8543880cf1.png)



---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)