### PR TITLE
refactor(color): improve readability and flexibility

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -152,8 +152,8 @@ impl Colors {
         Self { theme, lscolors }
     }
 
-    pub fn colorize(&self, input: String, elem: &Elem) -> ColoredString {
-        self.style(elem).apply(input)
+    pub fn colorize<S: Into<String>>(&self, input: S, elem: &Elem) -> ColoredString {
+        self.style(elem).apply(input.into())
     }
 
     pub fn colorize_using_path(&self, input: String, path: &Path, elem: &Elem) -> ColoredString {

--- a/src/display.rs
+++ b/src/display.rs
@@ -307,7 +307,7 @@ fn get_output<'a>(
     let mut strings: Vec<String> = Vec::new();
     for (i, block) in flags.blocks.0.iter().enumerate() {
         let mut block_vec = if Layout::Tree == flags.layout && tree.0 == i {
-            vec![colors.colorize(tree.1.to_string(), &Elem::TreeEdge)]
+            vec![colors.colorize(tree.1, &Elem::TreeEdge)]
         } else {
             Vec::new()
         };

--- a/src/meta/access_control.rs
+++ b/src/meta/access_control.rs
@@ -42,11 +42,11 @@ impl AccessControl {
 
     pub fn render_method(&self, colors: &Colors) -> ColoredString {
         if self.has_acl {
-            colors.colorize(String::from("+"), &Elem::Acl)
+            colors.colorize('+', &Elem::Acl)
         } else if !self.selinux_context.is_empty() || !self.smack_context.is_empty() {
-            colors.colorize(String::from("."), &Elem::Context)
+            colors.colorize('.', &Elem::Context)
         } else {
-            colors.colorize(String::from(""), &Elem::Acl)
+            colors.colorize("", &Elem::Acl)
         }
     }
 

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -91,18 +91,14 @@ impl FileType {
 impl FileType {
     pub fn render(self, colors: &Colors) -> ColoredString {
         match self {
-            FileType::File { exec, .. } => {
-                colors.colorize(String::from("."), &Elem::File { exec, uid: false })
-            }
-            FileType::Directory { .. } => {
-                colors.colorize(String::from("d"), &Elem::Dir { uid: false })
-            }
-            FileType::Pipe => colors.colorize(String::from("|"), &Elem::Pipe),
-            FileType::SymLink { .. } => colors.colorize(String::from("l"), &Elem::SymLink),
-            FileType::BlockDevice => colors.colorize(String::from("b"), &Elem::BlockDevice),
-            FileType::CharDevice => colors.colorize(String::from("c"), &Elem::CharDevice),
-            FileType::Socket => colors.colorize(String::from("s"), &Elem::Socket),
-            FileType::Special => colors.colorize(String::from("?"), &Elem::Special),
+            FileType::File { exec, .. } => colors.colorize('.', &Elem::File { exec, uid: false }),
+            FileType::Directory { .. } => colors.colorize('d', &Elem::Dir { uid: false }),
+            FileType::Pipe => colors.colorize('|', &Elem::Pipe),
+            FileType::SymLink { .. } => colors.colorize('l', &Elem::SymLink),
+            FileType::BlockDevice => colors.colorize('b', &Elem::BlockDevice),
+            FileType::CharDevice => colors.colorize('c', &Elem::CharDevice),
+            FileType::Socket => colors.colorize('s', &Elem::Socket),
+            FileType::Special => colors.colorize('?', &Elem::Special),
         }
     }
 }

--- a/src/meta/inode.rs
+++ b/src/meta/inode.rs
@@ -26,7 +26,7 @@ impl INode {
     pub fn render(&self, colors: &Colors) -> ColoredString {
         match self.index {
             Some(i) => colors.colorize(i.to_string(), &Elem::INode { valid: true }),
-            None => colors.colorize(String::from("-"), &Elem::INode { valid: false }),
+            None => colors.colorize('-', &Elem::INode { valid: false }),
         }
     }
 }

--- a/src/meta/links.rs
+++ b/src/meta/links.rs
@@ -26,7 +26,7 @@ impl Links {
     pub fn render(&self, colors: &Colors) -> ColoredString {
         match self.nlink {
             Some(i) => colors.colorize(i.to_string(), &Elem::Links { valid: true }),
-            None => colors.colorize(String::from("-"), &Elem::Links { valid: false }),
+            None => colors.colorize('-', &Elem::Links { valid: false }),
         }
     }
 }

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -62,9 +62,9 @@ impl Permissions {
     pub fn render(&self, colors: &Colors, flags: &Flags) -> ColoredString {
         let bit = |bit, chr: &'static str, elem: &Elem| {
             if bit {
-                colors.colorize(String::from(chr), elem)
+                colors.colorize(chr, elem)
             } else {
-                colors.colorize(String::from("-"), &Elem::NoAccess)
+                colors.colorize('-', &Elem::NoAccess)
             }
         };
 
@@ -74,28 +74,28 @@ impl Permissions {
                 bit(self.user_read, "r", &Elem::Read),
                 bit(self.user_write, "w", &Elem::Write),
                 match (self.user_execute, self.setuid) {
-                    (false, false) => colors.colorize(String::from("-"), &Elem::NoAccess),
-                    (true, false) => colors.colorize(String::from("x"), &Elem::Exec),
-                    (false, true) => colors.colorize(String::from("S"), &Elem::ExecSticky),
-                    (true, true) => colors.colorize(String::from("s"), &Elem::ExecSticky),
+                    (false, false) => colors.colorize('-', &Elem::NoAccess),
+                    (true, false) => colors.colorize('x', &Elem::Exec),
+                    (false, true) => colors.colorize('S', &Elem::ExecSticky),
+                    (true, true) => colors.colorize('s', &Elem::ExecSticky),
                 },
                 // Group permissions
                 bit(self.group_read, "r", &Elem::Read),
                 bit(self.group_write, "w", &Elem::Write),
                 match (self.group_execute, self.setgid) {
-                    (false, false) => colors.colorize(String::from("-"), &Elem::NoAccess),
-                    (true, false) => colors.colorize(String::from("x"), &Elem::Exec),
-                    (false, true) => colors.colorize(String::from("S"), &Elem::ExecSticky),
-                    (true, true) => colors.colorize(String::from("s"), &Elem::ExecSticky),
+                    (false, false) => colors.colorize('-', &Elem::NoAccess),
+                    (true, false) => colors.colorize('x', &Elem::Exec),
+                    (false, true) => colors.colorize('S', &Elem::ExecSticky),
+                    (true, true) => colors.colorize('s', &Elem::ExecSticky),
                 },
                 // Other permissions
                 bit(self.other_read, "r", &Elem::Read),
                 bit(self.other_write, "w", &Elem::Write),
                 match (self.other_execute, self.sticky) {
-                    (false, false) => colors.colorize(String::from("-"), &Elem::NoAccess),
-                    (true, false) => colors.colorize(String::from("x"), &Elem::Exec),
-                    (false, true) => colors.colorize(String::from("T"), &Elem::ExecSticky),
-                    (true, true) => colors.colorize(String::from("t"), &Elem::ExecSticky),
+                    (false, false) => colors.colorize('-', &Elem::NoAccess),
+                    (true, false) => colors.colorize('x', &Elem::Exec),
+                    (false, true) => colors.colorize('T', &Elem::ExecSticky),
+                    (true, true) => colors.colorize('t', &Elem::ExecSticky),
                 },
             ]
             .into_iter()


### PR DESCRIPTION
* Change parameter type of `colorize` function from `String` to generic type `Into<String>`

#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)