### PR TITLE
refactor(test): remove unnecessary `as_str()` in tests

### DIFF
--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -43,7 +43,7 @@ mod test {
 
         let file_type = Indicator::from(FileType::Directory { uid: false });
 
-        assert_eq!("/", file_type.render(&flags).to_string().as_str());
+        assert_eq!("/", file_type.render(&flags).to_string());
     }
 
     #[test]
@@ -56,7 +56,7 @@ mod test {
             exec: true,
         });
 
-        assert_eq!("*", file_type.render(&flags).to_string().as_str());
+        assert_eq!("*", file_type.render(&flags).to_string());
     }
 
     #[test]
@@ -66,7 +66,7 @@ mod test {
 
         let file_type = Indicator::from(FileType::Socket);
 
-        assert_eq!("=", file_type.render(&flags).to_string().as_str());
+        assert_eq!("=", file_type.render(&flags).to_string());
     }
 
     #[test]
@@ -75,10 +75,10 @@ mod test {
         flags.display_indicators = Indicators(true);
 
         let file_type = Indicator::from(FileType::SymLink { is_dir: false });
-        assert_eq!("@", file_type.render(&flags).to_string().as_str());
+        assert_eq!("@", file_type.render(&flags).to_string());
 
         let file_type = Indicator::from(FileType::SymLink { is_dir: true });
-        assert_eq!("@", file_type.render(&flags).to_string().as_str());
+        assert_eq!("@", file_type.render(&flags).to_string());
     }
 
     #[test]
@@ -92,6 +92,6 @@ mod test {
             uid: false,
         });
 
-        assert_eq!("", file_type.render(&flags).to_string().as_str());
+        assert_eq!("", file_type.render(&flags).to_string());
     }
 }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -398,7 +398,6 @@ mod test {
                     HyperlinkOption::Never
                 )
                 .to_string()
-                .as_str()
         );
     }
 
@@ -431,7 +430,6 @@ mod test {
                     HyperlinkOption::Always
                 )
                 .to_string()
-                .as_str()
         );
     }
 

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -164,13 +164,13 @@ mod test {
         let size = Size::new(42); // == 42 bytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
+        assert_eq!(size.value_string(&flags), "42");
 
-        assert_eq!(size.unit_string(&flags).as_str(), "B");
+        assert_eq!(size.unit_string(&flags), "B");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "B");
+        assert_eq!(size.unit_string(&flags), "B");
         flags.size = SizeFlag::Bytes;
-        assert_eq!(size.unit_string(&flags).as_str(), "");
+        assert_eq!(size.unit_string(&flags), "");
     }
 
     #[test]
@@ -178,10 +178,10 @@ mod test {
         let size = Size::new(4 * 1024); // 4 kilobytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "4.0");
-        assert_eq!(size.unit_string(&flags).as_str(), "KB");
+        assert_eq!(size.value_string(&flags), "4.0");
+        assert_eq!(size.unit_string(&flags), "KB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "K");
+        assert_eq!(size.unit_string(&flags), "K");
     }
 
     #[test]
@@ -189,10 +189,10 @@ mod test {
         let size = Size::new(42 * 1024); // 42 kilobytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
-        assert_eq!(size.unit_string(&flags).as_str(), "KB");
+        assert_eq!(size.value_string(&flags), "42");
+        assert_eq!(size.unit_string(&flags), "KB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "K");
+        assert_eq!(size.unit_string(&flags), "K");
     }
 
     #[test]
@@ -200,10 +200,10 @@ mod test {
         let size = Size::new(420 * 1024 + 420); // 420.4 kilobytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "420");
-        assert_eq!(size.unit_string(&flags).as_str(), "KB");
+        assert_eq!(size.value_string(&flags), "420");
+        assert_eq!(size.unit_string(&flags), "KB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "K");
+        assert_eq!(size.unit_string(&flags), "K");
     }
 
     #[test]
@@ -211,10 +211,10 @@ mod test {
         let size = Size::new(4 * 1024 * 1024); // 4 megabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "4.0");
-        assert_eq!(size.unit_string(&flags).as_str(), "MB");
+        assert_eq!(size.value_string(&flags), "4.0");
+        assert_eq!(size.unit_string(&flags), "MB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "M");
+        assert_eq!(size.unit_string(&flags), "M");
     }
 
     #[test]
@@ -222,10 +222,10 @@ mod test {
         let size = Size::new(42 * 1024 * 1024); // 42 megabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
-        assert_eq!(size.unit_string(&flags).as_str(), "MB");
+        assert_eq!(size.value_string(&flags), "42");
+        assert_eq!(size.unit_string(&flags), "MB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "M");
+        assert_eq!(size.unit_string(&flags), "M");
     }
 
     #[test]
@@ -233,10 +233,10 @@ mod test {
         let size = Size::new(420 * 1024 * 1024 + 420 * 1024); // 420.4 megabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "420");
-        assert_eq!(size.unit_string(&flags).as_str(), "MB");
+        assert_eq!(size.value_string(&flags), "420");
+        assert_eq!(size.unit_string(&flags), "MB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "M");
+        assert_eq!(size.unit_string(&flags), "M");
     }
 
     #[test]
@@ -244,10 +244,10 @@ mod test {
         let size = Size::new(4 * 1024 * 1024 * 1024); // 4 gigabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "4.0");
-        assert_eq!(size.unit_string(&flags).as_str(), "GB");
+        assert_eq!(size.value_string(&flags), "4.0");
+        assert_eq!(size.unit_string(&flags), "GB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "G");
+        assert_eq!(size.unit_string(&flags), "G");
     }
 
     #[test]
@@ -255,10 +255,10 @@ mod test {
         let size = Size::new(42 * 1024 * 1024 * 1024); // 42 gigabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
-        assert_eq!(size.unit_string(&flags).as_str(), "GB");
+        assert_eq!(size.value_string(&flags), "42");
+        assert_eq!(size.unit_string(&flags), "GB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "G");
+        assert_eq!(size.unit_string(&flags), "G");
     }
 
     #[test]
@@ -266,10 +266,10 @@ mod test {
         let size = Size::new(420 * 1024 * 1024 * 1024 + 420 * 1024 * 1024); // 420.4 gigabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "420");
-        assert_eq!(size.unit_string(&flags).as_str(), "GB");
+        assert_eq!(size.value_string(&flags), "420");
+        assert_eq!(size.unit_string(&flags), "GB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "G");
+        assert_eq!(size.unit_string(&flags), "G");
     }
 
     #[test]
@@ -277,10 +277,10 @@ mod test {
         let size = Size::new(4 * 1024 * 1024 * 1024 * 1024); // 4 terabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "4.0");
-        assert_eq!(size.unit_string(&flags).as_str(), "TB");
+        assert_eq!(size.value_string(&flags), "4.0");
+        assert_eq!(size.unit_string(&flags), "TB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "T");
+        assert_eq!(size.unit_string(&flags), "T");
     }
 
     #[test]
@@ -288,10 +288,10 @@ mod test {
         let size = Size::new(42 * 1024 * 1024 * 1024 * 1024); // 42 terabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
-        assert_eq!(size.unit_string(&flags).as_str(), "TB");
+        assert_eq!(size.value_string(&flags), "42");
+        assert_eq!(size.unit_string(&flags), "TB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "T");
+        assert_eq!(size.unit_string(&flags), "T");
     }
 
     #[test]
@@ -299,10 +299,10 @@ mod test {
         let size = Size::new(420 * 1024 * 1024 * 1024 * 1024 + 420 * 1024 * 1024 * 1024); // 420.4 terabytes
         let mut flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "420");
-        assert_eq!(size.unit_string(&flags).as_str(), "TB");
+        assert_eq!(size.value_string(&flags), "420");
+        assert_eq!(size.unit_string(&flags), "TB");
         flags.size = SizeFlag::Short;
-        assert_eq!(size.unit_string(&flags).as_str(), "T");
+        assert_eq!(size.unit_string(&flags), "T");
     }
 
     #[test]
@@ -310,8 +310,8 @@ mod test {
         let size = Size::new(42 * 1024 + 103); // 42.1 kilobytes
         let flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
-        assert_eq!(size.unit_string(&flags).as_str(), "KB");
+        assert_eq!(size.value_string(&flags), "42");
+        assert_eq!(size.unit_string(&flags), "KB");
     }
 
     #[test]
@@ -319,8 +319,8 @@ mod test {
         let size = Size::new(42 * 1024 + 1); // 42.001 kilobytes == 42 kilobytes
         let flags = Flags::default();
 
-        assert_eq!(size.value_string(&flags).as_str(), "42");
-        assert_eq!(size.unit_string(&flags).as_str(), "KB");
+        assert_eq!(size.value_string(&flags), "42");
+        assert_eq!(size.unit_string(&flags), "KB");
     }
 
     #[test]


### PR DESCRIPTION
The reason is that `String` can be compared to `&str`

#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)