### PR TITLE
Refactor tests with `clippy`

### DIFF
--- a/src/color/theme.rs
+++ b/src/color/theme.rs
@@ -351,7 +351,7 @@ mod tests {
     fn test_empty_theme_return_default() {
         // Must contain one field at least
         // ref https://github.com/dtolnay/serde-yaml/issues/86
-        let empty_theme = Theme::with_yaml("user: 230".into()).unwrap(); // 230 is the default value
+        let empty_theme = Theme::with_yaml("user: 230").unwrap(); // 230 is the default value
         let default_theme = Theme::default_dark();
         assert_eq!(empty_theme, default_theme);
     }
@@ -360,7 +360,7 @@ mod tests {
     fn test_first_level_theme_return_default_but_changed() {
         // Must contain one field at least
         // ref https://github.com/dtolnay/serde-yaml/issues/86
-        let empty_theme = Theme::with_yaml("user: 130".into()).unwrap();
+        let empty_theme = Theme::with_yaml("user: 130").unwrap();
         let mut theme = Theme::default_dark();
         use crossterm::style::Color;
         theme.user = Color::AnsiValue(130);
@@ -374,8 +374,7 @@ mod tests {
         let empty_theme = Theme::with_yaml(
             r#"---
 permission:
-  read: 130"#
-                .into(),
+  read: 130"#,
         )
         .unwrap();
         let mut theme = Theme::default_dark();

--- a/src/display.rs
+++ b/src/display.rs
@@ -429,7 +429,7 @@ mod tests {
         ] {
             let path = Path::new(s);
             let name = Name::new(
-                &path,
+                path,
                 FileType::File {
                     exec: false,
                     uid: false,
@@ -463,7 +463,7 @@ mod tests {
         ] {
             let path = Path::new(s);
             let name = Name::new(
-                &path,
+                path,
                 FileType::File {
                     exec: false,
                     uid: false,
@@ -496,7 +496,7 @@ mod tests {
         ] {
             let path = Path::new(s);
             let name = Name::new(
-                &path,
+                path,
                 FileType::File {
                     exec: false,
                     uid: false,
@@ -538,7 +538,7 @@ mod tests {
         ] {
             let path = Path::new(s);
             let name = Name::new(
-                &path,
+                path,
                 FileType::File {
                     exec: false,
                     uid: false,
@@ -648,14 +648,14 @@ mod tests {
                 .nth(i)
                 .unwrap()
                 .split(|c| c == 'K' || c == 'B')
-                .nth(0)
+                .next()
                 .unwrap()
                 .len()
         };
         assert_eq!(length_before_b(0), length_before_b(1));
         assert_eq!(
-            output.lines().nth(0).unwrap().find("d"),
-            output.lines().nth(1).unwrap().find("└")
+            output.lines().next().unwrap().find('d'),
+            output.lines().nth(1).unwrap().find('└')
         );
     }
 
@@ -681,11 +681,11 @@ mod tests {
             &Icons::new(icon::Theme::NoIcon, " ".to_string()),
         );
 
-        assert_eq!(output.lines().nth(1).unwrap().chars().nth(0).unwrap(), '└');
+        assert_eq!(output.lines().nth(1).unwrap().chars().next().unwrap(), '└');
         assert_eq!(
             output
                 .lines()
-                .nth(0)
+                .next()
                 .unwrap()
                 .chars()
                 .position(|x| x == 'd'),

--- a/src/display.rs
+++ b/src/display.rs
@@ -512,13 +512,12 @@ mod tests {
                 .to_string();
 
             // check if the color is present.
-            assert_eq!(
-                true,
+            assert!(
                 output.starts_with("\u{1b}[38;5;"),
                 "{:?} should start with color",
                 output,
             );
-            assert_eq!(true, output.ends_with("[39m"), "reset foreground color");
+            assert!(output.ends_with("[39m"), "reset foreground color");
 
             assert_eq!(get_visible_width(&output, false), *l, "visible match");
         }
@@ -554,8 +553,8 @@ mod tests {
                 .to_string();
 
             // check if the color is present.
-            assert_eq!(false, output.starts_with("\u{1b}[38;5;"));
-            assert_eq!(false, output.ends_with("[0m"));
+            assert!(!output.starts_with("\u{1b}[38;5;"));
+            assert!(!output.ends_with("[0m"));
 
             assert_eq!(get_visible_width(&output, false), *l);
         }

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -369,10 +369,7 @@ mod test_blocks {
     fn test_from_arg_matches_none() {
         let argv = ["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match Blocks::from_arg_matches(&matches) {
-            None => true,
-            _ => false,
-        });
+        assert!(matches!(Blocks::from_arg_matches(&matches), None));
     }
 
     #[test]
@@ -380,10 +377,9 @@ mod test_blocks {
         let argv = ["lsd", "--blocks", "permission"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let test_blocks = Blocks(vec![Block::Permission]);
-        assert!(match Blocks::from_arg_matches(&matches) {
-            Some(Ok(blocks)) if blocks == test_blocks => true,
-            _ => false,
-        });
+        assert!(
+            matches!(Blocks::from_arg_matches(&matches), Some(Ok(blocks)) if blocks == test_blocks)
+        );
     }
 
     #[test]
@@ -391,10 +387,9 @@ mod test_blocks {
         let argv = ["lsd", "--blocks", "permission", "--blocks", "name"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let test_blocks = Blocks(vec![Block::Permission, Block::Name]);
-        assert!(match Blocks::from_arg_matches(&matches) {
-            Some(Ok(blocks)) if blocks == test_blocks => true,
-            _ => false,
-        });
+        assert!(
+            matches!(Blocks::from_arg_matches(&matches), Some(Ok(blocks)) if blocks == test_blocks)
+        );
     }
 
     #[test]
@@ -402,10 +397,9 @@ mod test_blocks {
         let argv = ["lsd", "--blocks", "permission,name"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let test_blocks = Blocks(vec![Block::Permission, Block::Name]);
-        assert!(match Blocks::from_arg_matches(&matches) {
-            Some(Ok(blocks)) if blocks == test_blocks => true,
-            _ => false,
-        });
+        assert!(
+            matches!(Blocks::from_arg_matches(&matches), Some(Ok(blocks)) if blocks == test_blocks)
+        );
     }
 
     #[test]
@@ -420,10 +414,9 @@ mod test_blocks {
             Block::User,
             Block::Permission,
         ]);
-        assert!(match Blocks::from_arg_matches(&matches) {
-            Some(Ok(blocks)) if blocks == test_blocks => true,
-            _ => false,
-        });
+        assert!(
+            matches!(Blocks::from_arg_matches(&matches), Some(Ok(blocks)) if blocks == test_blocks)
+        );
     }
 
     #[test]
@@ -431,10 +424,9 @@ mod test_blocks {
         let argv = ["lsd", "--blocks", "permission,group,date"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let test_blocks = Blocks(vec![Block::Permission, Block::Group, Block::Date]);
-        assert!(match Blocks::from_arg_matches(&matches) {
-            Some(Ok(blocks)) if blocks == test_blocks => true,
-            _ => false,
-        });
+        assert!(
+            matches!(Blocks::from_arg_matches(&matches), Some(Ok(blocks)) if blocks == test_blocks)
+        );
     }
 
     #[test]

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -445,7 +445,7 @@ mod test_blocks {
     #[test]
     fn test_from_config_one() {
         let mut c = Config::with_none();
-        c.blocks = Some(vec!["permission".into()].into());
+        c.blocks = Some(vec!["permission".into()]);
 
         let blocks = Blocks(vec![Block::Permission]);
         assert_eq!(Some(blocks), Blocks::from_config(&c));
@@ -462,17 +462,14 @@ mod test_blocks {
             Block::Permission,
         ]);
         let mut c = Config::with_none();
-        c.blocks = Some(
-            vec![
-                "name".into(),
-                "date".into(),
-                "size".into(),
-                "group".into(),
-                "user".into(),
-                "permission".into(),
-            ]
-            .into(),
-        );
+        c.blocks = Some(vec![
+            "name".into(),
+            "date".into(),
+            "size".into(),
+            "group".into(),
+            "user".into(),
+            "permission".into(),
+        ]);
 
         assert_eq!(Some(target), Blocks::from_config(&c));
     }
@@ -480,7 +477,7 @@ mod test_blocks {
     #[test]
     fn test_from_config_every_second_one() {
         let mut c = Config::with_none();
-        c.blocks = Some(vec!["permission".into(), "group".into(), "date".into()].into());
+        c.blocks = Some(vec!["permission".into(), "group".into(), "date".into()]);
         let blocks = Blocks(vec![Block::Permission, Block::Group, Block::Date]);
         assert_eq!(Some(blocks), Blocks::from_config(&c));
     }
@@ -488,7 +485,7 @@ mod test_blocks {
     #[test]
     fn test_from_config_invalid_is_ignored() {
         let mut c = Config::with_none();
-        c.blocks = Some(vec!["permission".into(), "foo".into(), "date".into()].into());
+        c.blocks = Some(vec!["permission".into(), "foo".into(), "date".into()]);
         let blocks = Blocks(vec![Block::Permission, Block::Date]);
         assert_eq!(Some(blocks), Blocks::from_config(&c));
     }

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -143,24 +143,20 @@ mod test {
     fn test_configuration_from_none() {
         let argv = ["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(
-            match IgnoreGlobs::configure_from(&matches, &Config::with_none()) {
-                Ok(_) => true,
-                _ => false,
-            }
-        );
+        assert!(matches!(
+            IgnoreGlobs::configure_from(&matches, &Config::with_none()),
+            Ok(..)
+        ));
     }
 
     #[test]
     fn test_configuration_from_args() {
         let argv = ["lsd", "--ignore-glob", ".git"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(
-            match IgnoreGlobs::configure_from(&matches, &Config::with_none()) {
-                Ok(_) => true,
-                _ => false,
-            }
-        );
+        assert!(matches!(
+            IgnoreGlobs::configure_from(&matches, &Config::with_none()),
+            Ok(..)
+        ));
     }
 
     #[test]
@@ -169,27 +165,21 @@ mod test {
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let mut c = Config::with_none();
         c.ignore_globs = Some(vec![".git".into()]);
-        assert!(match IgnoreGlobs::configure_from(&matches, &c) {
-            Ok(_) => true,
-            _ => false,
-        });
+        assert!(matches!(IgnoreGlobs::configure_from(&matches, &c), Ok(..)));
     }
 
     #[test]
     fn test_from_arg_matches_none() {
         let argv = ["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match IgnoreGlobs::from_arg_matches(&matches) {
-            None => true,
-            _ => false,
-        });
+        assert!(matches!(IgnoreGlobs::from_arg_matches(&matches), None));
     }
 
     #[test]
     fn test_from_config_none() {
-        assert!(match IgnoreGlobs::from_config(&Config::with_none()) {
-            None => true,
-            _ => false,
-        });
+        assert!(matches!(
+            IgnoreGlobs::from_config(&Config::with_none()),
+            None
+        ));
     }
 }

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -168,7 +168,7 @@ mod test {
         let argv = ["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
         let mut c = Config::with_none();
-        c.ignore_globs = Some(vec![".git".into()].into());
+        c.ignore_globs = Some(vec![".git".into()]);
         assert!(match IgnoreGlobs::configure_from(&matches, &c) {
             Ok(_) => true,
             _ => false,

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -194,70 +194,43 @@ mod test {
     fn test_depth_from_arg_matches_empty() {
         let argv = ["lsd"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match Recursion::depth_from_arg_matches(&matches) {
-            None => true,
-            _ => false,
-        });
+        assert!(matches!(Recursion::depth_from_arg_matches(&matches), None));
     }
 
     #[test]
     fn test_depth_from_arg_matches_integer() {
         let argv = ["lsd", "--depth", "42"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match Recursion::depth_from_arg_matches(&matches) {
-            None => false,
-            Some(result) => {
-                match result {
-                    Ok(value) => value == 42,
-                    Err(_) => false,
-                }
-            }
-        });
+        assert!(
+            matches!(Recursion::depth_from_arg_matches(&matches), Some(Ok(value)) if value == 42)
+        );
     }
 
     #[test]
     fn test_depth_from_arg_matches_depth_multi() {
         let argv = ["lsd", "--depth", "4", "--depth", "2"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match Recursion::depth_from_arg_matches(&matches) {
-            None => false,
-            Some(result) => {
-                match result {
-                    Ok(value) => value == 2,
-                    Err(_) => false,
-                }
-            }
-        });
+        assert!(
+            matches!(Recursion::depth_from_arg_matches(&matches), Some(Ok(value)) if value == 2)
+        );
     }
 
     #[test]
     fn test_depth_from_arg_matches_neg_int() {
         let argv = ["lsd", "--depth", "\\-42"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match Recursion::depth_from_arg_matches(&matches) {
-            None => false,
-            Some(result) => {
-                match result {
-                    Ok(_) => false,
-                    Err(error) => error.kind == ErrorKind::ValueValidation,
-                }
-            }
-        });
+        assert!(
+            matches!(Recursion::depth_from_arg_matches(&matches), Some(Err(e)) if e.kind == ErrorKind::ValueValidation)
+        );
     }
 
     #[test]
     fn test_depth_from_arg_matches_non_int() {
         let argv = ["lsd", "--depth", "foo"];
         let matches = app::build().get_matches_from_safe(argv).unwrap();
-        assert!(match Recursion::depth_from_arg_matches(&matches) {
-            None => false,
-            Some(result) => {
-                match result {
-                    Ok(_) => false,
-                    Err(error) => error.kind == ErrorKind::ValueValidation,
-                }
-            }
-        });
+        assert!(
+            matches!(Recursion::depth_from_arg_matches(&matches), Some(Err(e)) if e.kind == ErrorKind::ValueValidation)
+        );
     }
 
     #[test]

--- a/src/flags/recursion.rs
+++ b/src/flags/recursion.rs
@@ -153,13 +153,10 @@ mod test {
     #[test]
     fn test_enabled_from_empty_matches_and_config() {
         let argv = ["lsd"];
-        assert_eq!(
-            false,
-            Recursion::enabled_from(
-                &app::build().get_matches_from_safe(argv).unwrap(),
-                &Config::with_none()
-            )
-        );
+        assert!(!Recursion::enabled_from(
+            &app::build().get_matches_from_safe(argv).unwrap(),
+            &Config::with_none()
+        ));
     }
 
     #[test]
@@ -170,10 +167,10 @@ mod test {
             enabled: Some(true),
             depth: None,
         });
-        assert_eq!(
-            true,
-            Recursion::enabled_from(&app::build().get_matches_from_safe(argv).unwrap(), &c)
-        );
+        assert!(Recursion::enabled_from(
+            &app::build().get_matches_from_safe(argv).unwrap(),
+            &c
+        ));
     }
 
     #[test]
@@ -184,10 +181,10 @@ mod test {
             enabled: Some(false),
             depth: None,
         });
-        assert_eq!(
-            false,
-            Recursion::enabled_from(&app::build().get_matches_from_safe(argv).unwrap(), &c)
-        );
+        assert!(!Recursion::enabled_from(
+            &app::build().get_matches_from_safe(argv).unwrap(),
+            &c
+        ));
     }
 
     // The following depth_from_arg_matches tests are implemented using match expressions instead

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -529,7 +529,7 @@ mod test {
     fn get_directory_icon() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(&file_path.to_path_buf(), false).unwrap();
+        let meta = Meta::from_path(file_path, false).unwrap();
 
         let icon = Icons::new(Theme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -541,7 +541,7 @@ mod test {
     fn get_directory_icon_unicode() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(&file_path.to_path_buf(), false).unwrap();
+        let meta = Meta::from_path(file_path, false).unwrap();
 
         let icon = Icons::new(Theme::Unicode, " ".to_string());
         let icon_str = icon.get(&meta.name);
@@ -553,7 +553,7 @@ mod test {
     fn get_directory_icon_with_ext() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
         let file_path = tmp_dir.path();
-        let meta = Meta::from_path(&file_path.to_path_buf(), false).unwrap();
+        let meta = Meta::from_path(file_path, false).unwrap();
 
         let icon = Icons::new(Theme::Fancy, " ".to_string());
         let icon_str = icon.get(&meta.name);

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -235,7 +235,7 @@ mod test {
         let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());
@@ -260,7 +260,7 @@ mod test {
         let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());
@@ -288,7 +288,7 @@ mod test {
         let success = cross_platform_touch(&file_path, &creation_date)
             .unwrap()
             .success();
-        assert_eq!(true, success, "failed to exec touch");
+        assert!(success, "failed to exec touch");
 
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());

--- a/src/meta/date.rs
+++ b/src/meta/date.rs
@@ -215,8 +215,10 @@ mod test {
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());
 
-        let mut flags = Flags::default();
-        flags.date = DateFlag::Relative;
+        let flags = Flags {
+            date: DateFlag::Relative,
+            ..Default::default()
+        };
 
         assert_eq!(
             "2 days ago".to_string().with(Color::AnsiValue(36)),
@@ -240,8 +242,10 @@ mod test {
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());
 
-        let mut flags = Flags::default();
-        flags.date = DateFlag::Relative;
+        let flags = Flags {
+            date: DateFlag::Relative,
+            ..Default::default()
+        };
 
         assert_eq!(
             "now".to_string().with(Color::AnsiValue(40)),
@@ -265,8 +269,10 @@ mod test {
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());
 
-        let mut flags = Flags::default();
-        flags.date = DateFlag::Iso;
+        let flags = Flags {
+            date: DateFlag::Iso,
+            ..Default::default()
+        };
 
         assert_eq!(
             creation_date
@@ -293,8 +299,10 @@ mod test {
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(&file_path.metadata().unwrap());
 
-        let mut flags = Flags::default();
-        flags.date = DateFlag::Iso;
+        let flags = Flags {
+            date: DateFlag::Iso,
+            ..Default::default()
+        };
 
         assert_eq!(
             creation_date
@@ -318,8 +326,10 @@ mod test {
         let colors = Colors::new(ThemeOption::Default);
         let date = Date::from(end_time);
 
-        let mut flags = Flags::default();
-        flags.date = DateFlag::Date;
+        let flags = Flags {
+            date: DateFlag::Date,
+            ..Default::default()
+        };
 
         assert_eq!(
             "-".to_string().with(Color::AnsiValue(36)),

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -143,8 +143,7 @@ mod test {
     #[test]
     fn test_dir_type() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
-        let meta = Meta::from_path(&tmp_dir.path().to_path_buf(), false)
-            .expect("failed to get tempdir path");
+        let meta = Meta::from_path(tmp_dir.path(), false).expect("failed to get tempdir path");
         let metadata = tmp_dir.path().metadata().expect("failed to get metas");
 
         let colors = Colors::new(ThemeOption::NoLscolors);

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -217,7 +217,7 @@ mod test {
             .status()
             .expect("failed to exec mkfifo")
             .success();
-        assert_eq!(true, success, "failed to exec mkfifo");
+        assert!(success, "failed to exec mkfifo");
         let meta = pipe_path.metadata().expect("failed to get metas");
 
         let colors = Colors::new(ThemeOption::NoLscolors);
@@ -245,7 +245,7 @@ mod test {
             .status()
             .expect("failed to exec mknod")
             .success();
-        assert_eq!(true, success, "failed to exec mknod");
+        assert!(success, "failed to exec mknod");
         let meta = char_device_path.metadata().expect("failed to get metas");
 
         let colors = Colors::new(ThemeOption::NoLscolors);

--- a/src/meta/indicator.rs
+++ b/src/meta/indicator.rs
@@ -38,8 +38,10 @@ mod test {
 
     #[test]
     fn test_directory_indicator() {
-        let mut flags = Flags::default();
-        flags.display_indicators = Indicators(true);
+        let flags = Flags {
+            display_indicators: Indicators(true),
+            ..Default::default()
+        };
 
         let file_type = Indicator::from(FileType::Directory { uid: false });
 
@@ -48,8 +50,10 @@ mod test {
 
     #[test]
     fn test_executable_file_indicator() {
-        let mut flags = Flags::default();
-        flags.display_indicators = Indicators(true);
+        let flags = Flags {
+            display_indicators: Indicators(true),
+            ..Default::default()
+        };
 
         let file_type = Indicator::from(FileType::File {
             uid: false,
@@ -61,8 +65,10 @@ mod test {
 
     #[test]
     fn test_socket_indicator() {
-        let mut flags = Flags::default();
-        flags.display_indicators = Indicators(true);
+        let flags = Flags {
+            display_indicators: Indicators(true),
+            ..Default::default()
+        };
 
         let file_type = Indicator::from(FileType::Socket);
 
@@ -71,8 +77,10 @@ mod test {
 
     #[test]
     fn test_symlink_indicator() {
-        let mut flags = Flags::default();
-        flags.display_indicators = Indicators(true);
+        let flags = Flags {
+            display_indicators: Indicators(true),
+            ..Default::default()
+        };
 
         let file_type = Indicator::from(FileType::SymLink { is_dir: false });
         assert_eq!("@", file_type.render(&flags).to_string());
@@ -83,8 +91,10 @@ mod test {
 
     #[test]
     fn test_not_represented_indicator() {
-        let mut flags = Flags::default();
-        flags.display_indicators = Indicators(true);
+        let flags = Flags {
+            display_indicators: Indicators(true),
+            ..Default::default()
+        };
 
         // The File type doesn't have any indicator
         let file_type = Indicator::from(FileType::File {

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -358,7 +358,7 @@ mod test {
             .status()
             .expect("failed to exec mkfifo")
             .success();
-        assert_eq!(true, success, "failed to exec mkfifo");
+        assert!(success, "failed to exec mkfifo");
         let meta = pipe_path.metadata().expect("failed to get metas");
 
         let colors = Colors::new(color::ThemeOption::NoLscolors);
@@ -506,7 +506,7 @@ mod test {
             },
         );
 
-        assert_eq!(true, name_a < name_z);
+        assert!(name_a < name_z);
     }
 
     #[test]
@@ -529,7 +529,7 @@ mod test {
             },
         );
 
-        assert_eq!(true, name_a < name_z);
+        assert!(name_a < name_z);
     }
 
     #[test]
@@ -552,7 +552,7 @@ mod test {
             },
         );
 
-        assert_eq!(true, name_1 == name_2);
+        assert!(name_1 == name_2);
     }
 
     #[test]
@@ -575,7 +575,7 @@ mod test {
             },
         );
 
-        assert_eq!(true, name_1 == name_2);
+        assert!(name_1 == name_2);
     }
 
     #[test]

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -438,7 +438,7 @@ mod test {
         let path = Path::new("some-file.txt");
 
         let name = Name::new(
-            &path,
+            path,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -453,7 +453,7 @@ mod test {
         let path = Path::new(".gitignore");
 
         let name = Name::new(
-            &path,
+            path,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -467,7 +467,7 @@ mod test {
     fn test_order_impl_is_case_insensitive() {
         let path_1 = Path::new("/AAAA");
         let name_1 = Name::new(
-            &path_1,
+            path_1,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -476,7 +476,7 @@ mod test {
 
         let path_2 = Path::new("/aaaa");
         let name_2 = Name::new(
-            &path_2,
+            path_2,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -490,7 +490,7 @@ mod test {
     fn test_partial_order_impl() {
         let path_a = Path::new("/aaaa");
         let name_a = Name::new(
-            &path_a,
+            path_a,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -499,7 +499,7 @@ mod test {
 
         let path_z = Path::new("/zzzz");
         let name_z = Name::new(
-            &path_z,
+            path_z,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -513,7 +513,7 @@ mod test {
     fn test_partial_order_impl_is_case_insensitive() {
         let path_a = Path::new("aaaa");
         let name_a = Name::new(
-            &path_a,
+            path_a,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -522,7 +522,7 @@ mod test {
 
         let path_z = Path::new("ZZZZ");
         let name_z = Name::new(
-            &path_z,
+            path_z,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -536,7 +536,7 @@ mod test {
     fn test_partial_eq_impl() {
         let path_1 = Path::new("aaaa");
         let name_1 = Name::new(
-            &path_1,
+            path_1,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -545,7 +545,7 @@ mod test {
 
         let path_2 = Path::new("aaaa");
         let name_2 = Name::new(
-            &path_2,
+            path_2,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -559,7 +559,7 @@ mod test {
     fn test_partial_eq_impl_is_case_insensitive() {
         let path_1 = Path::new("AAAA");
         let name_1 = Name::new(
-            &path_1,
+            path_1,
             FileType::File {
                 uid: false,
                 exec: false,
@@ -568,7 +568,7 @@ mod test {
 
         let path_2 = Path::new("aaaa");
         let name_2 = Name::new(
-            &path_2,
+            path_2,
             FileType::File {
                 uid: false,
                 exec: false,

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -221,8 +221,10 @@ mod test {
         let meta = file_path.metadata().expect("failed to get meta");
 
         let colors = Colors::new(ThemeOption::NoColor);
-        let mut flags = Flags::default();
-        flags.permission = PermissionFlag::Rwx;
+        let flags = Flags {
+            permission: PermissionFlag::Rwx,
+            ..Default::default()
+        };
         let perms = Permissions::from(&meta);
 
         assert_eq!("rwxrwxrwt", perms.render(&colors, &flags).content());
@@ -240,8 +242,10 @@ mod test {
         let meta = file_path.metadata().expect("failed to get meta");
 
         let colors = Colors::new(ThemeOption::NoColor);
-        let mut flags = Flags::default();
-        flags.permission = PermissionFlag::Octal;
+        let flags = Flags {
+            permission: PermissionFlag::Octal,
+            ..Default::default()
+        };
         let perms = Permissions::from(&meta);
 
         assert_eq!("0655", perms.render(&colors, &flags).content());
@@ -259,8 +263,10 @@ mod test {
         let meta = file_path.metadata().expect("failed to get meta");
 
         let colors = Colors::new(ThemeOption::NoColor);
-        let mut flags = Flags::default();
-        flags.permission = PermissionFlag::Octal;
+        let flags = Flags {
+            permission: PermissionFlag::Octal,
+            ..Default::default()
+        };
         let perms = Permissions::from(&meta);
 
         assert_eq!("0777", perms.render(&colors, &flags).content());
@@ -279,8 +285,10 @@ mod test {
         let meta = file_path.metadata().expect("failed to get meta");
 
         let colors = Colors::new(ThemeOption::NoColor);
-        let mut flags = Flags::default();
-        flags.permission = PermissionFlag::Octal;
+        let flags = Flags {
+            permission: PermissionFlag::Octal,
+            ..Default::default()
+        };
         let perms = Permissions::from(&meta);
 
         assert_eq!("1777", perms.render(&colors, &flags).content());

--- a/src/meta/size.rs
+++ b/src/meta/size.rs
@@ -317,8 +317,10 @@ mod test {
     #[test]
     fn render_short_nospaces() {
         let size = Size::new(42 * KB); // 42 kilobytes
-        let mut flags = Flags::default();
-        flags.size = SizeFlag::Short;
+        let flags = Flags {
+            size: SizeFlag::Short,
+            ..Default::default()
+        };
         let colors = Colors::new(ThemeOption::NoColor);
 
         assert_eq!(size.render(&colors, &flags, Some(2)).to_string(), "42K");

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -217,7 +217,7 @@ mod tests {
             .unwrap()
             .success();
 
-        assert_eq!(true, success, "failed to change file timestamp");
+        assert!(success, "failed to change file timestamp");
         let meta_z = Meta::from_path(&path_z, false).expect("failed to get meta");
 
         let mut flags = Flags::default();


### PR DESCRIPTION
By default, running `cargo clippy` doesn't check the testing code. We can lint the testing code with `cargo clippy --tests`.
Running `cargo clippy --fix` also check and try to fix the testing code.

This PR refactor testing code with many lints from `clippy`

List of lints
- [bool_assert_comparison](https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison)
- [field_reassign_with_default](https://rust-lang.github.io/rust-clippy/master/index.html#field_reassign_with_default)
- [iter_nth_zero](https://rust-lang.github.io/rust-clippy/master/index.html#iter_nth_zero)
- [match_like_matches_macro](https://rust-lang.github.io/rust-clippy/master/index.html#match_like_matches_macro)
- [needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
- [single_char_pattern](https://rust-lang.github.io/rust-clippy/master/index.html#single_char_pattern)
- [unnecessary_to_owned](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned)
- [useless_conversion](https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion)


#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)