### PR TITLE
docs(readme): make example config file collapsible

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ You can also provide a configuration file from a non standard location:
 
 ### Config file content
 
-This is an example config file with the default values and some additional
-remarks.
-
+<details open>
+<summary>This is an example config file with the default values and some additional remarks.</summary>
+  
 ```yaml
 # == Classic ==
 # This is a shorthand to override some of the options to be backwards compatible
@@ -222,6 +222,8 @@ symlink-arrow: ⇒
 # Possible values: false, true
 header: false
 ```
+</details>
+
 
 ## Theme
 


### PR DESCRIPTION
Because the example config files is quite long, it's annoying to scroll all the way down to the bottom.
This PR makes example config file collapsible. However, it still shows the config file by default.

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)