### PR TITLE
refactor(flags): refactor parsing arguments

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,7 +6,7 @@ env:
   PROJECT_NAME: lsd
   PROJECT_DESC: "An ls command with a lot of pretty colors."
   PROJECT_AUTH: "Peltoche <peltoche@halium.fr>"
-  RUST_MIN_SRV: "1.56.0"
+  RUST_MIN_SRV: "1.62.1"
 
 on: [push, pull_request]
 

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -71,24 +71,24 @@ impl Blocks {
     /// This errors if any of the parameter arguments causes [Block]'s implementation of
     /// [TryFrom::try_from] to return an [Err].
     fn from_arg_matches(matches: &ArgMatches) -> Option<Result<Self, Error>> {
-        if matches.occurrences_of("blocks") > 0 {
-            if let Some(values) = matches.values_of("blocks") {
-                let mut blocks: Vec<Block> = vec![];
-                for value in values {
-                    match Block::try_from(value) {
-                        Ok(block) => blocks.push(block),
-                        Err(message) => {
-                            return Some(Err(Error::with_description(
-                                &message,
-                                ErrorKind::ValueValidation,
-                            )))
-                        }
+        if matches.occurrences_of("blocks") == 0 {
+            return None;
+        }
+
+        if let Some(values) = matches.values_of("blocks") {
+            let mut blocks: Vec<Block> = Vec::with_capacity(values.len());
+            for value in values {
+                match Block::try_from(value) {
+                    Ok(block) => blocks.push(block),
+                    Err(message) => {
+                        return Some(Err(Error::with_description(
+                            &message,
+                            ErrorKind::ValueValidation,
+                        )))
                     }
                 }
-                Some(Ok(Self(blocks)))
-            } else {
-                None
             }
+            Some(Ok(Self(blocks)))
         } else {
             None
         }

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -106,8 +106,10 @@ impl ColorOption {
             "always" => Self::Always,
             "auto" => Self::Auto,
             "never" => Self::Never,
-            _ => {
-                unreachable!("Invalid value should be handled by `clap`");
+            other => {
+                unreachable!(
+                    "Invalid value '{other}' for 'color' flag should be handled by `clap`"
+                );
             }
         }
     }

--- a/src/flags/dereference.rs
+++ b/src/flags/dereference.rs
@@ -29,7 +29,7 @@ impl Configurable<Self> for Dereference {
     /// If the `Config::dereference` has value, this returns its value
     /// as the value of the `Dereference`, in a [Some], Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        config.dereference.as_ref().map(|deref| Self(*deref))
+        config.dereference.map(Self)
     }
 }
 

--- a/src/flags/hyperlink.rs
+++ b/src/flags/hyperlink.rs
@@ -23,7 +23,9 @@ impl HyperlinkOption {
             "always" => Self::Always,
             "auto" => Self::Auto,
             "never" => Self::Never,
-            _ => unreachable!("Invalid value should be handled by `clap`"),
+            other => unreachable!(
+                "Invalid value '{other}' for 'hyperlink' flag should be handled by `clap`"
+            ),
         }
     }
 }

--- a/src/flags/hyperlink.rs
+++ b/src/flags/hyperlink.rs
@@ -17,6 +17,17 @@ pub enum HyperlinkOption {
     Never,
 }
 
+impl HyperlinkOption {
+    fn from_arg_str(value: &str) -> Self {
+        match value {
+            "always" => Self::Always,
+            "auto" => Self::Auto,
+            "never" => Self::Never,
+            _ => unreachable!("Invalid value should be handled by `clap`"),
+        }
+    }
+}
+
 impl Configurable<Self> for HyperlinkOption {
     /// Get a potential `HyperlinkOption` variant from [ArgMatches].
     ///
@@ -27,12 +38,10 @@ impl Configurable<Self> for HyperlinkOption {
         if matches.is_present("classic") {
             Some(Self::Never)
         } else if matches.occurrences_of("hyperlink") > 0 {
-            match matches.values_of("hyperlink")?.last() {
-                Some("always") => Some(Self::Always),
-                Some("auto") => Some(Self::Auto),
-                Some("never") => Some(Self::Never),
-                _ => panic!("This should not be reachable!"),
-            }
+            matches
+                .values_of("hyperlink")?
+                .last()
+                .map(Self::from_arg_str)
         } else {
             None
         }
@@ -45,11 +54,11 @@ impl Configurable<Self> for HyperlinkOption {
     /// this returns its corresponding variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(true) = &config.classic {
-            return Some(Self::Never);
+        if config.classic == Some(true) {
+            Some(Self::Never)
+        } else {
+            config.hyperlink
         }
-
-        config.hyperlink
     }
 }
 

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -51,8 +51,8 @@ impl IconOption {
             "always" => Self::Always,
             "auto" => Self::Auto,
             "never" => Self::Never,
-            _ => {
-                unreachable!("Invalid value should be handled by `clap`");
+            other => {
+                unreachable!("Invalid value '{other}' for 'icon' flag should be handled by `clap`");
             }
         }
     }
@@ -109,8 +109,10 @@ impl IconTheme {
         match value {
             "fancy" => Self::Fancy,
             "unicode" => Self::Unicode,
-            _ => {
-                unreachable!("Invalid value should be handled by `clap`");
+            other => {
+                unreachable!(
+                    "Invalid value '{other}' for 'icon-theme' flag should be handled by `clap`"
+                );
             }
         }
     }

--- a/src/flags/permission.rs
+++ b/src/flags/permission.rs
@@ -23,8 +23,10 @@ impl PermissionFlag {
         match value {
             "rwx" => Self::Rwx,
             "octal" => Self::Octal,
-            _ => {
-                unreachable!("Invalid value should be handled by `serde` or `clap`");
+            other => {
+                unreachable!(
+                    "Invalid value '{other}' for 'permission' flag should be handled by `clap`"
+                );
             }
         }
     }

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -26,8 +26,8 @@ impl SizeFlag {
             "default" => Self::Default,
             "short" => Self::Short,
             "bytes" => Self::Bytes,
-            _ => {
-                unreachable!("Invalid value should be handled by `clap`");
+            other => {
+                unreachable!("Invalid value '{other}' for 'size' flag should be handled by `clap`");
             }
         }
     }

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -21,16 +21,13 @@ pub enum SizeFlag {
 }
 
 impl SizeFlag {
-    fn from_str(value: &str) -> Option<Self> {
+    fn from_arg_str(value: &str) -> Self {
         match value {
-            "default" => Some(Self::Default),
-            "short" => Some(Self::Short),
-            "bytes" => Some(Self::Bytes),
+            "default" => Self::Default,
+            "short" => Self::Short,
+            "bytes" => Self::Bytes,
             _ => {
-                panic!(
-                    "Size can only be one of default, short or bytes, but got {}.",
-                    value
-                );
+                unreachable!("Invalid value should be handled by `clap`");
             }
         }
     }
@@ -44,13 +41,12 @@ impl Configurable<Self> for SizeFlag {
     /// [None].
     fn from_arg_matches(matches: &ArgMatches) -> Option<Self> {
         if matches.is_present("classic") {
-            return Some(Self::Bytes);
+            Some(Self::Bytes)
         } else if matches.occurrences_of("size") > 0 {
-            if let Some(size) = matches.values_of("size")?.last() {
-                return Self::from_str(size);
-            }
+            matches.values_of("size")?.last().map(Self::from_arg_str)
+        } else {
+            None
         }
-        None
     }
 
     /// Get a potential `SizeFlag` variant from a [Config].
@@ -59,7 +55,7 @@ impl Configurable<Self> for SizeFlag {
     /// this returns the corresponding `SizeFlag` variant in a [Some].
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
-        if let Some(true) = config.classic {
+        if config.classic == Some(true) {
             Some(Self::Bytes)
         } else {
             config.size

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -142,8 +142,10 @@ impl DirGrouping {
             "first" => Self::First,
             "last" => Self::Last,
             "none" => Self::None,
-            _ => {
-                unreachable!("Invalid value should be handled by `clap`");
+            other => {
+                unreachable!(
+                    "Invalid value '{other}' for 'group-dirs' flag should be handled by `clap`"
+                );
             }
         }
     }


### PR DESCRIPTION
- Make code more idiomatic and readable and have the same pattern
- Use `unreachable` to clearly show internal logic error
- Rename function `from_str` to `from_arg_str` to make it more specific


#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)