### PR TITLE
refactor: implement `Configurable` for `blocks`

### DIFF
--- a/src/flags.rs
+++ b/src/flags.rs
@@ -83,7 +83,7 @@ impl Flags {
     /// the recursion depth parameter fails.
     pub fn configure_from(matches: &ArgMatches, config: &Config) -> Result<Self, Error> {
         Ok(Self {
-            blocks: Blocks::configure_from(matches, config)?,
+            blocks: Blocks::configure_from(matches, config),
             color: Color::configure_from(matches, config),
             date: DateFlag::configure_from(matches, config),
             dereference: Dereference::configure_from(matches, config),

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -51,7 +51,7 @@ impl Blocks {
         self.0.contains(&Block::Size)
     }
 
-    /// Tnserts a [Block] of variant [INode](Block::Context), if `self` does not already contain a
+    /// Inserts a [Block] of variant [INode](Block::Context), if `self` does not already contain a
     /// [Block] of that variant. The positioning will be best-effort approximation of coreutils
     /// ls position for a security context
     fn optional_insert_context(&mut self) {

--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -121,9 +121,8 @@ impl Configurable<Self> for Blocks {
             let mut blocks: Vec<Block> = Vec::with_capacity(values.len());
             for value in values {
                 blocks.push(Block::try_from(value).unwrap_or_else(|_| {
-                    unreachable!(
-                        "Invalid value '{value}' for 'blocks' flag should be handled by `clap`"
-                    )
+                    // Invalid value should be handled by `clap` when building an `ArgMatches`
+                    unreachable!("Invalid value '{value}' for 'blocks'")
                 }));
             }
             Some(Self(blocks))


### PR DESCRIPTION
Previously, `blocks` struct try to mimic the `Configurable` trait by having functions with the same name and similar signature. It cannot implement `Configurable` because it propagate an `Error` to caller in case of invalid values.
However, those invalid values should be handled by `clap` in the first place. So, we can implement `Configurable` for `blocks` with custom `configure_from` instead of the default one.

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)