### PR TITLE
refactor: use default attribute for enum

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -6,7 +6,7 @@ env:
   PROJECT_NAME: lsd
   PROJECT_DESC: "An ls command with a lot of pretty colors."
   PROJECT_AUTH: "Peltoche <peltoche@halium.fr>"
-  RUST_MIN_SRV: "1.62.1"
+  RUST_MIN_SRV: "1.62.0"
 
 on: [push, pull_request]
 

--- a/build.rs
+++ b/build.rs
@@ -18,11 +18,11 @@ use std::process::exit;
 include!("src/app.rs");
 
 fn main() {
-    match version_check::is_min_version("1.62.1") {
+    match version_check::is_min_version("1.62.0") {
         Some(true) => {}
         // rustc version too small or can't figure it out
         _ => {
-            writeln!(&mut io::stderr(), "'lsd' requires rustc >= 1.62.1").unwrap();
+            writeln!(&mut io::stderr(), "'lsd' requires rustc >= 1.62.0").unwrap();
             exit(1);
         }
     }

--- a/build.rs
+++ b/build.rs
@@ -18,11 +18,11 @@ use std::process::exit;
 include!("src/app.rs");
 
 fn main() {
-    match version_check::is_min_version("1.43.1") {
+    match version_check::is_min_version("1.62.1") {
         Some(true) => {}
         // rustc version too small or can't figure it out
         _ => {
-            writeln!(&mut io::stderr(), "'lsd' requires rustc >= 1.43.1").unwrap();
+            writeln!(&mut io::stderr(), "'lsd' requires rustc >= 1.62.1").unwrap();
             exit(1);
         }
     }

--- a/src/flags/color.rs
+++ b/src/flags/color.rs
@@ -33,9 +33,10 @@ impl Color {
 /// ThemeOption could be one of the following:
 /// Custom(*.yaml): use the YAML theme file as theme file
 /// if error happened, use the default theme
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Default)]
 pub enum ThemeOption {
     NoColor,
+    #[default]
     Default,
     #[allow(dead_code)]
     NoLscolors,
@@ -53,12 +54,6 @@ impl ThemeOption {
                 .and_then(|c| c.theme.clone())
                 .unwrap_or_default()
         }
-    }
-}
-
-impl Default for ThemeOption {
-    fn default() -> Self {
-        ThemeOption::Default
     }
 }
 
@@ -92,10 +87,11 @@ impl<'de> de::Deserialize<'de> for ThemeOption {
 }
 
 /// The flag showing when to use colors in the output.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum ColorOption {
     Always,
+    #[default]
     Auto,
     Never,
 }
@@ -150,13 +146,6 @@ impl Configurable<Self> for ColorOption {
         } else {
             None
         }
-    }
-}
-
-/// The default value for `ColorOption` is [ColorOption::Auto].
-impl Default for ColorOption {
-    fn default() -> Self {
-        Self::Auto
     }
 }
 

--- a/src/flags/date.rs
+++ b/src/flags/date.rs
@@ -10,8 +10,9 @@ use crate::print_error;
 use clap::ArgMatches;
 
 /// The flag showing which kind of time stamps to display.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub enum DateFlag {
+    #[default]
     Date,
     Relative,
     Iso,
@@ -90,13 +91,6 @@ impl Configurable<Self> for DateFlag {
         } else {
             None
         }
-    }
-}
-
-/// The default value for `DateFlag` is [DateFlag::Date].
-impl Default for DateFlag {
-    fn default() -> Self {
-        Self::Date
     }
 }
 

--- a/src/flags/display.rs
+++ b/src/flags/display.rs
@@ -9,12 +9,13 @@ use clap::ArgMatches;
 use serde::Deserialize;
 
 /// The flag showing which file system nodes to display.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum Display {
     All,
     AlmostAll,
     DirectoryOnly,
+    #[default]
     VisibleOnly,
 }
 
@@ -44,13 +45,6 @@ impl Configurable<Self> for Display {
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
         config.display
-    }
-}
-
-/// The default value for `Display` is [Display::VisibleOnly].
-impl Default for Display {
-    fn default() -> Self {
-        Display::VisibleOnly
     }
 }
 

--- a/src/flags/hyperlink.rs
+++ b/src/flags/hyperlink.rs
@@ -9,11 +9,12 @@ use clap::ArgMatches;
 use serde::Deserialize;
 
 /// The flag showing when to use hyperlink in the output.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum HyperlinkOption {
     Always,
     Auto,
+    #[default]
     Never,
 }
 
@@ -61,13 +62,6 @@ impl Configurable<Self> for HyperlinkOption {
         } else {
             config.hyperlink
         }
-    }
-}
-
-/// The default value for the `HyperlinkOption` is [HyperlinkOption::Auto].
-impl Default for HyperlinkOption {
-    fn default() -> Self {
-        Self::Never
     }
 }
 

--- a/src/flags/icons.rs
+++ b/src/flags/icons.rs
@@ -37,10 +37,11 @@ impl Icons {
 }
 
 /// The flag showing when to use icons in the output.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum IconOption {
     Always,
+    #[default]
     Auto,
     Never,
 }
@@ -89,18 +90,12 @@ impl Configurable<Self> for IconOption {
     }
 }
 
-/// The default value for the `IconOption` is [IconOption::Auto].
-impl Default for IconOption {
-    fn default() -> Self {
-        Self::Auto
-    }
-}
-
 /// The flag showing which icon theme to use.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum IconTheme {
     Unicode,
+    #[default]
     Fancy,
 }
 
@@ -141,13 +136,6 @@ impl Configurable<Self> for IconTheme {
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
         config.icons.as_ref().and_then(|icon| icon.theme)
-    }
-}
-
-/// The default value for `IconTheme` is [IconTheme::Fancy].
-impl Default for IconTheme {
-    fn default() -> Self {
-        Self::Fancy
     }
 }
 

--- a/src/flags/layout.rs
+++ b/src/flags/layout.rs
@@ -9,9 +9,10 @@ use clap::ArgMatches;
 use serde::Deserialize;
 
 /// The flag showing which output layout to print.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum Layout {
+    #[default]
     Grid,
     Tree,
     OneLine,
@@ -47,13 +48,6 @@ impl Configurable<Layout> for Layout {
     /// Otherwise this returns [None].
     fn from_config(config: &Config) -> Option<Self> {
         config.layout
-    }
-}
-
-/// The default value for `Layout` is [Layout::Grid].
-impl Default for Layout {
-    fn default() -> Self {
-        Self::Grid
     }
 }
 

--- a/src/flags/permission.rs
+++ b/src/flags/permission.rs
@@ -9,10 +9,11 @@ use clap::ArgMatches;
 use serde::Deserialize;
 
 /// The flag showing which file permissions units to use.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum PermissionFlag {
     /// The variant to show file permissions in rwx format
+    #[default]
     Rwx,
     /// The variant to show file permissions in octal format
     Octal,
@@ -64,13 +65,6 @@ impl Configurable<Self> for PermissionFlag {
         } else {
             config.permission
         }
-    }
-}
-
-/// The default value for `PermissionFlag` is [PermissionFlag::Default].
-impl Default for PermissionFlag {
-    fn default() -> Self {
-        Self::Rwx
     }
 }
 

--- a/src/flags/size.rs
+++ b/src/flags/size.rs
@@ -9,10 +9,11 @@ use clap::ArgMatches;
 use serde::Deserialize;
 
 /// The flag showing which file size units to use.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum SizeFlag {
     /// The variant to show file size with SI unit prefix and a B for bytes.
+    #[default]
     Default,
     /// The variant to show file size with only the SI unit prefix.
     Short,
@@ -60,13 +61,6 @@ impl Configurable<Self> for SizeFlag {
         } else {
             config.size
         }
-    }
-}
-
-/// The default value for `SizeFlag` is [SizeFlag::Default].
-impl Default for SizeFlag {
-    fn default() -> Self {
-        Self::Default
     }
 }
 

--- a/src/flags/sorting.rs
+++ b/src/flags/sorting.rs
@@ -34,11 +34,12 @@ impl Sorting {
 }
 
 /// The flag showing which column to use for sorting.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum SortColumn {
     None,
     Extension,
+    #[default]
     Name,
     Time,
     Size,
@@ -78,16 +79,10 @@ impl Configurable<Self> for SortColumn {
     }
 }
 
-/// The default value for `SortColumn` is [SortColumn::Name].
-impl Default for SortColumn {
-    fn default() -> Self {
-        Self::Name
-    }
-}
-
 /// The flag showing which sort order to use.
-#[derive(Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Default)]
 pub enum SortOrder {
+    #[default]
     Default,
     Reverse,
 }
@@ -120,17 +115,11 @@ impl Configurable<Self> for SortOrder {
     }
 }
 
-/// The default value for `SortOrder` is [SortOrder::Default].
-impl Default for SortOrder {
-    fn default() -> Self {
-        Self::Default
-    }
-}
-
 /// The flag showing where to place directories.
-#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Clone, Debug, Copy, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub enum DirGrouping {
+    #[default]
     None,
     First,
     Last,
@@ -188,13 +177,6 @@ impl Configurable<Self> for DirGrouping {
         } else {
             config.sorting.as_ref().and_then(|s| s.dir_grouping)
         }
-    }
-}
-
-/// The default value for `DirGrouping` is [DirGrouping::None].
-impl Default for DirGrouping {
-    fn default() -> Self {
-        Self::None
     }
 }
 


### PR DESCRIPTION
Use the new feature from Rust 1.62 to make code more concise
https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#default-enum-variants

Since we just bump the CICD to Rust 1.62.1, I think it's ok to use the new feature from Rust.

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)