### PR TITLE
Fix typos and markdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update minimal rust version to 1.42.0 from [zwpaper](https://github.com/zwpaper) [#534](https://github.com/Peltoche/lsd/issues/534)
 - [`NO_COLOR`](https://no-color.org/) environment variable support from [AnInternetTroll](https://github.com/aninternettroll)
 ### Changed
-- Change size to use btyes in classic mode from [meain](https://github.com/meain)
+- Change size to use bytes in classic mode from [meain](https://github.com/meain)
 - Show tree edge before name block or first column if no name block from [zwpaper](https://github.com/zwpaper) [#468](https://github.com/Peltoche/lsd/issues/468)
 - Added icons for Perl modules (.pm) and test scripts (.t)
 - Add `--config-file` flag to read configuration file from a custom location
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add more icons for wmv,wma and others from [0jdxt](https://github.com/0jdxt)
 - Add Windows(Scoop) installation instructions from [turtlebasket](https://github.com/turtlebasket)
 - Add opus filetype icon from [nabakolu](https://github.com/nabakolu)
-- Add FreeBSD insallation instructions from [andoriyu](https://github.com/andoriyu)
+- Add FreeBSD installation instructions from [andoriyu](https://github.com/andoriyu)
 
 ### Changed
 - Drop snap support from [zwpaper](https://github.com/zwpaper)
@@ -343,7 +343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add the '.cfg' icon
 
 ### Changed
-- Change the component alignement by using term_grid
+- Change the component alignment by using term_grid
 
 
 [Unreleased]: https://github.com/Peltoche/lsd/compare/0.22.0...HEAD

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@
 This project is a rewrite of GNU `ls` with lot of added features like colors, icons, tree-view, more formatting options etc.
 The project is heavily inspired by the super [colorls](https://github.com/athityakumar/colorls) project.
 
-
 ## Installation
 
 <details>
@@ -21,7 +20,7 @@ The project is heavily inspired by the super [colorls](https://github.com/athity
 </a>
 </details>
 
-#### Prerequisites
+### Prerequisites
 
 Install the patched fonts of powerline nerd-font and/or font-awesome. Have a look at the [Nerd Font README](https://github.com/ryanoasis/nerd-fonts/blob/master/readme.md) for more installation instructions. Don't forget to setup your terminal in order to use the correct font.
 
@@ -39,7 +38,6 @@ Install the patched fonts of powerline nerd-font and/or font-awesome. Have a loo
 | Ubuntu/Debian based distro      | `sudo dpkg -i lsd_0.22.0_amd64.deb` get `.deb` file from [release page](https://github.com/Peltoche/lsd/releases) |
 | Solus                           | `eopkg it lsd`                                                                                                    |
 | Void Linux                      | `sudo xbps-install lsd`                                                                                           |
-
 
 ### From source
 
@@ -66,7 +64,7 @@ Check [Config file content](#config-file-content) for details.
 
 ### Config file location
 
-#### Non-Windows
+### Non-Windows
 
 On non-Windows systems `lsd` follows the
 [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
@@ -76,12 +74,12 @@ called `config.yaml`.
 For most people it should be enough to put their config file at
 `~/.config/lsd/config.yaml`.
 
-#### Windows
+### Windows
 
 On Windows systems `lsd` only looks for the `config.yaml` files in one location:
 `%APPDATA%\lsd\`
 
-#### Custom
+### Custom
 
 You can also provide a configuration file from a non standard location:
 `lsd --config-file [PATH]`
@@ -90,7 +88,7 @@ You can also provide a configuration file from a non standard location:
 
 <details open>
 <summary>This is an example config file with the default values and some additional remarks.</summary>
-  
+
 ```yaml
 # == Classic ==
 # This is a shorthand to override some of the options to be backwards compatible
@@ -229,8 +227,8 @@ symlink-arrow: ⇒
 # Possible values: false, true
 header: false
 ```
-</details>
 
+</details>
 
 ## Theme
 
@@ -302,11 +300,9 @@ Please also notice that an empty theme is **NOT** supported due to
 
 ### Required
 
-Enable nerd fonts for your terminal, URxvt for example:
+Enable nerd fonts for your terminal, URxvt for example in `.Xresources`:
 
-.Xresources
-
-```
+```sh
 URxvt*font:    xft:Hack Nerd Font:style=Regular:size=11
 ```
 
@@ -365,12 +361,13 @@ The default colors are:
 _Checkout [trapd00r/LS_COLORS](https://github.com/trapd00r/LS_COLORS) and [sharkdp/vivid](https://github.com/sharkdp/vivid) for help in themeing using `LS_COLORS`._
 
 ### First char of folder/file getting trimmed
+
 Workaround for Konsole: ㅤEdit the config file (or [create it](#config-file-location) if it doesn't already exist) and paste the following into it (contains invisible unicode characters):
-  ```yml
+
+```yml
 icons:
     separator: " ㅤ"
 ```
-
 
 This is a known issue in a few terminal emulator. Try using a different terminal emulator like. [Alacritty](https://github.com/alacritty/alacritty) and [Kitty](https://github.com/kovidgoyal/kitty) are really good alternatives. You might also want to check if your font is responsible for causing this.
 To verify this, try running lsd with icons disabled and if it still does not have the first character, then this is an lsd bug:

--- a/doc/lsd.md
+++ b/doc/lsd.md
@@ -119,7 +119,7 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 `-I, --ignore-glob <pattern>...`
 : Do not display files/directories with names matching the glob pattern(s). More than one can be specified by repeating the argument [default: ]
 
-  * [ ] `--permission <permission>...`
+`--permission <permission>...`
 : How to display permissions [default: rwx]  [possible values: rwx, octal]
 
 `--size <size>...`
@@ -160,4 +160,3 @@ lsd is a ls command with a lot of pretty colours and some other stuff to enrich 
 
 `XDG_CONFIG_HOME`
 : Used to locate optional config file. If `XDG_CONFIG_HOME` is set, use `$XDG_CONFIG_HOME/lsd/config.yaml` else `$HOME/.config/lsd/config.yaml`.
-

--- a/src/meta/windows_utils.rs
+++ b/src/meta/windows_utils.rs
@@ -217,7 +217,7 @@ unsafe fn get_acl_access_mask(
 /// is
 ///
 /// Note: winapi's TRUSTEE_W looks different from the one in the MS docs because
-/// of some unusal pre-processor macros in the original .h file. The winapi
+/// of some unusual pre-processor macros in the original .h file. The winapi
 /// version is correct (MS's doc generator messed up)
 unsafe fn trustee_from_sid(sid_ptr: *mut c_void) -> TRUSTEE_W {
     let mut trustee: TRUSTEE_W = std::mem::zeroed();

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -124,7 +124,7 @@ mod tests {
         let sorter = assemble_sorters(&flags);
         assert_eq!(by_meta(&sorter, &meta_a, &meta_z), Ordering::Less);
 
-        // Sort with file first reversed (thie files stay first)
+        // Sort with file first reversed (this files stay first)
         let sorter = assemble_sorters(&flags);
         assert_eq!(by_meta(&sorter, &meta_a, &meta_z), Ordering::Less);
     }


### PR DESCRIPTION
Found via these commands:

    codespell -L crate,complies
    markdownlint README.md docs/lsd.md --disable MD034 MD013 MD033 MD025


<!--- PR Description --->

---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [X] Update man page at lsd/doc/lsd.md (if applicable)