### PR TITLE
perf: reduces the binary size and improves the performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - ReleaseDate
 ### Added
 ### Changed
+- Reduce the binary size and improve the performance from [sabify](https://github.com/sabify)
 ### Fixed
 - Fix rendering issues in Windows from [meain](https://gitHub.com/meain)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,9 @@ serial_test = "0.5"
 
 [features]
 sudo = []
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true
+debug = false


### PR DESCRIPTION
This PR reduces the binary size by ~25% and improves the performance slightly by ~2% on M1 Mac.

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [x] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)