### PR TITLE
refactor: remove unnecessary check for 'ignore-config'

### DIFF
--- a/src/flags/blocks.rs
+++ b/src/flags/blocks.rs
@@ -87,7 +87,7 @@ impl Configurable<Self> for Blocks {
             Default::default()
         };
 
-        if matches.is_present("long") && !matches.is_present("ignore-config") {
+        if matches.is_present("long") {
             if let Some(value) = Self::from_config(config) {
                 blocks = value;
             }

--- a/src/flags/ignore_globs.rs
+++ b/src/flags/ignore_globs.rs
@@ -25,10 +25,8 @@ impl IgnoreGlobs {
             return value;
         }
 
-        if !matches.is_present("ignore-config") {
-            if let Some(value) = Self::from_config(config) {
-                return value;
-            }
+        if let Some(value) = Self::from_config(config) {
+            return value;
         }
 
         Ok(Default::default())


### PR DESCRIPTION
<!--- PR Description --->
These check for `ignore-config` flag are unnecessary because when the `ignore-config` flag is present, the `config` variable is initialized with all `None` value. So, the result of `Self::from_config(config)` will always be `None`.
https://github.com/Peltoche/lsd/blob/7869839bd8d93889b6b7336af51b3132da142c23/src/main.rs#L104-L105

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)