### PR TITLE
chore: add empty `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+# use empty config file to ensure that `rustfmt` will always use 
+# the default configuration when formatting code
+# even if there is a `rustfmt.toml` file in parent directories


### PR DESCRIPTION
This ensure that `rustfmt` will always use default configs for this
project even if there is a `rustfmt.toml` in parent directories


<!--- PR Description --->

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)