### PR TITLE
return POSIX-compatible exit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix tab completion for paths in ZSH
+- Fix POSIX-compatible exit status
 
 ## [0.23.0] - 2022-09-05
 ### Added

--- a/src/display.rs
+++ b/src/display.rs
@@ -602,6 +602,7 @@ mod tests {
             .unwrap()
             .recurse_into(42, &flags)
             .unwrap()
+            .0
             .unwrap();
         sort(&mut metas, &sort::assemble_sorters(&flags));
         let output = tree(
@@ -633,6 +634,7 @@ mod tests {
             .unwrap()
             .recurse_into(42, &flags)
             .unwrap()
+            .0
             .unwrap();
         let output = tree(
             &metas,
@@ -672,6 +674,7 @@ mod tests {
             .unwrap()
             .recurse_into(42, &flags)
             .unwrap()
+            .0
             .unwrap();
         let output = tree(
             &metas,
@@ -710,6 +713,7 @@ mod tests {
             .unwrap()
             .recurse_into(42, &flags)
             .unwrap()
+            .0
             .unwrap();
         let output = tree(
             &metas,
@@ -739,6 +743,7 @@ mod tests {
             .unwrap()
             .recurse_into(1, &flags)
             .unwrap()
+            .0
             .unwrap();
         let output = grid(
             &metas,
@@ -771,6 +776,7 @@ mod tests {
             .unwrap()
             .recurse_into(1, &flags)
             .unwrap()
+            .0
             .unwrap();
         let output = grid(
             &metas,

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,21 @@ use crate::core::Core;
 use crate::flags::Flags;
 use std::path::PathBuf;
 
+#[derive(PartialEq, Eq, PartialOrd, Copy, Clone)]
+pub enum ExitCode {
+    OK,
+    MinorIssue,
+    MajorIssue,
+}
+impl ExitCode {
+    pub fn set_if_greater(&mut self, code: ExitCode) {
+        let self_i32 = *self as i32;
+        let code_i32 = code as i32;
+        if self_i32 < code_i32 {
+            *self = code;
+        }
+    }
+}
 /// Macro used to avoid panicking when the lsd method is used with a pipe and
 /// stderr close before our program.
 #[macro_export]
@@ -115,5 +130,6 @@ fn main() {
     let flags = Flags::configure_from(&matches, &config).unwrap_or_else(|err| err.exit());
     let core = Core::new(flags);
 
-    core.run(inputs);
+    let exit_code = core.run(inputs);
+    std::process::exit(exit_code as i32);
 }


### PR DESCRIPTION
Return POSIX-compatible exit status, mimicking GNU behavior.

> Exit status:
> 0 if OK,
> 1 if minor problems (e.g., cannot access subdirectory),
> 2 if serious trouble (e.g., cannot access command-line argument).


Closes #502 

Uses much of the same code from #536 submitted by @zarkone while applying the changes requested by @meain and resolving conflicts.

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry