### PR TITLE
use ValueHint::AnyPath on FILE argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED]
+## [Unreleased] - ReleaseDate
 
 ### Fixed
 - Fix tab completion for paths in ZSH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+- Fix tab completion for paths in ZSH
+
 ## [0.23.0] - 2022-09-05
 ### Added
 - Add icon for Zstandard from [nix6839](https://github.com/nix6839)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,15 @@
-use clap::{App, Arg};
+use clap::{App, Arg, ValueHint};
 
 pub fn build() -> App<'static> {
     App::new("lsd")
         .version(env!("CARGO_PKG_VERSION"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
-        .arg(Arg::with_name("FILE").multiple(true).default_value("."))
+        .arg(
+            Arg::with_name("FILE")
+                .multiple(true)
+                .default_value(".")
+                .value_hint(ValueHint::AnyPath),
+        )
         .arg(
             Arg::with_name("all")
                 .short('a')


### PR DESCRIPTION
This fixes an issue with path completion in ZSH.

Closes #740 


---
#### TODO

- [x] Use `cargo fmt`
- [x] Add changelog entry