### PR TITLE
Fix symlink_arrow test intercepting cli args

### DIFF
--- a/src/flags/symlink_arrow.rs
+++ b/src/flags/symlink_arrow.rs
@@ -62,9 +62,10 @@ mod test {
     #[test]
     fn test_symlink_arrow_from_args_none() {
         use clap::App;
+        let empty_args: [String; 0] = [];
         assert_eq!(
             None,
-            SymlinkArrow::from_arg_matches(&App::new("lsd").get_matches())
+            SymlinkArrow::from_arg_matches(&App::new("lsd").get_matches_from(empty_args))
         );
     }
 


### PR DESCRIPTION
<!--- PR Description --->

This test attempts to intercept the cli args, so it can cause a fail if any args are passed to the test binary, e.g. `cargo test -- --skip <test_name>`

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)