### PR TITLE
fix: do not quote filename when piping to another program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - In keeping with the coreutils change, add quotes and escapes for necessary filenames from [merelymyself](https://github.com/merelymyself)
 
+### Fixed
+- Do not quote filename when piping into another program from [TeamTamoad](https://github.com/TeamTamoad)
+
 ## [0.23.1] - 2022-09-13
 
 ### Fixed

--- a/src/core.rs
+++ b/src/core.rs
@@ -71,6 +71,8 @@ impl Core {
             // Most of the programs does not handle correctly the ansi colors
             // or require a raw output (like the `wc` command).
             inner_flags.layout = Layout::OneLine;
+
+            flags.should_quote = false;
         };
 
         let sorters = sort::assemble_sorters(&flags);

--- a/src/display.rs
+++ b/src/display.rs
@@ -321,8 +321,13 @@ fn get_output(
             Block::Date => block_vec.push(meta.date.render(colors, flags)),
             Block::Name => {
                 block_vec.extend([
-                    meta.name
-                        .render(colors, icons, display_option, flags.hyperlink),
+                    meta.name.render(
+                        colors,
+                        icons,
+                        display_option,
+                        flags.hyperlink,
+                        flags.should_quote,
+                    ),
                     meta.indicator.render(flags),
                 ]);
                 if !(flags.no_symlink.0 || flags.dereference.0 || flags.layout == Layout::Grid) {
@@ -441,6 +446,7 @@ mod tests {
                     &Icons::new(icon::Theme::NoIcon, " ".to_string()),
                     &DisplayOption::FileName,
                     HyperlinkOption::Never,
+                    true,
                 )
                 .to_string();
 
@@ -475,6 +481,7 @@ mod tests {
                     &Icons::new(icon::Theme::Fancy, " ".to_string()),
                     &DisplayOption::FileName,
                     HyperlinkOption::Never,
+                    true,
                 )
                 .to_string();
 
@@ -508,6 +515,7 @@ mod tests {
                     &Icons::new(icon::Theme::NoIcon, " ".to_string()),
                     &DisplayOption::FileName,
                     HyperlinkOption::Never,
+                    true,
                 )
                 .to_string();
 
@@ -549,6 +557,7 @@ mod tests {
                     &Icons::new(icon::Theme::NoIcon, " ".to_string()),
                     &DisplayOption::FileName,
                     HyperlinkOption::Never,
+                    true,
                 )
                 .to_string();
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -72,6 +72,7 @@ pub struct Flags {
     pub symlink_arrow: SymlinkArrow,
     pub hyperlink: HyperlinkOption,
     pub header: Header,
+    pub should_quote: bool,
 }
 
 impl Flags {
@@ -101,6 +102,7 @@ impl Flags {
             symlink_arrow: SymlinkArrow::configure_from(matches, config),
             hyperlink: HyperlinkOption::configure_from(matches, config),
             header: Header::configure_from(matches, config),
+            should_quote: true,
         })
     }
 }

--- a/src/meta/name.rs
+++ b/src/meta/name.rs
@@ -78,15 +78,17 @@ impl Name {
             .collect()
     }
 
-    fn escape(&self, string: &str) -> String {
+    fn escape(&self, string: &str, should_quote: bool) -> String {
         let mut name = string.to_string();
-        if name.contains('\\') || name.contains('"') {
-            name = name.replace('\'', "\'\\\'\'");
-            name = format!("\'{}\'", &name);
-        } else if name.contains('\'') {
-            name = format!("\"{}\"", &name);
-        } else if name.contains(' ') || name.contains('$') {
-            name = format!("\'{}\'", &name);
+        if should_quote {
+            if name.contains('\\') || name.contains('"') {
+                name = name.replace('\'', "\'\\\'\'");
+                name = format!("\'{}\'", &name);
+            } else if name.contains('\'') {
+                name = format!("\"{}\"", &name);
+            } else if name.contains(' ') || name.contains('$') {
+                name = format!("\'{}\'", &name);
+            }
         }
         let string = name;
         if string
@@ -144,27 +146,28 @@ impl Name {
         icons: &Icons,
         display_option: &DisplayOption,
         hyperlink: HyperlinkOption,
+        quote: bool,
     ) -> ColoredString {
         let content = match display_option {
             DisplayOption::FileName => {
                 format!(
                     "{}{}",
                     icons.get(self),
-                    self.hyperlink(self.escape(self.file_name()), hyperlink)
+                    self.hyperlink(self.escape(self.file_name(), quote), hyperlink)
                 )
             }
             DisplayOption::Relative { base_path } => format!(
                 "{}{}",
                 icons.get(self),
                 self.hyperlink(
-                    self.escape(&self.relative_path(base_path).to_string_lossy()),
+                    self.escape(&self.relative_path(base_path).to_string_lossy(), quote),
                     hyperlink
                 )
             ),
             DisplayOption::None => format!(
                 "{}{}",
                 icons.get(self),
-                self.hyperlink(self.escape(&self.path.to_string_lossy()), hyperlink)
+                self.hyperlink(self.escape(&self.path.to_string_lossy(), quote), hyperlink)
             ),
         };
 
@@ -254,7 +257,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                false,
             )
         );
     }
@@ -277,7 +281,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                false
             )
         );
     }
@@ -310,7 +315,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                false
             )
         );
     }
@@ -343,7 +349,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                false
             )
         );
     }
@@ -374,7 +381,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                false
             )
         );
     }
@@ -398,7 +406,8 @@ mod test {
                     &colors,
                     &icons,
                     &DisplayOption::FileName,
-                    HyperlinkOption::Never
+                    HyperlinkOption::Never,
+                    false
                 )
                 .to_string()
         );
@@ -430,7 +439,8 @@ mod test {
                     &colors,
                     &icons,
                     &DisplayOption::FileName,
-                    HyperlinkOption::Always
+                    HyperlinkOption::Always,
+                    false
                 )
                 .to_string()
         );
@@ -650,7 +660,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                true,
             )
         );
 
@@ -668,7 +679,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                true,
             )
         );
 
@@ -686,7 +698,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                true,
             )
         );
 
@@ -706,7 +719,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                true,
             )
         );
 
@@ -726,7 +740,8 @@ mod test {
                 &colors,
                 &icons,
                 &DisplayOption::FileName,
-                HyperlinkOption::Never
+                HyperlinkOption::Never,
+                true,
             )
         );
     }


### PR DESCRIPTION
According to GNU `ls` behavior, when piping the output to another program, the filename with special characters should not be quoted.

**Old**
![image](https://user-images.githubusercontent.com/43115371/193452548-ecff3d1b-9e66-4024-a871-e40dc611d678.png)

**New**
![image](https://user-images.githubusercontent.com/43115371/193452568-2bc65a08-f61a-466e-9ddb-e637aefd75f6.png)

**Reference**
![image](https://user-images.githubusercontent.com/43115371/193452603-248b7691-a938-485d-a011-bb02f0399db0.png)

## Note
- I put `should_quote` field in `Flag` struct because I think users should be able to configure this behavior. I'll submit another PR  implementing that when I have time. What do you think?
- I'm investigating the behavior of GNU `ls` about quoting and I'm not confident that the current implementation is full compatible with GNU `ls`. So, I think we should not release a new version soon.
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)