### PR TITLE
Fix showing every file as executable on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Do not quote filename when piping into another program from [TeamTamoad](https://github.com/TeamTamoad)
 - Respect `hidden` flag on Windows [#752](https://github.com/Peltoche/lsd/issues/752)
+- Do not show every file are `executable` (green) on Windows
+  [#712](https://github.com/Peltoche/lsd/issues/712). Executables will be marked
+  based on the file extension: `exe`, `msi`, `bat` and `ps1`.
+  [`LS_COLORS`](README.md#Colors) can be used to customize.
 
 ## [0.23.1] - 2022-09-13
 

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -112,7 +112,6 @@ mod test {
     #[cfg(unix)]
     use crate::meta::Permissions;
     use crossterm::style::{Color, Stylize};
-    #[cfg(unix)]
     use std::fs::File;
     #[cfg(unix)]
     use std::os::unix::fs::symlink;
@@ -278,6 +277,44 @@ mod test {
 
         assert_eq!(
             "s".to_string().with(Color::AnsiValue(44)),
+            file_type.render(&colors)
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_file_executable() {
+        let tmp_dir = tempdir().expect("failed to create temp dir");
+        for ext in FileType::EXECUTABLE_EXTENSIONS {
+            // Create the file;
+            let file_path = tmp_dir.path().join(format!("file.{ext}"));
+            File::create(&file_path).expect("failed to create file");
+            let meta = file_path.metadata().expect("failed to get metas");
+
+            let colors = Colors::new(ThemeOption::NoLscolors);
+            let file_type = FileType::new(&meta, None, &file_path);
+
+            assert_eq!(
+                ".".to_string().with(Color::AnsiValue(40)),
+                file_type.render(&colors)
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_file_not_executable() {
+        let tmp_dir = tempdir().expect("failed to create temp dir");
+        // Create the file;
+        let file_path = tmp_dir.path().join("file.txt");
+        File::create(&file_path).expect("failed to create file");
+        let meta = file_path.metadata().expect("failed to get metas");
+
+        let colors = Colors::new(ThemeOption::NoLscolors);
+        let file_type = FileType::new(&meta, None, &file_path);
+
+        assert_eq!(
+            ".".to_string().with(Color::AnsiValue(184)),
             file_type.render(&colors)
         );
     }

--- a/src/meta/filetype.rs
+++ b/src/meta/filetype.rs
@@ -1,5 +1,4 @@
 use crate::color::{ColoredString, Colors, Elem};
-use crate::meta::Permissions;
 use std::fs::Metadata;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
@@ -16,11 +15,14 @@ pub enum FileType {
 }
 
 impl FileType {
+    #[cfg(windows)]
+    const EXECUTABLE_EXTENSIONS: &[&'static str] = &["exe", "msi", "bat", "ps1"];
+
     #[cfg(unix)]
     pub fn new(
         meta: &Metadata,
         symlink_meta: Option<&Metadata>,
-        permissions: &Permissions,
+        permissions: &crate::meta::Permissions,
     ) -> Self {
         use std::os::unix::fs::FileTypeExt;
 
@@ -54,22 +56,22 @@ impl FileType {
     }
 
     #[cfg(windows)]
-    pub fn new(
-        meta: &Metadata,
-        symlink_meta: Option<&Metadata>,
-        permissions: &Permissions,
-    ) -> Self {
+    pub fn new(meta: &Metadata, symlink_meta: Option<&Metadata>, path: &std::path::Path) -> Self {
         let file_type = meta.file_type();
 
         if file_type.is_file() {
-            FileType::File {
-                exec: permissions.is_executable(),
-                uid: permissions.setuid,
-            }
+            let exec = path
+                .extension()
+                .map(|ext| {
+                    Self::EXECUTABLE_EXTENSIONS
+                        .iter()
+                        .map(std::ffi::OsStr::new)
+                        .any(|exec_ext| ext == exec_ext)
+                })
+                .unwrap_or(false);
+            FileType::File { exec, uid: false }
         } else if file_type.is_dir() {
-            FileType::Directory {
-                uid: permissions.setuid,
-            }
+            FileType::Directory { uid: false }
         } else if file_type.is_symlink() {
             FileType::SymLink {
                 // if broken, defaults to false
@@ -107,7 +109,6 @@ impl FileType {
 mod test {
     use super::FileType;
     use crate::color::{Colors, ThemeOption};
-    use crate::meta::Meta;
     #[cfg(unix)]
     use crate::meta::Permissions;
     use crossterm::style::{Color, Stylize};
@@ -143,11 +144,16 @@ mod test {
     #[test]
     fn test_dir_type() {
         let tmp_dir = tempdir().expect("failed to create temp dir");
-        let meta = Meta::from_path(tmp_dir.path(), false).expect("failed to get tempdir path");
+        #[cfg(not(windows))]
+        let meta = crate::meta::Meta::from_path(tmp_dir.path(), false)
+            .expect("failed to get tempdir path");
         let metadata = tmp_dir.path().metadata().expect("failed to get metas");
 
         let colors = Colors::new(ThemeOption::NoLscolors);
+        #[cfg(not(windows))]
         let file_type = FileType::new(&metadata, None, &meta.permissions);
+        #[cfg(windows)]
+        let file_type = FileType::new(&metadata, None, tmp_dir.path());
 
         assert_eq!(
             "d".to_string().with(Color::AnsiValue(33)),

--- a/src/meta/mod.rs
+++ b/src/meta/mod.rs
@@ -253,7 +253,13 @@ impl Meta {
         let (owner, permissions) = windows_utils::get_file_data(path)?;
 
         let access_control = AccessControl::for_path(path);
+
+        #[cfg(not(windows))]
         let file_type = FileType::new(&metadata, symlink_meta.as_ref(), &permissions);
+
+        #[cfg(windows)]
+        let file_type = FileType::new(&metadata, symlink_meta.as_ref(), path);
+
         let name = Name::new(path, file_type);
         let inode = INode::from(&metadata);
         let links = Links::from(&metadata);

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -127,7 +127,7 @@ impl Permissions {
         ColoredString::new(Colors::default_style(), res)
     }
 
-    #[cfg_attr(windows, allow(dead_code))]
+    #[cfg(not(windows))]
     pub fn is_executable(&self) -> bool {
         self.user_execute || self.group_execute || self.other_execute
     }

--- a/src/meta/permissions.rs
+++ b/src/meta/permissions.rs
@@ -127,6 +127,7 @@ impl Permissions {
         ColoredString::new(Colors::default_style(), res)
     }
 
+    #[cfg_attr(windows, allow(dead_code))]
     pub fn is_executable(&self) -> bool {
         self.user_execute || self.group_execute || self.other_execute
     }


### PR DESCRIPTION
This PR determines the executable state of a file on Windows using the file extension instead of permissions.
This fixes that every regular file was marked executable (green).

- ~~added `--exec-ext <ext>` to change mark extensions as executable on the fly~~
- ~~added `executable-extensions` config to modify them more permantly~~ `LS_COLORS` can be used to customize (other) extentions
- ~~cli flags and config file options will be merged~~
- `exe`, `msi`, `cmd` and `ps1` will be marked as executable on windows

Fixes #712 

---
#### TODO

- [x] Use `cargo fmt`
- [x] Add necessary tests
- [x] Add changelog entry
- [x] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)