### PR TITLE
ci: :sparkles: add clap deprecated checks

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -38,6 +38,12 @@ jobs:
       with:
         command: clippy
         args: --tests -- -D warnings
+    - name: "`clap` deprecated checks"
+      if: success() || failure() # run regardless of prior step ("`fmt` testing") success/failure
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --features clap/deprecated
 
   min_version:
     name: MinSRV # Minimum supported rust version


### PR DESCRIPTION
Signed-off-by: zwPapEr <zw.paper@gmail.com>


<!--- PR Description --->

Thanks to https://github.com/Peltoche/lsd/pull/787, we now have no deprecated warning of clap,
so I am adding a CI to avoid that later

---
#### TODO

~~- [ ] Use `cargo fmt`~~
~~- [ ] Add necessary tests~~
~~- [ ] Add changelog entry~~
~~- [ ] Update default config/theme in README (if applicable)~~
~~- [ ] Update man page at lsd/doc/lsd.md (if applicable)~~