### PR TITLE
Add installation information for debian sid and bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Install the patched fonts of powerline nerd-font and/or font-awesome. Have a loo
 | NetBSD or any `pkgsrc` platform | `pkgin install lsd` or `cd /usr/pkgsrc/sysutils/lsd && make install`                                              |
 | Windows                         | `scoop install lsd`                                                                                               |
 | Android (via Termux)            | `pkg install lsd`                                                                                                 |
+| Debian sid and bookworm         | `apt install lsd`                                                                                                 |
 | Ubuntu/Debian based distro      | `sudo dpkg -i lsd_0.23.1_amd64.deb` get `.deb` file from [release page](https://github.com/Peltoche/lsd/releases) |
 | Solus                           | `eopkg it lsd`                                                                                                    |
 | Void Linux                      | `sudo xbps-install lsd`                                                                                           |


### PR DESCRIPTION
I packaged `lsd` for Debian, adding install information to the list. It will be part of the next Debian stable, and imported into Ubuntu also.

https://packages.debian.org/sid/lsd
https://packages.debian.org/bookworm/lsd