### PR TITLE
Drop size_value from blocks docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ classic: false
 # == Blocks ==
 # This specifies the columns and their order when using the long and the tree
 # layout.
-# Possible values: permission, user, group, size, size_value, date, name, inode
+# Possible values: permission, user, group, size, date, name, inode
 blocks:
   - permission
   - user

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -203,7 +203,7 @@ classic: false
 # == Blocks ==
 # This specifies the columns and their order when using the long and the tree
 # layout.
-# Possible values: permission, user, group, context, size, size_value, date, name, inode
+# Possible values: permission, user, group, context, size, date, name, inode
 blocks:
   - permission
   - user


### PR DESCRIPTION
Looks like this accidentally got into the docs. This is not available to the user anyways.
---
#### TODO

- [ ] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Add changelog entry
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)