### PR TITLE
Update README for installation on OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Install the patched fonts of powerline nerd-font and/or font-awesome. Have a loo
 | NixOS                           | `nix-env -iA nixos.lsd`                                              |
 | FreeBSD                         | `pkg install lsd`                                                    |
 | NetBSD or any `pkgsrc` platform | `pkgin install lsd` or `cd /usr/pkgsrc/sysutils/lsd && make install` |
+| OpenBSD                         | `pkg_add lsd`                                                        |
 | Windows                         | `scoop install lsd`                                                  |
 | Android (via Termux)            | `pkg install lsd`                                                    |
 | Debian sid and bookworm         | `apt install lsd`                                                    |


### PR DESCRIPTION
Add command-line in README to install `lsd` on OpenBSD with `pkg_add`