### PR TITLE
add icon for containerfiles

### DIFF
--- a/src/theme/icon.rs
+++ b/src/theme/icon.rs
@@ -158,6 +158,7 @@ impl IconTheme {
             (".config", "\u{e5fc}"),            // ""
             ("config", "\u{e5fc}"),             // ""
             ("configure", "\u{f0ad}"),          // ""
+            ("containerfile", "\u{f4b7}"),      // ""
             ("content", "\u{f0c7}"),            // ""
             ("contributing", "\u{e60a}"),       // ""
             ("copyright", "\u{e60a}"),          // ""


### PR DESCRIPTION
This PR adds an icon for the container service independent `Containerfile`s. I use Podman quite a lot and `lsd` is something that I use even more, so this would be a nice-to-have.

---
#### TODO

- [x] Use `cargo fmt`
- [/] Add necessary tests
- [/] Update default config/theme in README (if applicable)
- [/] Update man page at lsd/doc/lsd.md (if applicable)
