### PR TITLE
Fix crossterm use to respect `--color` option

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -49,6 +49,10 @@ impl Core {
             _ => flags.color.theme.clone(),
         };
 
+        // Ensure that --color=... option is respected by crossterm.
+        // ref https://github.com/lsd-rs/lsd/issues/1159
+        crossterm::style::force_color_output(color_theme != ThemeOption::NoColor);
+
         let icon_when = flags.icons.when;
         let icon_theme = flags.icons.theme.clone();
 


### PR DESCRIPTION
Make sure to override crossterm module's `NO_COLOR` autodetection with our color flag, so that `--color=...` option correctly overrides the value of `NO_COLOR` in the environment.

Fixes #1159

---
#### TODO

- [x] Use `cargo fmt`
- [ ] Add necessary tests
- [ ] Update default config/theme in README (if applicable)
- [ ] Update man page at lsd/doc/lsd.md (if applicable)
