### PR TITLE
Add more specific NixOS and Nix instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Please consult the table below for the installation command associated with your
 | Fedora                          | `dnf install lsd`                                                                                                    |
 | Gentoo                          | `sudo emerge sys-apps/lsd`                                                                                           |
 | macOS                           | `brew install lsd` or `sudo port install lsd`                                                                        |
-| Nix (non NixOS)                 | `nix-env -iA nixpkgs.lsd`                                                                                            |
-| NixOS                           | Add `environment.systemPackages = [ [pkgs.lsd](https://search.nixos.org/packages?show=lsd) ];` to your system config |
+| Nix (non NixOS)                 | [`nix-env -iA nixpkgs.lsd`](https://search.nixos.org/packages?show=lsd)                                              |
+| NixOS                           | Add [`environment.systemPackages = [ pkgs.lsd ];`](https://search.nixos.org/packages?show=lsd) to your system config |
 | FreeBSD                         | `pkg install lsd`                                                                                                    |
 | NetBSD or any `pkgsrc` platform | `pkgin install lsd` or `cd /usr/pkgsrc/sysutils/lsd && make install`                                                 |
 | OpenBSD                         | `pkg_add lsd`                                                                                                        |


### PR DESCRIPTION
I changed the NixOS installation instructions to use the system config, as this is the preferred way on NixOS.
Additionally, I moved the `nix-env` instructions to a `Nix (non NixOS)` section and linked both to the Nix package.